### PR TITLE
Trim field names in compiler generated types

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -307,7 +307,7 @@ namespace Mono.Linker.Steps
 		protected virtual void SweepType (TypeDefinition type)
 		{
 			if (type.HasFields)
-				SweepCollectionWithCustomAttributes (type.Fields);
+				SweepFields (type);
 
 			if (type.HasMethods)
 				SweepMethods (type.Methods);
@@ -439,6 +439,18 @@ namespace Mono.Linker.Steps
 		{
 			foreach (var provider in providers)
 				SweepCustomAttributes (provider);
+		}
+
+		void SweepFields (TypeDefinition type)
+		{
+			SweepCollectionWithCustomAttributes (type.Fields);
+
+			if (type.IsCompilerGenerated ()) {
+				foreach (var field in type.Fields) {
+					if (CanSweepNamesForMember (field, MetadataTrimming.FieldName))
+						field.Name = null;
+				}
+			}
 		}
 
 		protected virtual void SweepMethods (Collection<MethodDefinition> methods)

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -1114,6 +1114,9 @@ namespace Mono.Linker
 			case "none":
 				metadataTrimming = MetadataTrimming.None;
 				return true;
+			case "fieldname":
+				metadataTrimming = MetadataTrimming.FieldName;
+				return true;
 			case "parametername":
 				metadataTrimming = MetadataTrimming.ParameterName;
 				return true;
@@ -1289,6 +1292,7 @@ namespace Mono.Linker
 			Console.WriteLine ("  --keep-dep-attributes      Keep attributes used for manual dependency tracking. Defaults to false");
 			Console.WriteLine ("  --keep-metadata NAME       Keep metadata which would otherwise be removed if not used");
 			Console.WriteLine ("                               all: Metadata for any member are all kept");
+			Console.WriteLine ("                               fieldname: All field names are kept");
 			Console.WriteLine ("                               parametername: All parameter names are kept");
 			Console.WriteLine ("  --new-mvid                 Generate a new guid for each linked assembly (short -g). Defaults to true");
 			Console.WriteLine ("  --strip-descriptors        Remove XML descriptor resources for linked assemblies. Defaults to true");

--- a/src/linker/Linker/MetadataTrimming.cs
+++ b/src/linker/Linker/MetadataTrimming.cs
@@ -11,7 +11,8 @@ namespace Mono.Linker
 	{
 		None = 0,
 		ParameterName = 1,
+		FieldName = 1 << 1,
 
-		Any = ParameterName
+		Any = ParameterName | FieldName
 	}
 }

--- a/src/linker/Linker/TypeDefinitionExtensions.cs
+++ b/src/linker/Linker/TypeDefinitionExtensions.cs
@@ -25,5 +25,19 @@ namespace Mono.Linker
 		{
 			return (td.Attributes & TypeAttributes.Serializable) != 0;
 		}
+
+		public static bool IsCompilerGenerated (this TypeDefinition td)
+		{
+			if (!td.HasCustomAttributes)
+				return false;
+
+			foreach (var ca in td.CustomAttributes) {
+				var caType = ca.AttributeType;
+				if (caType.Name == "CompilerGeneratedAttribute" && caType.Namespace == "System.Runtime.CompilerServices")
+					return true;
+			}
+
+			return false;
+		}
 	}
 }

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -531,7 +531,7 @@ namespace ILLink.Tasks.Tests
 			};
 
 			using (var driver = task.CreateDriver ()) {
-				Assert.Equal (MetadataTrimming.None, driver.Context.MetadataTrimming);
+				Assert.Equal (MetadataTrimming.FieldName, driver.Context.MetadataTrimming);
 			}
 		}
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -624,7 +624,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			if (expectKeptAll) {
 				foreach (var srcField in possibleInitializerFields) {
-					var linkedField = linkedImplementationDetails.Fields.FirstOrDefault (f => f.Name == srcField.Name);
+					var linkedField = linkedImplementationDetails.Fields.FirstOrDefault (f => f.InitialValue.SequenceEqual (srcField.InitialValue));
 					VerifyInitializerField (srcField, linkedField);
 				}
 			} else {
@@ -633,7 +633,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						Assert.Fail ($"Invalid expected index `{index}` in {src}.  Value must be between 0 and {expectedIndicies.Length}");
 
 					var srcField = possibleInitializerFields[index];
-					var linkedField = linkedImplementationDetails.Fields.FirstOrDefault (f => f.Name == srcField.Name);
+					var linkedField = linkedImplementationDetails.Fields.FirstOrDefault (f => f.InitialValue.SequenceEqual (srcField.InitialValue));
 
 					VerifyInitializerField (srcField, linkedField);
 				}
@@ -735,14 +735,14 @@ namespace Mono.Linker.Tests.TestCasesRunner
 					Assert.Fail ($"Missing expected type {originalCompilerGeneratedBufferType}");
 
 				// Have to verify the field before the type
-				var originalElementField = originalCompilerGeneratedBufferType.Fields.FirstOrDefault (f => f.Name == "FixedElementField");
+				var originalElementField = originalCompilerGeneratedBufferType.Fields.FirstOrDefault ();
 				if (originalElementField == null)
 					Assert.Fail ($"Could not locate original compiler generated FixedElementField on {originalCompilerGeneratedBufferType}");
 
-				var linkedField = linkedCompilerGeneratedBufferType?.Fields.FirstOrDefault (l => l.Name == originalElementField.Name);
+				var linkedField = linkedCompilerGeneratedBufferType?.Fields.FirstOrDefault ();
 				VerifyFieldKept (originalElementField, linkedField);
 				verifiedGeneratedFields.Add (originalElementField.FullName);
-				linkedMembers.Remove (originalElementField.FullName);
+				linkedMembers.Remove (linkedField.FullName);
 
 				VerifyTypeDefinitionKept (originalCompilerGeneratedBufferType, linkedCompilerGeneratedBufferType);
 				verifiedGeneratedTypes.Add (originalCompilerGeneratedBufferType.FullName);


### PR DESCRIPTION
Contributes to #1282

Saves about 10k (uncompressed) for default Blazor template