### PR TITLE
Mark forwarders for all TypeReferences

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1380,7 +1380,12 @@ namespace Mono.Linker.Steps
 			foreach (TypeDefinition type in module.Types)
 				MarkEntireType (type, new DependencyInfo (DependencyKind.TypeInAssembly, assembly));
 
-			// Mark scopes of type references and exported types by traversing the assembly.
+			foreach (ExportedType exportedType in module.ExportedTypes) {
+				MarkingHelpers.MarkExportedType (exportedType, module, new DependencyInfo (DependencyKind.ExportedType, assembly));
+				MarkingHelpers.MarkForwardedScope (new TypeReference (exportedType.Namespace, exportedType.Name, module, exportedType.Scope));
+			}
+
+			// Mark scopes of type references by traversing the assembly.
 			new TypeReferenceMarker (assembly, MarkingHelpers).Process ();
 
 			// Also mark the scopes of metadata typeref rows to cover any not discovered by the traversal.

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1380,11 +1380,11 @@ namespace Mono.Linker.Steps
 			foreach (TypeDefinition type in module.Types)
 				MarkEntireType (type, new DependencyInfo (DependencyKind.TypeInAssembly, assembly));
 
-			foreach (ExportedType exportedType in module.ExportedTypes) {
-				MarkingHelpers.MarkExportedType (exportedType, module, new DependencyInfo (DependencyKind.ExportedType, assembly));
-				MarkingHelpers.MarkForwardedScope (new TypeReference (exportedType.Namespace, exportedType.Name, module, exportedType.Scope));
-			}
+			// Mark scopes of type references and exported types by traversing the assembly.
+			new TypeReferenceMarker (assembly, MarkingHelpers).Process ();
 
+			// Also mark the scopes of metadata typeref rows to cover any not discovered by the traversal.
+			// This can happen when the compiler emits typerefs into IL which aren't strictly necessary per ECMA 335.
 			foreach (TypeReference typeReference in module.GetTypeReferences ())
 				MarkingHelpers.MarkForwardedScope (typeReference);
 		}

--- a/src/linker/Linker/TypeReferenceMarker.cs
+++ b/src/linker/Linker/TypeReferenceMarker.cs
@@ -22,7 +22,7 @@ namespace Mono.Linker
 			visited = null;
 		}
 
-		// Traverse the assembly and mark exported types, and the scopes of discovered type references.
+		// Traverse the assembly and mark the scopes of discovered type references (but not exported types).
 		// This includes scopes referenced by Cecil TypeReference objects that don't represent rows in the typeref table,
 		// such as references to built-in types, or attribute arguments which encode type references as strings.
 		public void Process ()
@@ -41,9 +41,6 @@ namespace Mono.Linker
 					WalkScopes (type);
 				}
 			}
-
-			if (mmodule.HasExportedTypes)
-				WalkTypeScope (mmodule.ExportedTypes);
 
 			visited = null;
 		}
@@ -141,15 +138,6 @@ namespace Mono.Linker
 				WalkCustomAttributesTypesScopes (p);
 				WalkScopeOfTypeReference (p.ParameterType);
 				WalkMarshalInfoTypeScope (p);
-			}
-		}
-
-		void WalkTypeScope (Collection<ExportedType> forwarders)
-		{
-			var module = assembly.MainModule;
-			foreach (var f in forwarders) {
-				markingHelpers.MarkExportedType (f, module, new DependencyInfo (DependencyKind.ExportedType, assembly));
-				markingHelpers.MarkForwardedScope (new TypeReference (f.Namespace, f.Name, module, f.Scope));
 			}
 		}
 

