### PR TITLE
Switch to servicing pools on release/6.0

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -55,8 +55,8 @@ stages:
           ${{ if eq(variables.officialBuild, 'false') }}:
             name: Hosted VS2017
           ${{ if eq(variables.officialBuild, 'true') }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
         variables:
           - ${{ if eq(variables.officialBuild, 'false') }}:
             - _SignType: test


### PR DESCRIPTION
We're required to move all servicing branches to the new 1ES servicing pools by September 30. This accomplishes that for release/latest.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276