### PR TITLE
Add COMAnalyzer

### DIFF
--- a/src/ILLink.RoslynAnalyzer/COMAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/COMAnalyzer.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using ILLink.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace ILLink.RoslynAnalyzer
+{
+	[DiagnosticAnalyzer (LanguageNames.CSharp)]
+	public sealed class COMAnalyzer : DiagnosticAnalyzer
+	{
+		private const string DllImportAttribute = nameof (DllImportAttribute);
+		private const string MarshalAsAttribute = nameof (MarshalAsAttribute);
+
+		static readonly DiagnosticDescriptor s_correctnessOfCOMCannotBeGuaranteed = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.CorrectnessOfCOMCannotBeGuaranteed,
+			helpLinkUri: "https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-warnings/il2050");
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create (s_correctnessOfCOMCannotBeGuaranteed);
+
+		public override void Initialize (AnalysisContext context)
+		{
+			context.EnableConcurrentExecution ();
+			context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.ReportDiagnostics);
+			context.RegisterCompilationStartAction (context => {
+				var compilation = context.Compilation;
+				if (!context.Options.IsMSBuildPropertyValueTrue (MSBuildPropertyOptionNames.EnableTrimAnalyzer, compilation))
+					return;
+
+				context.RegisterOperationAction (operationContext => {
+					var invocationOperation = (IInvocationOperation) operationContext.Operation;
+					var targetMethod = invocationOperation.TargetMethod;
+					if (!targetMethod.HasAttribute (DllImportAttribute))
+						return;
+
+					foreach (var parameter in targetMethod.Parameters) {
+						if (IsComInterop (parameter)) {
+							operationContext.ReportDiagnostic (Diagnostic.Create (s_correctnessOfCOMCannotBeGuaranteed,
+								operationContext.Operation.Syntax.GetLocation (), targetMethod.GetDisplayName ()));
+						}
+					}
+
+					if (IsComInterop (targetMethod.ReturnType)) {
+						operationContext.ReportDiagnostic (Diagnostic.Create (s_correctnessOfCOMCannotBeGuaranteed,
+								operationContext.Operation.Syntax.GetLocation (), targetMethod.GetDisplayName ()));
+					}
+				}, OperationKind.Invocation);
+			});
+
+			static bool IsComInterop (ISymbol symbol)
+			{
+				if (symbol.TryGetAttribute (MarshalAsAttribute, out var marshalAsAttribute) &&
+					marshalAsAttribute.ConstructorArguments.Length >= 1 && marshalAsAttribute.ConstructorArguments[0] is TypedConstant typedConstant &&
+					typedConstant.Type != null && typedConstant.Type.IsUnmanagedType) {
+					var unmanagedType = typedConstant.Type;
+					switch (unmanagedType.Name) {
+					case "IUnknown":
+					case "IDispatch":
+					case "Interface":
+						return true;
+
+					default:
+						break;
+					}
+				}
+
+				var namedTypeSymbol = symbol.ContainingType;
+				if (namedTypeSymbol.ContainingNamespace.Name == "System" && namedTypeSymbol.Name == "Array") {
+					return true;
+				} else if (namedTypeSymbol.ContainingNamespace.Name == "System" && namedTypeSymbol.Name == "String" ||
+					namedTypeSymbol.ContainingNamespace.Name == "System.Text" && namedTypeSymbol.Name == "StringBuilder") {
+					return false;
+				}
+
+				return false;
+			}
+		}
+	}
+}

--- a/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
@@ -69,5 +69,30 @@ namespace ILLink.RoslynAnalyzer
 
 			return sb.ToString ();
 		}
+
+		public static bool IsInterface (this ISymbol symbol)
+		{
+			if (symbol is not INamedTypeSymbol namedTypeSymbol)
+				return false;
+
+			var typeSymbol = namedTypeSymbol as ITypeSymbol;
+			return typeSymbol.TypeKind == TypeKind.Interface;
+		}
+
+		public static bool IsSubclassOf (this ISymbol symbol, string ns, string type)
+		{
+			if (symbol is not ITypeSymbol typeSymbol)
+				return false;
+
+			while (typeSymbol != null) {
+				if (typeSymbol.ContainingNamespace.Name == ns &&
+					typeSymbol.ContainingType.Name == type)
+					return true;
+
+				typeSymbol = typeSymbol.ContainingType;
+			}
+
+			return false;
+		}
 	}
 }

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -5,6 +5,7 @@
 		// Linker diagnostic ids.
 		RequiresUnreferencedCode = 2026,
 		RequiresUnreferencedCodeAttributeMismatch = 2046,
+		CorrectnessOfCOMCannotBeGuaranteed = 2050,
 		MakeGenericType = 2055,
 		MakeGenericMethod = 2060,
 		RequiresUnreferencedCodeOnStaticConstructor = 2116,

--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -183,7 +183,7 @@
   <data name="RequiresUnreferencedCodeOnStaticConstructorTitle" xml:space="preserve">
     <value>The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.</value>
   </data>
-  <data name="CorrectnessOfCOMCannotBeGuaranteed" xml:space="preserve">
+  <data name="CorrectnessOfCOMCannotBeGuaranteedMessage" xml:space="preserve">
     <value>P/invoke method '{0}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.</value>
   </data>
 </root>

--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -183,4 +183,7 @@
   <data name="RequiresUnreferencedCodeOnStaticConstructorTitle" xml:space="preserve">
     <value>The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.</value>
   </data>
