### PR TITLE
Use DAM binder for MarkEntireType

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2794,13 +2794,12 @@ namespace Mono.Linker.Steps
 			case DependencyKind.MethodForInstantiatedType:
 			case DependencyKind.VirtualNeededDueToPreservedScope:
 
-			// Used when the type is included as a whole due to the assembly action or for some other reason. This alone
-			// should not act as a base for raising a warning.
+			// Used when the type is included as a whole due to the assembly action. This alone should not act as a
+			// base for raising a warning.
 			// Note that "include whole type" due to dynamic access is handled differently and the DependencyKind in
 			// that case will be one of the dynamic access kinds and not MemberOfType since in those cases the warnings
 			// are desirable (potential access through reflection).
 			case DependencyKind.MemberInAssembly:
-			case DependencyKind.PreservedDependency:
 
 			// We should not be generating code which would produce warnings
 			case DependencyKind.UnreachableBodyRequirement:

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -19,7 +19,6 @@ namespace Mono.Linker
 		AssemblyOrModuleAttribute = 4, // assembly/module -> entry attribute
 
 		// Membership and containment relationships
-		NestedType = 5, // parent type -> nested type
 		MemberOfType = 6, // type -> member
 		DeclaringType = 7, // member -> type
 		FieldOnGenericInstance = 8, // fieldref on instantiated generic -> field on generic typedef
@@ -52,7 +51,7 @@ namespace Mono.Linker
 		// Modules and assemblies
 		ScopeOfType = 28, // type -> module/assembly
 		AssemblyOfModule = 81, // module -> assembly
-		TypeInAssembly = 29, // assembly -> type
+		MemberInAssembly = 29, // assembly -> member
 		ModuleOfExportedType = 30, // exported type -> module
 		ExportedType = 31, // type -> exported type
 


### PR DESCRIPTION
This changes MarkEntireType to reuse the recursive logic in the DynamicallyAccessedMembers binder, as suggested here: https://github.com/mono/linker/pull/2191#discussion_r685445252.

Ideally we could just call MarkType on the type and its nested types, but this would produce extra warnings in copy assemblies since MarkType can cause us to mark extra methods.

The cache is no longer necessary because we usually only call MarkEntireType once for a type. The exception is `PresereveDependencyAttribute` which is deprecated.