### PR TITLE
Added method name to Linked Away

### DIFF
--- a/src/linker/Linker.Steps/CodeRewriterStep.cs
+++ b/src/linker/Linker.Steps/CodeRewriterStep.cs
@@ -137,7 +137,7 @@ namespace Mono.Linker.Steps
 			ctor = Context.MarkedKnownMembers.NotSupportedExceptionCtorString;
 			ctor = assembly.MainModule.ImportReference (ctor);
 
-			il.Emit (OpCodes.Ldstr, "Linked away");
+			il.Emit (OpCodes.Ldstr, "Linked away: " + method.FullName);
 			il.Emit (OpCodes.Newobj, ctor);
 			il.Emit (OpCodes.Throw);
 


### PR DESCRIPTION
Small change to identify the method that got linked away.