### PR TITLE
Enable nullable on annotations

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1817,9 +1817,10 @@ namespace Mono.Linker.Steps
 			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 			MarkSecurityDeclarations (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 
-			if (type.BaseType is not null &&
+			var baseType = _context.TryResolve (type.BaseType);
+			if (baseType is not null &&
 				!_context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (type) &&
-				_context.Annotations.TryGetLinkerAttribute (_context.TryResolve (type.BaseType), out RequiresUnreferencedCodeAttribute effectiveRequiresUnreferencedCode)) {
+				_context.Annotations.TryGetLinkerAttribute (baseType, out RequiresUnreferencedCodeAttribute effectiveRequiresUnreferencedCode)) {
 
 				var currentOrigin = _scopeStack.CurrentScope.Origin;
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1817,8 +1817,7 @@ namespace Mono.Linker.Steps
 			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 			MarkSecurityDeclarations (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 
-			var baseType = _context.TryResolve (type.BaseType);
-			if (baseType is not null &&
+			if (_context.TryResolve (type.BaseType) is TypeDefinition baseType &&
 				!_context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (type) &&
 				_context.Annotations.TryGetLinkerAttribute (baseType, out RequiresUnreferencedCodeAttribute effectiveRequiresUnreferencedCode)) {
 
@@ -2737,8 +2736,8 @@ namespace Mono.Linker.Steps
 			if (reference.DeclaringType is ArrayType arrayType) {
 				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference));
 
-				if (reference.Name == ".ctor") {
-					Annotations.MarkRelevantToVariantCasting (_context.TryResolve (arrayType));
+				if (reference.Name == ".ctor" && _context.TryResolve (arrayType) is TypeDefinition typeDefinition) {
+					Annotations.MarkRelevantToVariantCasting (typeDefinition);
 				}
 				return null;
 			}
@@ -3415,7 +3414,8 @@ namespace Mono.Linker.Steps
 				var operand = (TypeReference) instruction.Operand;
 				switch (instruction.OpCode.Code) {
 				case Code.Newarr:
-					Annotations.MarkRelevantToVariantCasting (_context.TryResolve (operand));
+					if (_context.TryResolve (operand) is TypeDefinition typeDefinition)
+						Annotations.MarkRelevantToVariantCasting (typeDefinition);
 					break;
 				case Code.Isinst:
 					if (operand is TypeSpecification || operand is GenericParameter)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -245,7 +245,7 @@ namespace Mono.Linker
 			return marked_instantiated.Contains (type);
 		}
 
-		public void MarkRelevantToVariantCasting (TypeDefinition? type)
+		public void MarkRelevantToVariantCasting (TypeDefinition type)
 		{
 			if (type != null)
 				types_relevant_to_variant_casting.Add (type);

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -245,7 +245,7 @@ namespace Mono.Linker
 			return marked_instantiated.Contains (type);
 		}
 
-		public void MarkRelevantToVariantCasting (TypeDefinition type)
+		public void MarkRelevantToVariantCasting (TypeDefinition? type)
 		{
 			if (type != null)
 				types_relevant_to_variant_casting.Add (type);

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -411,9 +412,9 @@ namespace Mono.Linker
 			return MemberActions.TryGetFieldUserValue (field, out value);
 		}
 
-		public HashSet<EmbeddedResource> GetResourcesToRemove (AssemblyDefinition assembly)
+		public HashSet<EmbeddedResource>? GetResourcesToRemove (AssemblyDefinition assembly)
 		{
-			if (resources_to_remove.TryGetValue (assembly, out HashSet<EmbeddedResource> resources))
+			if (resources_to_remove.TryGetValue (assembly, out HashSet<EmbeddedResource>? resources))
 				return resources;
 
 			return null;
@@ -421,7 +422,7 @@ namespace Mono.Linker
 
 		public void AddResourceToRemove (AssemblyDefinition assembly, EmbeddedResource resource)
 		{
-			if (!resources_to_remove.TryGetValue (assembly, out HashSet<EmbeddedResource> resources))
+			if (!resources_to_remove.TryGetValue (assembly, out HashSet<EmbeddedResource>? resources))
 				resources = resources_to_remove[assembly] = new HashSet<EmbeddedResource> ();
 
 			resources.Add (resource);
@@ -452,7 +453,7 @@ namespace Mono.Linker
 			return TypeMapInfo.GetBaseMethods (method);
 		}
 
-		public List<MethodDefinition> GetPreservedMethods (TypeDefinition type)
+		public List<MethodDefinition>? GetPreservedMethods (TypeDefinition type)
 		{
 			return GetPreservedMethods (type as IMemberDefinition);
 		}
@@ -467,7 +468,7 @@ namespace Mono.Linker
 			AddPreservedMethod (type as IMemberDefinition, method);
 		}
 
-		public List<MethodDefinition> GetPreservedMethods (MethodDefinition method)
+		public List<MethodDefinition>? GetPreservedMethods (MethodDefinition method)
 		{
 			return GetPreservedMethods (method as IMemberDefinition);
 		}
@@ -482,9 +483,9 @@ namespace Mono.Linker
 			AddPreservedMethod (key as IMemberDefinition, method);
 		}
 
-		List<MethodDefinition> GetPreservedMethods (IMemberDefinition definition)
+		List<MethodDefinition>? GetPreservedMethods (IMemberDefinition definition)
 		{
-			if (preserved_methods.TryGetValue (definition, out List<MethodDefinition> preserved))
+			if (preserved_methods.TryGetValue (definition, out List<MethodDefinition>? preserved))
 				return preserved;
 
 			return null;
@@ -514,19 +515,19 @@ namespace Mono.Linker
 
 		public void CloseSymbolReader (AssemblyDefinition assembly)
 		{
-			if (!symbol_readers.TryGetValue (assembly, out ISymbolReader symbolReader))
+			if (!symbol_readers.TryGetValue (assembly, out ISymbolReader? symbolReader))
 				return;
 
 			symbol_readers.Remove (assembly);
 			symbolReader.Dispose ();
 		}
 
-		public object GetCustomAnnotation (object key, IMetadataTokenProvider item)
+		public object? GetCustomAnnotation (object key, IMetadataTokenProvider item)
 		{
-			if (!custom_annotations.TryGetValue (key, out Dictionary<IMetadataTokenProvider, object> slots))
+			if (!custom_annotations.TryGetValue (key, out Dictionary<IMetadataTokenProvider, object>? slots))
 				return null;
 
-			if (!slots.TryGetValue (item, out object value))
+			if (!slots.TryGetValue (item, out object? value))
 				return null;
 
 			return value;
@@ -534,7 +535,7 @@ namespace Mono.Linker
 
 		public void SetCustomAnnotation (object key, IMetadataTokenProvider item, object value)
 		{
-			if (!custom_annotations.TryGetValue (key, out Dictionary<IMetadataTokenProvider, object> slots)) {
+			if (!custom_annotations.TryGetValue (key, out Dictionary<IMetadataTokenProvider, object>? slots)) {
 				slots = new Dictionary<IMetadataTokenProvider, object> ();
 				custom_annotations.Add (key, slots);
 			}
@@ -580,7 +581,7 @@ namespace Mono.Linker
 			return linkerAttributeInformation.GetAttributes<T> ();
 		}
 
-		public bool TryGetLinkerAttribute<T> (IMemberDefinition member, out T attribute) where T : Attribute
+		public bool TryGetLinkerAttribute<T> (IMemberDefinition member, [NotNullWhen (returnValue: true)] out T? attribute) where T : Attribute
 		{
 			var attributes = GetLinkerAttributes<T> (member);
 			if (attributes.Count () > 1) {
@@ -596,7 +597,7 @@ namespace Mono.Linker
 		/// </summary>
 		/// <remarks>Unlike <see cref="IsMethodInRequiresUnreferencedCodeScope(MethodDefinition)"/> only static methods 
 		/// and .ctors are reported as requiring unreferenced code when the declaring type has RUC on it.</remarks>
-		internal bool DoesMethodRequireUnreferencedCode (MethodDefinition method, out RequiresUnreferencedCodeAttribute attribute)
+		internal bool DoesMethodRequireUnreferencedCode (MethodDefinition method, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
 			if (method.IsStaticConstructor ()) {
 				attribute = null;
@@ -628,7 +629,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		internal bool DoesFieldRequireUnreferencedCode (FieldDefinition field, out RequiresUnreferencedCodeAttribute attribute)
+		internal bool DoesFieldRequireUnreferencedCode (FieldDefinition field, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
 			if (!field.IsStatic || field.DeclaringType is null) {
 				attribute = null;
@@ -638,7 +639,7 @@ namespace Mono.Linker
 			return TryGetLinkerAttribute (field.DeclaringType, out attribute);
 		}
 
-		internal bool DoesMemberRequireUnreferencedCode (IMemberDefinition member, out RequiresUnreferencedCodeAttribute attribute)
+		internal bool DoesMemberRequireUnreferencedCode (IMemberDefinition member, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
 			attribute = null;
 			return member switch {


### PR DESCRIPTION
Enable nullable on Annotations.cs
Change the MarkStep condition to check for null after TryResolve

Fixes https://github.com/dotnet/linker/issues/2274
I couldn't add a test case because I couldn't come up with a scenario in which the TypeReference Type.BaseType is not null but resolving the TypeReference is null