### PR TITLE
Fix handling of unknowns BindingFlags

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1115,8 +1115,7 @@ namespace Mono.Linker.Dataflow
 								reflectionContext.RecordHandledPattern ();
 							} else {
 								// Otherwise fall back to the bitfield requirements
-								var requiredMemberTypes = HasBindingFlag (bindingFlags, BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicConstructors : DynamicallyAccessedMemberTypes.None;
-								requiredMemberTypes |= HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicConstructors : DynamicallyAccessedMemberTypes.None;
+								var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags);
 								// We can scope down the public constructors requirement if we know the number of parameters is 0
 								if (requiredMemberTypes == DynamicallyAccessedMemberTypes.PublicConstructors && ctorParameterCount == 0)
 									requiredMemberTypes = DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
@@ -2406,27 +2405,33 @@ namespace Mono.Linker.Dataflow
 
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForNestedTypes (BindingFlags? bindingFlags) =>
 			(HasBindingFlag (bindingFlags, BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicNestedTypes : DynamicallyAccessedMemberTypes.None) |
-			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicNestedTypes : DynamicallyAccessedMemberTypes.None);
+			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicNestedTypes : DynamicallyAccessedMemberTypes.None) |
+			(!bindingFlags.HasValue ? DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes : DynamicallyAccessedMemberTypes.None);
 
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (BindingFlags? bindingFlags) =>
 			(HasBindingFlag (bindingFlags, BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicConstructors : DynamicallyAccessedMemberTypes.None) |
-			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicConstructors : DynamicallyAccessedMemberTypes.None);
+			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicConstructors : DynamicallyAccessedMemberTypes.None) |
+			(!bindingFlags.HasValue ? DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors : DynamicallyAccessedMemberTypes.None);
 
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (BindingFlags? bindingFlags) =>
 			(HasBindingFlag (bindingFlags, BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicMethods : DynamicallyAccessedMemberTypes.None) |
-			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicMethods : DynamicallyAccessedMemberTypes.None);
+			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicMethods : DynamicallyAccessedMemberTypes.None) |
+			(!bindingFlags.HasValue ? DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods : DynamicallyAccessedMemberTypes.None);
 
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForFields (BindingFlags? bindingFlags) =>
 			(HasBindingFlag (bindingFlags, BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicFields : DynamicallyAccessedMemberTypes.None) |
-			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicFields : DynamicallyAccessedMemberTypes.None);
+			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicFields : DynamicallyAccessedMemberTypes.None) |
+			(!bindingFlags.HasValue ? DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields : DynamicallyAccessedMemberTypes.None);
 
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForProperties (BindingFlags? bindingFlags) =>
 			(HasBindingFlag (bindingFlags, BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicProperties : DynamicallyAccessedMemberTypes.None) |
-			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicProperties : DynamicallyAccessedMemberTypes.None);
+			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicProperties : DynamicallyAccessedMemberTypes.None) |
+			(!bindingFlags.HasValue ? DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties : DynamicallyAccessedMemberTypes.None);
 
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForEvents (BindingFlags? bindingFlags) =>
 			(HasBindingFlag (bindingFlags, BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicEvents : DynamicallyAccessedMemberTypes.None) |
-			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicEvents : DynamicallyAccessedMemberTypes.None);
+			(HasBindingFlag (bindingFlags, BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicEvents : DynamicallyAccessedMemberTypes.None) |
+			(!bindingFlags.HasValue ? DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents : DynamicallyAccessedMemberTypes.None);
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForMembers (BindingFlags? bindingFlags) =>
 			GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags) |
 			GetDynamicallyAccessedMemberTypesFromBindingFlagsForEvents (bindingFlags) |

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNameBindingFlags ();
 			TestNameWrongBindingFlags ();
 			TestNameUnknownBindingFlags (BindingFlags.Public);
+			TestNameUnknownBindingFlagsAndName (BindingFlags.Public, "DoesntMatter");
 			TestNullName ();
 			TestEmptyName ();
 			TestNonExistingName ();
@@ -69,6 +70,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			// Since the binding flags are not known linker should mark all events on the type
 			var eventInfo = typeof (UnknownBindingFlags).GetEvent ("PrivateEvent", bindingFlags);
+		}
+
+		[Kept]
+		static void TestNameUnknownBindingFlagsAndName (BindingFlags bindingFlags, string name)
+		{
+			// Since the binding flags are not known linker should mark all events on the type
+			var eventInfo = typeof (UnknownBindingFlagsAndName).GetEvent (name, bindingFlags);
 		}
 
 		[Kept]
@@ -198,6 +206,30 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		class UnknownBindingFlags
+		{
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			internal event EventHandler<EventArgs> InternalEvent;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			static event EventHandler<EventArgs> Static;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			private event EventHandler<EventArgs> PrivateEvent;
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified]
+			public event EventHandler<EventArgs> PublicEvent;
+		}
+
+		class UnknownBindingFlagsAndName
 		{
 			[Kept]
 			[KeptEventAddMethod]

--- a/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
@@ -15,6 +15,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNameBindingFlags ();
 			TestNameWrongBindingFlags ();
 			TestNameUnknownBindingFlags (BindingFlags.Public);
+			TestNameUnknownBindingFlagsAndName (BindingFlags.Public, "DoesntMatter");
 			TestNullName ();
 			TestEmptyName ();
 			TestNonExistingName ();
@@ -64,6 +65,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			// Since the binding flags are not known linker should mark all fields on the type
 			var field = typeof (UnknownBindingFlags).GetField ("field", bindingFlags);
+		}
+
+		[Kept]
+		static void TestNameUnknownBindingFlagsAndName (BindingFlags bindingFlags, string name)
+		{
+			// Since the binding flags and name are not known linker should mark all fields on the type
+			var field = typeof (UnknownBindingFlagsAndName).GetField (name, bindingFlags);
 		}
 
 		[Kept]