+  <data name="CorrectnessOfCOMCannotBeGuaranteed" xml:space="preserve">
+    <value>P/invoke method '{0}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.</value>
+  </data>
 </root>

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
@@ -28,5 +28,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 
 			RunTest<RequiresUnreferencedCodeAnalyzer> (m, attrs, UseMSBuildProperties (MSBuildPropertyOptionNames.EnableTrimAnalyzer));
 		}
+
+		[Theory]
+		[MemberData (nameof (TestCaseUtils.GetTestData), parameters: nameof (Interop))]
+		public void Interop (MethodDeclarationSyntax m, List<AttributeSyntax> attrs)
+		{
+			RunTest<COMAnalyzer> (m, attrs, UseMSBuildProperties (MSBuildPropertyOptionNames.EnableTrimAnalyzer));
+		}
 	}
 }

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -19,6 +19,8 @@ namespace ILLink.RoslynAnalyzer.Tests
 {
 	public abstract class TestCaseUtils
 	{
+		private static readonly string MonoLinkerTestsCases = "Mono.Linker.Tests.Cases";
+
 		public static readonly ReferenceAssemblies Net6PreviewAssemblies =
 			new ReferenceAssemblies (
 				"net6.0",
@@ -83,12 +85,16 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var builder = ImmutableDictionary.CreateBuilder<string, List<string>> ();
 
 			foreach (var file in GetTestFiles ()) {
-				var dirName = Path.GetFileName (Path.GetDirectoryName (file))!;
-				if (builder.TryGetValue (dirName, out var sources)) {
+				var dirName = Path.GetDirectoryName (file);
+				while (Path.GetFileName (Path.GetDirectoryName (dirName)) != MonoLinkerTestsCases)
+					dirName = Path.GetDirectoryName (dirName);
+
+				dirName = Path.GetFileName (dirName);
+				if (builder.TryGetValue (dirName!, out var sources)) {
 					sources.Add (file);
 				} else {
 					sources = new List<string> () { file };
-					builder[dirName] = sources;
+					builder[dirName!] = sources;
 				}
 			}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -85,16 +85,16 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var builder = ImmutableDictionary.CreateBuilder<string, List<string>> ();
 
 			foreach (var file in GetTestFiles ()) {
-				var dirName = Path.GetDirectoryName (file);
-				while (Path.GetFileName (Path.GetDirectoryName (dirName)) != MonoLinkerTestsCases)
-					dirName = Path.GetDirectoryName (dirName);
+				var directory = Path.GetDirectoryName (file);
+				while (Path.GetFileName (Path.GetDirectoryName (directory)) != MonoLinkerTestsCases)
+					directory = Path.GetDirectoryName (directory);
 
-				dirName = Path.GetFileName (dirName);
-				if (builder.TryGetValue (dirName!, out var sources)) {
+				var parentDirectory = Path.GetFileName (directory);
+				if (builder.TryGetValue (parentDirectory!, out var sources)) {
 					sources.Add (file);
 				} else {
 					sources = new List<string> () { file };
-					builder[dirName!] = sources;
+					builder[parentDirectory!] = sources;
 				}
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -38,6 +38,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingInterface (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingInterface (IFoo foo);
 
@@ -46,6 +47,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingObject (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingObject ([MarshalAs (UnmanagedType.IUnknown)] object obj);
 
@@ -54,6 +56,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingArray (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingArray (Array array);
 
@@ -61,6 +64,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingStringBuilder (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingStringBuilder (StringBuilder str);
 
@@ -68,6 +72,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingCriticalHandle (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingCriticalHandle (MyCriticalHandle handle);
 
@@ -76,6 +81,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingSafeHandle (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingSafeHandle (TestSafeHandle handle);
 
@@ -83,6 +89,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingExplicitLayout (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingExplicitLayout (ExplicitLayout _class);
 
@@ -90,6 +97,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingSequentialLayout (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingSequentialLayout (SequentialLayout _class);
 
@@ -98,6 +106,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingAutoLayout (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingAutoLayout (AutoLayout _class);
 
@@ -106,6 +115,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			SomeMethodTakingString (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingString (String str);
 
@@ -114,6 +124,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			GetInterface ();
 		}
+
 		[DllImport ("Foo")]
 		static extern IFoo GetInterface ();
 
@@ -122,6 +133,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			CanSuppressWarningOnParameter (null);
 		}
+
 		[DllImport ("Foo")]
 		static extern void CanSuppressWarningOnParameter ([MarshalAs (UnmanagedType.IUnknown)] object obj);
 
@@ -130,6 +142,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			CanSuppressWarningOnReturnType ();
 		}
+
 		[DllImport ("Foo")]
 		static extern IFoo CanSuppressWarningOnReturnType ();
 

--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -15,6 +15,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		[UnconditionalSuppressMessage ("trim", "IL2026")]
 		static void Main ()
 		{
+			Call_SomeMethodReturningAutoLayoutClass ();
 			Call_SomeMethodTakingInterface ();
 			Call_SomeMethodTakingObject ();
 			Call_SomeMethodTakingArray ();
@@ -110,6 +111,14 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingAutoLayout (AutoLayout _class);
 
+		[ExpectedWarning ("IL2050")]
+		static void Call_SomeMethodReturningAutoLayoutClass ()
+		{
+			SomeMethodReturningAutoLayout ();
+		}
+
+		[DllImport ("Foo")]
+		static extern AutoLayout SomeMethodReturningAutoLayout ();
 
 		static void Call_SomeMethodTakingString ()
 		{


### PR DESCRIPTION
This adds support for `IL2050`. It is intended to be used for all other diagnostics related to COM in the analyzers. I didn't add any new tests -- we are reusing the ones under `Interop`. 