### PR TITLE
Share logic for discovering typereferences

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1381,7 +1381,7 @@ namespace Mono.Linker.Steps
 				MarkEntireType (type, new DependencyInfo (DependencyKind.TypeInAssembly, assembly));
 
 			// Mark scopes of type references and exported types.
-			new TypeReferenceMarker (assembly, MarkingHelpers).Process ();
+			TypeReferenceMarker.MarkTypeReferences (assembly, MarkingHelpers);
 		}
 
 		class TypeReferenceMarker : TypeReferenceWalker
@@ -1389,10 +1389,15 @@ namespace Mono.Linker.Steps
 
 			readonly MarkingHelpers markingHelpers;
 
-			public TypeReferenceMarker (AssemblyDefinition assembly, MarkingHelpers markingHelpers)
+			TypeReferenceMarker (AssemblyDefinition assembly, MarkingHelpers markingHelpers)
 				: base (assembly)
 			{
 				this.markingHelpers = markingHelpers;
+			}
+
+			public static void MarkTypeReferences (AssemblyDefinition assembly, MarkingHelpers markingHelpers)
+			{
+				new TypeReferenceMarker (assembly, markingHelpers).Process ();
 			}
 
 			protected override void ProcessTypeReference (TypeReference type)
@@ -1411,7 +1416,7 @@ namespace Mono.Linker.Steps
 				// Also mark the scopes of metadata typeref rows to cover any not discovered by the traversal.
 				// This can happen when the compiler emits typerefs into IL which aren't strictly necessary per ECMA 335.
 				foreach (TypeReference typeReference in assembly.MainModule.GetTypeReferences ()) {
-					if (!visited!.Add (typeReference))
+					if (!Visited!.Add (typeReference))
 						continue;
 					markingHelpers.MarkForwardedScope (typeReference);
 				}

--- a/src/linker/Linker/TypeReferenceWalker.cs
+++ b/src/linker/Linker/TypeReferenceWalker.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -15,7 +16,8 @@ namespace Mono.Linker
 	{
 		protected readonly AssemblyDefinition assembly;
 
-		protected HashSet<TypeReference>? visited;
+		HashSet<TypeReference>? visited;
+		protected HashSet<TypeReference> Visited => visited ?? throw new InvalidOperationException ();
 
 		public TypeReferenceWalker (AssemblyDefinition assembly)
 		{
@@ -26,7 +28,7 @@ namespace Mono.Linker
 		// Traverse the assembly and mark the scopes of discovered type references (but not exported types).
 		// This includes scopes referenced by Cecil TypeReference objects that don't represent rows in the typeref table,
 		// such as references to built-in types, or attribute arguments which encode type references as strings.
-		public virtual void Process ()
+		protected virtual void Process ()
 		{
 			visited = new HashSet<TypeReference> ();
 


### PR DESCRIPTION
Factor out the logic for walking an assembly to discover typerefs into a new abstract class, `TypeReferenceWalker`.