@@ -177,6 +185,17 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		private class UnknownBindingFlags
+		{
+			[Kept]
+			public static int field;
+			[Kept]
+			public int nonStatic;
+			[Kept]
+			private static int privatefield;
+		}
+
+		[Kept]
+		private class UnknownBindingFlagsAndName
 		{
 			[Kept]
 			public static int field;

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			GetMethod_Name_Types.TestNameAndType ();
 			GetMethod_Name_BindingAttr.TestExplicitBindingFlags ();
 			GetMethod_Name_BindingAttr.TestUnknownBindingFlags (BindingFlags.Public);
+			GetMethod_Name_BindingAttr.TestUnknownBindingFlagsAndName (BindingFlags.Public, "DoesntMatter");
 			GetMethod_Name_BindingAttr.TestUnknownNullBindingFlags (BindingFlags.Public);
 			GetMethod_Name_BindingAttr_Binder_Types_Modifiers.TestNameBindingFlagsAndParameterModifier ();
 			GetMethod_Name_BindingAttr_Binder_CallConvention_Types_Modifiers.TestNameBindingFlagsCallingConventionParameterModifier ();
@@ -196,6 +197,25 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{
 				// Since the binding flags are not known linker should mark all methods on the type
 				var method = typeof (UnknownBindingFlags).GetMethod ("OnlyCalledViaReflection", bindingFlags);
+				method.Invoke (null, new object[] { });
+			}
+
+			[Kept]
+			class UnknownBindingFlagsAndName
+			{
+				[Kept]
+				private static int OnlyCalledViaReflection ()
+				{
+					return 42;
+				}
+			}
+
+			[Kept]
+			[RecognizedReflectionAccessPattern]
+			public static void TestUnknownBindingFlagsAndName (BindingFlags bindingFlags, string name)
+			{
+				// Since the binding flags and name are not known linker should mark all methods on the type
+				var method = typeof (UnknownBindingFlagsAndName).GetMethod (name, bindingFlags);
 				method.Invoke (null, new object[] { });
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestPrivateByName ();
 			TestByBindingFlags ();
 			TestByUnknownBindingFlags (BindingFlags.Public);
+			TestByUnknownBindingFlagsAndName (BindingFlags.Public, "DoesntMatter");
 			TestNonExistingName ();
 			TestNullType ();
 			TestIgnoreCaseBindingFlags ();
@@ -82,6 +83,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string), typeof (BindingFlags) },
+			typeof (UnknownBindingFlagsAndName.PublicNestedType), null, (Type[]) null)]
+		static void TestByUnknownBindingFlagsAndName (BindingFlags bindingFlags, string name)
+		{
+			// Since the binding flags and name are not known linker should mark all nested types on the type
+			_ = typeof (UnknownBindingFlagsAndName).GetNestedType (name, bindingFlags);
+		}
+
+		[Kept]
 		static void TestNonExistingName ()
 		{
 			_ = typeof (NestedTypeUsedViaReflection).GetNestedType ("NonExisting");
@@ -117,6 +128,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		private class UnknownBindingFlags
+		{
+			[Kept]
+			public static class PublicNestedType { }
+
+			[Kept]
+			private static class PrivateNestedType { }
+		}
+
+		[Kept]
+		private class UnknownBindingFlagsAndName
 		{
 			[Kept]
 			public static class PublicNestedType { }

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestGetterOnly ();
 			TestBindingFlags ();
 			TestUnknownBindingFlags (BindingFlags.Public);
+			TestUnknownBindingFlagsAndName (BindingFlags.Public, "IrrelevantName");
 			TestNullName ();
 			TestEmptyName ();
 			TestNonExistingName ();
@@ -86,6 +87,17 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			// Since the binding flags are not known linker should mark all properties on the type
 			var property = typeof (UnknownBindingFlags).GetProperty ("SomeProperty", bindingFlags);
+			property.GetValue (null, new object[] { });
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type[] { typeof (string), typeof (BindingFlags) },
+			typeof (UnknownBindingFlagsAndName), nameof (UnknownBindingFlagsAndName.SomeProperty), (Type[]) null)]
+		static void TestUnknownBindingFlagsAndName (BindingFlags bindingFlags, string name)
+		{
+			// Since the binding flags and name are not known linker should mark all properties on the type
+			var property = typeof (UnknownBindingFlagsAndName).GetProperty (name, bindingFlags);
 			property.GetValue (null, new object[] { });
 		}
 
@@ -303,6 +315,18 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		class UnknownBindingFlags
+		{
+			[Kept]
+			internal static int SomeProperty {
+				[Kept]
+				private get { return _field; }
+				[Kept]
+				set { _field = value; }
+			}
+		}
+
+		[Kept]
+		class UnknownBindingFlagsAndName
 		{
 			[Kept]
 			internal static int SomeProperty {


### PR DESCRIPTION
Found on the NativeAOT side, since we're bug-for-bug compatible.

` GetDynamicallyAccessedMemberTypesFromBindingFlagsForXXX` would return `DynamicallyAccessedMembers.None` when the binding flags are null/unknown.

This fix is a bit more targeted so that we can potentially take it to 6.0.

In the existing linker code, there's some duality in how BindingFlags are handled - there are places that call `BindingFlagsAreUnsupported` and avoid `GetDynamicallyAccessedMemberTypesFromBindingFlagsForXXX` for null that way. Others call into this API without checking whether the flags are supported first.

I'm unclear whether it would be more appropriate to check for `BindingFlagsAreUnsupported` in the code I'm adding. It's a valid option as well.