--- a/src/linker/Linker/TypeReferenceMarker.cs
+++ b/src/linker/Linker/TypeReferenceMarker.cs
@@ -1,0 +1,355 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
+
+namespace Mono.Linker
+{
+	struct TypeReferenceMarker
+	{
+		readonly AssemblyDefinition assembly;
+		readonly MarkingHelpers markingHelpers;
+		HashSet<TypeReference> visited;
+
+		public TypeReferenceMarker (AssemblyDefinition assembly, MarkingHelpers markingHelpers)
+		{
+			this.assembly = assembly;
+			this.markingHelpers = markingHelpers;
+			visited = null;
+		}
+
+		// Traverse the assembly and mark exported types, and the scopes of discovered type references.
+		// This includes scopes referenced by Cecil TypeReference objects that don't represent rows in the typeref table,
+		// such as references to built-in types, or attribute arguments which encode type references as strings.
+		public void Process ()
+		{
+			visited = new HashSet<TypeReference> ();
+
+			WalkCustomAttributesTypesScopes (assembly);
+			WalkSecurityAttributesTypesScopes (assembly);
+
+			foreach (var module in assembly.Modules)
+				WalkCustomAttributesTypesScopes (module);
+
+			var mmodule = assembly.MainModule;
+			if (mmodule.HasTypes) {
+				foreach (var type in mmodule.Types) {
+					WalkScopes (type);
+				}
+			}
+
+			if (mmodule.HasExportedTypes)
+				WalkTypeScope (mmodule.ExportedTypes);
+
+			visited = null;
+		}
+
+		void WalkScopes (TypeDefinition typeDefinition)
+		{
+			WalkCustomAttributesTypesScopes (typeDefinition);
+			WalkSecurityAttributesTypesScopes (typeDefinition);
+
+			if (typeDefinition.BaseType != null)
+				WalkScopeOfTypeReference (typeDefinition.BaseType);
+
+			if (typeDefinition.HasInterfaces) {
+				foreach (var iface in typeDefinition.Interfaces) {
+					WalkCustomAttributesTypesScopes (iface);
+					WalkScopeOfTypeReference (iface.InterfaceType);
+				}
+			}
+
+			if (typeDefinition.HasGenericParameters)
+				WalkTypeScope (typeDefinition.GenericParameters);
+
+			if (typeDefinition.HasEvents) {
+				foreach (var e in typeDefinition.Events) {
+					WalkCustomAttributesTypesScopes (e);
+					// e.EventType is not saved
+				}
+			}
+
+			if (typeDefinition.HasFields) {
+				foreach (var f in typeDefinition.Fields) {
+					WalkCustomAttributesTypesScopes (f);
+					WalkScopeOfTypeReference (f.FieldType);
+					WalkMarshalInfoTypeScope (f);
+				}
+			}
+
+			if (typeDefinition.HasMethods) {
+				foreach (var m in typeDefinition.Methods) {
+					WalkCustomAttributesTypesScopes (m);
+					WalkSecurityAttributesTypesScopes (m);
+					if (m.HasGenericParameters)
+						WalkTypeScope (m.GenericParameters);
+
+					WalkCustomAttributesTypesScopes (m.MethodReturnType);
+					WalkScopeOfTypeReference (m.MethodReturnType.ReturnType);
+					WalkMarshalInfoTypeScope (m.MethodReturnType);
+					if (m.HasOverrides) {
+						foreach (var mo in m.Overrides)
+							WalkMethodReference (mo);
+					}
+
+					if (m.HasParameters)
+						WalkTypeScope (m.Parameters);
+
+					if (m.HasBody)
+						WalkTypeScope (m.Body);
+				}
+			}
+
+			if (typeDefinition.HasProperties) {
+				foreach (var p in typeDefinition.Properties) {
+					WalkCustomAttributesTypesScopes (p);
+					// p.PropertyType is not saved
+				}
+			}
+
+			if (typeDefinition.HasNestedTypes) {
+				foreach (var nestedType in typeDefinition.NestedTypes) {
+					WalkScopes (nestedType);
+				}
+			}
+		}
+
+		void WalkTypeScope (Collection<GenericParameter> genericParameters)
+		{
+			foreach (var gp in genericParameters) {
+				WalkCustomAttributesTypesScopes (gp);
+				if (gp.HasConstraints)
+					WalkTypeScope (gp.Constraints);
+			}
+		}
+
+		void WalkTypeScope (Collection<GenericParameterConstraint> constraints)
+		{
+			foreach (var gc in constraints) {
+				WalkCustomAttributesTypesScopes (gc);
+				WalkScopeOfTypeReference (gc.ConstraintType);
+			}
+		}
+
+		void WalkTypeScope (Collection<ParameterDefinition> parameters)
+		{
+			foreach (var p in parameters) {
+				WalkCustomAttributesTypesScopes (p);
+				WalkScopeOfTypeReference (p.ParameterType);
+				WalkMarshalInfoTypeScope (p);
+			}
+		}
+
+		void WalkTypeScope (Collection<ExportedType> forwarders)
+		{
+			var module = assembly.MainModule;
+			foreach (var f in forwarders) {
+				markingHelpers.MarkExportedType (f, module, new DependencyInfo (DependencyKind.ExportedType, assembly));
+				markingHelpers.MarkForwardedScope (new TypeReference (f.Namespace, f.Name, module, f.Scope));
+			}
+		}
+
+		void WalkTypeScope (MethodBody body)
+		{
+			if (body.HasVariables) {
+				foreach (var v in body.Variables) {
+					WalkScopeOfTypeReference (v.VariableType);
+				}
+			}
+
+			if (body.HasExceptionHandlers) {
+				foreach (var eh in body.ExceptionHandlers) {
+					if (eh.CatchType != null)
+						WalkScopeOfTypeReference (eh.CatchType);
+				}
+			}
+
+			foreach (var instr in body.Instructions) {
+				switch (instr.OpCode.OperandType) {
+
+				case OperandType.InlineMethod: {
+						var mr = (MethodReference) instr.Operand;
+						WalkMethodReference (mr);
+						break;
+					}
+
+				case OperandType.InlineField: {
+						var fr = (FieldReference) instr.Operand;
+						WalkFieldReference (fr);
+						break;
+					}
+
+				case OperandType.InlineTok: {
+						switch (instr.Operand) {
+						case TypeReference tr:
+							WalkScopeOfTypeReference (tr);
+							break;
+						case FieldReference fr:
+							WalkFieldReference (fr);
+							break;
+						case MethodReference mr:
+							WalkMethodReference (mr);
+							break;
+						}
+
+						break;
+					}
+
+				case OperandType.InlineType: {
+						var tr = (TypeReference) instr.Operand;
+						WalkScopeOfTypeReference (tr);
+						break;
+					}
+				}
+			}
+		}
+
+		void WalkMethodReference (MethodReference mr)
+		{
+			WalkScopeOfTypeReference (mr.ReturnType);
+			WalkScopeOfTypeReference (mr.DeclaringType);
+
+			if (mr is GenericInstanceMethod gim) {
+				foreach (var tr in gim.GenericArguments)
+					WalkScopeOfTypeReference (tr);
+			}
+
+			if (mr.HasParameters) {
+				WalkTypeScope (mr.Parameters);
+			}
+		}
+
+		void WalkFieldReference (FieldReference fr)
+		{
+			WalkScopeOfTypeReference (fr.FieldType);
+			WalkScopeOfTypeReference (fr.DeclaringType);
+		}
+
+		void WalkMarshalInfoTypeScope (IMarshalInfoProvider provider)
+		{
+			if (!provider.HasMarshalInfo)
+				return;
+
+			if (provider.MarshalInfo is CustomMarshalInfo cmi)
+				WalkScopeOfTypeReference (cmi.ManagedType);
+		}
+
+		void WalkCustomAttributesTypesScopes (ICustomAttributeProvider customAttributeProvider)
+		{
+			if (!customAttributeProvider.HasCustomAttributes)
+				return;
+
+			foreach (var ca in customAttributeProvider.CustomAttributes)
+				WalkForwardedTypesScope (ca);
+		}
+
+		void WalkSecurityAttributesTypesScopes (ISecurityDeclarationProvider securityAttributeProvider)
+		{
+			if (!securityAttributeProvider.HasSecurityDeclarations)
+				return;
+
+			foreach (var ca in securityAttributeProvider.SecurityDeclarations) {
+				if (!ca.HasSecurityAttributes)
+					continue;
+
+				foreach (var securityAttribute in ca.SecurityAttributes)
+					WalkForwardedTypesScope (securityAttribute);
+			}
+		}
+
+		void WalkForwardedTypesScope (CustomAttribute attribute)
+		{
+			WalkMethodReference (attribute.Constructor);
+
+			if (attribute.HasConstructorArguments) {
+				foreach (var ca in attribute.ConstructorArguments)
+					WalkForwardedTypesScope (ca);
+			}
+
+			if (attribute.HasFields) {
+				foreach (var field in attribute.Fields)
+					WalkForwardedTypesScope (field.Argument);
+			}
+
+			if (attribute.HasProperties) {
+				foreach (var property in attribute.Properties)
+					WalkForwardedTypesScope (property.Argument);
+			}
+		}
+
+		void WalkForwardedTypesScope (SecurityAttribute attribute)
+		{
+			if (attribute.HasFields) {
+				foreach (var field in attribute.Fields)
+					WalkForwardedTypesScope (field.Argument);
+			}
+
+			if (attribute.HasProperties) {
+				foreach (var property in attribute.Properties)
+					WalkForwardedTypesScope (property.Argument);
+			}
+		}
+
+		void WalkForwardedTypesScope (CustomAttributeArgument attributeArgument)
+		{
+			WalkScopeOfTypeReference (attributeArgument.Type);
+
+			switch (attributeArgument.Value) {
+			case TypeReference tr:
+				WalkScopeOfTypeReference (tr);
+				break;
+			case CustomAttributeArgument caa:
+				WalkForwardedTypesScope (caa);
+				break;
+			case CustomAttributeArgument[] array:
+				foreach (var item in array)
+					WalkForwardedTypesScope (item);
+				break;
+			}
+		}
+
+		void WalkScopeOfTypeReference (TypeReference type)
+		{
+			if (type == null)
+				return;
+
+			if (!visited.Add (type))
+				return;
+
+			// Don't walk the scope of windows runtime projections
+			if (type.IsWindowsRuntimeProjection)
+				return;
+
+			switch (type) {
+			case GenericInstanceType git:
+				WalkScopeOfTypeReference (git.ElementType);
+				foreach (var ga in git.GenericArguments)
+					WalkScopeOfTypeReference (ga);
+				return;
+			case FunctionPointerType fpt:
+				WalkScopeOfTypeReference (fpt.ReturnType);
+				if (fpt.HasParameters)
+					WalkTypeScope (fpt.Parameters);
+				return;
+			case IModifierType imt:
+				WalkScopeOfTypeReference (imt.ModifierType);
+				WalkScopeOfTypeReference (imt.ElementType);
+				return;
+			case TypeSpecification ts:
+				WalkScopeOfTypeReference (ts.ElementType);
+				return;
+			case TypeDefinition:
+			case GenericParameter:
+				// Nothing to walk
+				return;
+			}
+
+			markingHelpers.MarkForwardedScope (type);
+		}
+	}
+
+}

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomEventSource.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomEventSource.cs
@@ -1,9 +1,10 @@
-﻿using System;
-using System.Diagnostics.Tracing;
+﻿using System.Diagnostics.Tracing;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 {
+	[Reference ("System.Diagnostics.Tracing.dll")]
 	public class CustomEventSource
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomLibraryEventSource.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomLibraryEventSource.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Diagnostics.Tracing;
+﻿using System.Diagnostics.Tracing;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 {
+	[Reference ("System.Diagnostics.Tracing.dll")]
 	[SetupLinkerArgument ("-a", "test.exe", "library")]
 	[KeptMember (".ctor()")]
 	public class CustomLibraryEventSource

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -300,14 +300,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -367,14 +367,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -435,7 +435,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			public event EventHandler<EventArgs> HideEvent;
@@ -491,12 +491,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> HideEvent;
 
@@ -563,18 +563,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -646,22 +646,22 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1372,14 +1372,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1403,14 +1403,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1443,7 +1443,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			public event EventHandler<EventArgs> HideEvent;
@@ -1466,12 +1466,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> HideEvent;
 
@@ -1503,18 +1503,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1542,22 +1542,22 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
@@ -212,7 +212,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler PublicEvent;
 
 			event EventHandler NonPublicEvent;
@@ -225,7 +225,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			event EventHandler NonPublicEvent;
 
 			public event EventHandler PublicEven;

--- a/test/Mono.Linker.Tests.Cases/Extensibility/CustomStepCanResolveTypesAfterSweep.cs
+++ b/test/Mono.Linker.Tests.Cases/Extensibility/CustomStepCanResolveTypesAfterSweep.cs
@@ -1,0 +1,33 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Extensibility
+{
+	// Repro for https://github.com/dotnet/linker/issues/2267.
+#if !NETCOREAPP
+	[IgnoreTestCase ("Specific to the illink build")]
+#endif
+	[SetupCompileBefore ("ResolveTypesSubStep.dll", new[] { "Dependencies/ResolveTypesSubStep.cs" }, new[] { "illink.dll", "Mono.Cecil.dll", "netstandard.dll" })]
+	[SetupLinkerArgument ("--custom-step", "+OutputStep:ResolveTypesSubStep,ResolveTypesSubStep.dll")]
+	[SetupLinkerAction ("copy", "test")]
+	[SetupLinkerTrimMode ("link")]
+	[KeptMember (".ctor()")]
+	public class CustomStepCanResolveTypesAfterSweep
+	{
+		public static void Main ()
+		{
+			var f = TypeWithFields.primitiveField;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class TypeWithFields
+		{
+			[Kept]
+			public static int primitiveField;
+
+			[Kept]
+			public static float unusedPrimitiveField;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Extensibility/Dependencies/ResolveTypesSubStep.cs
+++ b/test/Mono.Linker.Tests.Cases/Extensibility/Dependencies/ResolveTypesSubStep.cs
@@ -1,0 +1,34 @@
+using System;
+using Mono.Cecil;
+using Mono.Linker.Steps;
+
+class ResolveTypesSubStep : BaseStep
+{
+
+	protected override void Process ()
+	{
+		foreach (var assembly in Context.GetAssemblies ()) {
+			foreach (var type in assembly.MainModule.Types)
+				ProcessType (type);
+		}
+	}
+
+	void ProcessType (TypeDefinition type)
+	{
+		if (type.HasNestedTypes) {
+			foreach (var nested in type.NestedTypes)
+				ProcessType (nested);
+		}
+
+		if (type.Name == "TypeWithFields") {
+			foreach (var field in type.Fields)
+				ProcessField (field);
+		}
+	}
+
+	public void ProcessField (FieldDefinition field)
+	{
+		if (field.FieldType.Resolve () == null)
+			throw new Exception($"Unresolved field type {field.FieldType} for field {field}!");
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCsc.cs
+++ b/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCsc.cs
@@ -21,7 +21,7 @@ namespace Mono.Linker.Tests.Cases.References
 
 	// We library should be gone.  The `using` statement leaves no traces in the IL so nothing in `library` will be marked
 	[RemovedAssembly ("library.dll")]
-	[KeptReferencesInAssembly ("copied.dll", new[] { PlatformAssemblies.CoreLib, "library" })]
+	[KeptReferencesInAssembly ("copied.dll", new[] { "System.Runtime", "library" })]
 	public class AssemblyOnlyUsedByUsingWithCsc
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCscWithKeepFacades.cs
+++ b/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCscWithKeepFacades.cs
@@ -23,7 +23,7 @@ namespace Mono.Linker.Tests.Cases.References
 
 	// We library should be gone.  The `using` statement leaves no traces in the IL so nothing in `library` will be marked
 	[RemovedAssembly ("library.dll")]
-	[KeptReferencesInAssembly ("copied.dll", new[] { PlatformAssemblies.CoreLib, "library" })]
+	[KeptReferencesInAssembly ("copied.dll", new[] { "System.Runtime", "library" })]
 	public class AssemblyOnlyUsedByUsingWithCscWithKeepFacades
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -192,7 +192,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> PublicEvent;
 		}
@@ -202,7 +202,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			internal event EventHandler<EventArgs> InternalEvent;
 			[Kept]
 			[KeptBackingField]
@@ -212,12 +212,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEvent;
 		}
 
@@ -226,12 +226,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> IfEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> ElseEvent;
 		}
 
@@ -245,7 +245,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> IfEvent;
 		}
 
@@ -256,7 +256,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 		}
 		[KeptBaseType (typeof (BaseClass))]
@@ -269,13 +269,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			private event EventHandler<EventArgs> MarkedDueToIgnoreCaseEvent;
 		}
 
@@ -291,13 +291,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			private event EventHandler<EventArgs> MarkedDueToPutRefDispPropertyEvent;
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
@@ -83,7 +83,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
@@ -158,7 +158,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			[method: ExpectBodyModified, ExpectLocalsModified]
+			[method: ExpectBodyModified]
 			public event EventHandler<EventArgs> Event;
 
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/Serialization/CanDisableSerializationDiscovery.cs
+++ b/test/Mono.Linker.Tests.Cases/Serialization/CanDisableSerializationDiscovery.cs
@@ -7,8 +7,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Serialization
 {
+	[Reference ("System.Xml.ReaderWriter.dll")]
 	[Reference ("System.Xml.XmlSerializer.dll")]
-	[Reference ("System.Private.Xml.dll")]
 	[SetupLinkerArgument ("--disable-serialization-discovery")]
 	public class CanDisableSerializationDiscovery
 	{

--- a/test/Mono.Linker.Tests.Cases/Serialization/DataContractJsonSerialization.cs
+++ b/test/Mono.Linker.Tests.Cases/Serialization/DataContractJsonSerialization.cs
@@ -7,7 +7,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Serialization
 {
 	[Reference ("System.Runtime.Serialization.dll")]
-	[Reference ("System.Private.DataContractSerialization.dll")]
 	[Reference ("System.Runtime.Serialization.Primitives.dll")]
 	[Reference ("System.Runtime.Serialization.Json.dll")]
 	public class DataContractJsonSerialization

--- a/test/Mono.Linker.Tests.Cases/Serialization/DataContractSerialization.cs
+++ b/test/Mono.Linker.Tests.Cases/Serialization/DataContractSerialization.cs
@@ -9,7 +9,6 @@ namespace Mono.Linker.Tests.Cases.Serialization
 {
 	[Reference ("System.Runtime.Serialization.dll")]
 	[Reference ("System.Runtime.Serialization.Xml.dll")]
-	[Reference ("System.Private.DataContractSerialization.dll")]
 	[Reference ("System.Runtime.Serialization.Primitives.dll")]
 	public class DataContractSerialization
 	{

--- a/test/Mono.Linker.Tests.Cases/Serialization/DataContractSerializationUnused.cs
+++ b/test/Mono.Linker.Tests.Cases/Serialization/DataContractSerializationUnused.cs
@@ -7,10 +7,8 @@ namespace Mono.Linker.Tests.Cases.Serialization
 {
 	[Reference ("System.Runtime.Serialization.dll")]
 	[Reference ("System.Runtime.Serialization.Xml.dll")]
-	[Reference ("System.Private.DataContractSerialization.dll")]
 	[Reference ("System.Runtime.Serialization.Primitives.dll")]
 	[Reference ("System.Xml.XmlSerializer.dll")]
-	[Reference ("System.Private.Xml.dll")]
 	public class DataContractSerializationUnused
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Serialization/SerializationTypeRecursion.cs
+++ b/test/Mono.Linker.Tests.Cases/Serialization/SerializationTypeRecursion.cs
@@ -6,8 +6,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Serialization
 {
+	[Reference ("System.Xml.ReaderWriter.dll")]
 	[Reference ("System.Xml.XmlSerializer.dll")]
-	[Reference ("System.Private.Xml.dll")]
 	[SetupCompileArgument ("/unsafe")]
 	public class SerializationTypeRecursion
 	{

--- a/test/Mono.Linker.Tests.Cases/Serialization/XmlSerialization.cs
+++ b/test/Mono.Linker.Tests.Cases/Serialization/XmlSerialization.cs
@@ -7,8 +7,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Serialization
 {
+	[Reference ("System.Xml.ReaderWriter.dll")]
 	[Reference ("System.Xml.XmlSerializer.dll")]
-	[Reference ("System.Private.Xml.dll")]
 	public class XmlSerialization
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Serialization/XmlSerializationUnused.cs
+++ b/test/Mono.Linker.Tests.Cases/Serialization/XmlSerializationUnused.cs
@@ -5,11 +5,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Serialization
 {
-	[Reference ("System.Xml.XmlSerializer.dll")]
-	[Reference ("System.Private.Xml.dll")]
-	[Reference ("System.Runtime.Serialization.dll")]
 	[Reference ("System.Runtime.Serialization.Xml.dll")]
-	[Reference ("System.Private.DataContractSerialization.dll")]
+	[Reference ("System.Xml.ReaderWriter.dll")]
+	[Reference ("System.Xml.XmlSerializer.dll")]
 	public class XmlSerializationUnused
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedAndUnusedForwarderWithAssemblyCopy.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedAndUnusedForwarderWithAssemblyCopy.cs
@@ -23,7 +23,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	// The whole assembly is kept as is, since it is marked with the `copy` action.
 	[KeptTypeInAssembly ("Forwarder.dll", typeof (ImplementationLibrary))]
 	[KeptTypeInAssembly ("Forwarder.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.AnotherLibrary`1")]
-	[KeptReferencesInAssembly ("Forwarder.dll", new[] { "System.Private.CoreLib", "Implementation", "Unused" })]
+	[KeptReferencesInAssembly ("Forwarder.dll", new[] { "System.Runtime", "Implementation", "Unused" })]
 	// Even though `Forwarder` references this assembly, none of its members are marked (none is used) and, since `Unused`
 	// has `link` action, it is removed.
 	[RemovedAssembly ("Unused.dll")]

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
+	[Reference ("System.Reflection.Emit.dll")]
 	[SetupCompileArgument ("/optimize-")] // Relying on debug csc behaviour
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
 	public class ComplexConditions

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -160,24 +160,27 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			return false;
 		}
 
+#if NETCOREAPP
+		static string GetReferenceDir ()
+		{
+			string runtimeDir = Path.GetDirectoryName (typeof (object).Assembly.Location);
+			string ncaVersion = Path.GetFileName (runtimeDir);
+			var dotnetDir = Path.GetDirectoryName (Path.GetDirectoryName (Path.GetDirectoryName (runtimeDir)));
+			return Path.Combine (dotnetDir, "packs", "Microsoft.NETCore.App.Ref", ncaVersion, "ref", PathUtilities.TFMDirectoryName);
+		}
+#endif
+
 		public virtual IEnumerable<string> GetCommonReferencedAssemblies (NPath workingDirectory)
 		{
 			yield return workingDirectory.Combine ("Mono.Linker.Tests.Cases.Expectations.dll").ToString ();
 #if NETCOREAPP
-
-			string runtimeDir = Path.GetDirectoryName (typeof (object).Assembly.Location);
-			string ncaVersion = Path.GetFileName (runtimeDir);
-			var dotnetDir = Path.GetDirectoryName (Path.GetDirectoryName (Path.GetDirectoryName (runtimeDir)));
-			var referenceDir = Path.Combine (dotnetDir, "packs", "Microsoft.NETCore.App.Ref", ncaVersion, "ref", PathUtilities.TFMDirectoryName);
-
+			var referenceDir = GetReferenceDir ();
 			yield return Path.Combine (referenceDir, "mscorlib.dll");
 			yield return Path.Combine (referenceDir, "System.Collections.dll");
 			yield return Path.Combine (referenceDir, "System.ComponentModel.TypeConverter.dll");
 			yield return Path.Combine (referenceDir, "System.Console.dll");
-			yield return Path.Combine (referenceDir, "System.Diagnostics.Tracing.dll");
 			yield return Path.Combine (referenceDir, "System.Linq.Expressions.dll");
 			yield return Path.Combine (referenceDir, "System.ObjectModel.dll");
-			yield return Path.Combine (referenceDir, "System.Reflection.Emit.dll");
 			yield return Path.Combine (referenceDir, "System.Runtime.dll");
 			yield return Path.Combine (referenceDir, "System.Runtime.Extensions.dll");
 			yield return Path.Combine (referenceDir, "System.Runtime.InteropServices.dll");
@@ -192,9 +195,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 				if (fileName.StartsWith ("System.", StringComparison.Ordinal) || fileName.StartsWith ("Mono.", StringComparison.Ordinal) || fileName.StartsWith ("Microsoft.", StringComparison.Ordinal)) {
 #if NETCOREAPP
-					// Try to find the assembly alongside the host's framework dependencies
-					var frameworkDir = Path.GetFullPath (Path.GetDirectoryName (typeof (object).Assembly.Location));
-					var filePath = Path.Combine (frameworkDir, fileName);
+					var referenceDir = GetReferenceDir ();
+					var filePath = Path.Combine (referenceDir, fileName);
 
 					if (File.Exists (filePath)) {
 						yield return filePath;

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -164,16 +164,23 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		{
 			yield return workingDirectory.Combine ("Mono.Linker.Tests.Cases.Expectations.dll").ToString ();
 #if NETCOREAPP
-			string frameworkDir = Path.GetDirectoryName (typeof (object).Assembly.Location);
 
-			yield return typeof (object).Assembly.Location;
-			yield return Path.Combine (frameworkDir, "System.Runtime.dll");
-			yield return Path.Combine (frameworkDir, "System.Linq.Expressions.dll");
-			yield return Path.Combine (frameworkDir, "System.ComponentModel.TypeConverter.dll");
-			yield return Path.Combine (frameworkDir, "System.Console.dll");
-			yield return Path.Combine (frameworkDir, "mscorlib.dll");
-			yield return Path.Combine (frameworkDir, "System.ObjectModel.dll");
-			yield return Path.Combine (frameworkDir, "System.Runtime.Extensions.dll");
+			string runtimeDir = Path.GetDirectoryName (typeof (object).Assembly.Location);
+			string ncaVersion = Path.GetFileName (runtimeDir);
+			var dotnetDir = Path.GetDirectoryName (Path.GetDirectoryName (Path.GetDirectoryName (runtimeDir)));
+			var referenceDir = Path.Combine (dotnetDir, "packs", "Microsoft.NETCore.App.Ref", ncaVersion, "ref", PathUtilities.TFMDirectoryName);
+
+			yield return Path.Combine (referenceDir, "mscorlib.dll");
+			yield return Path.Combine (referenceDir, "System.Collections.dll");
+			yield return Path.Combine (referenceDir, "System.ComponentModel.TypeConverter.dll");
+			yield return Path.Combine (referenceDir, "System.Console.dll");
+			yield return Path.Combine (referenceDir, "System.Diagnostics.Tracing.dll");
+			yield return Path.Combine (referenceDir, "System.Linq.Expressions.dll");
+			yield return Path.Combine (referenceDir, "System.ObjectModel.dll");
+			yield return Path.Combine (referenceDir, "System.Reflection.Emit.dll");
+			yield return Path.Combine (referenceDir, "System.Runtime.dll");
+			yield return Path.Combine (referenceDir, "System.Runtime.Extensions.dll");
+			yield return Path.Combine (referenceDir, "System.Runtime.InteropServices.dll");
 #else
 			yield return "mscorlib.dll";
 #endif


### PR DESCRIPTION
Fixes https://github.com/dotnet/linker/issues/2267.

This fixes the issue by taking the first approach mentioned in https://github.com/dotnet/linker/issues/2267#issuecomment-916379762. We now mark type forwarders referenced from any `TypeReference` we discover for a copy assembly, including `TypeReference`s to built-in types which only exist as bytes in metadata rather than typeref rows.

The walking logic in `TypeReferenceMarker` is copied from `AssemblyReferencesCorrector` in `SweepStep` and adjusted so that instead of updating the scopes of typereferences, it just marks any type forwarders they point to. The walking logic was duplicated to avoid touching `SweepStep` to reduce the risk of this change.

This includes a change to the test infrastructure to build tests against `System.Runtime`, which is necessary to reproduce the issue (since it has to do with references to builtin types forwarded from `System.Runtime` to `System.Private.CoreLib`). That change caused the compiler to produce different code for event methods - before the change, there were unnecessary locals in the generated code. Either way the unreachablebodies optimization removes all locals for unreachable event methods, which is why I removed the `ExpectLocalsModified` from a few testcases.

I plan to factor out the duplicated logic in a follow-up that we won't consider taking into .NET6.