### PR TITLE
Analyzer test infra improvements

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
@@ -15,7 +15,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 	{
 		[Theory]
 		[MemberData (nameof (TestCaseUtils.GetTestData), parameters: nameof (RequiresCapability))]
-		public void RequiresCapability (MemberDeclarationSyntax m, List<AttributeSyntax> attrs)
+		public void RequiresCapability (string testName, MemberDeclarationSyntax m, List<AttributeSyntax> attrs)
 		{
 			if (m is MethodDeclarationSyntax method &&
 				method.Identifier.ValueText == "TestTypeIsBeforeFieldInit") {

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
@@ -786,10 +786,7 @@ class StaticCtor
 		_ = new StaticCtor ();
 	}
 }";
-			return VerifyRequiresAssemblyFilesAnalyzer (src,
-				// (13,7): warning IL3002: Using member 'StaticCtor.StaticCtor()' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app. Message for --TestStaticCtor--.
-				VerifyCS.Diagnostic (DiagnosticId.RequiresAssemblyFiles).WithSpan (13, 7, 13, 24).WithArguments ("StaticCtor.StaticCtor()", " Message for --TestStaticCtor--.", "")
-				);
+			return VerifyRequiresAssemblyFilesAnalyzer (src);
 		}
 
 		[Fact]
@@ -815,10 +812,7 @@ class C
 		var x = StaticCtorTriggeredByFieldAccess.field + 1;
 	}
 }";
-			return VerifyRequiresAssemblyFilesAnalyzer (src,
-				// (18,11): warning IL3002: Using member 'StaticCtorTriggeredByFieldAccess.StaticCtorTriggeredByFieldAccess()' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app.. Message for --StaticCtorTriggeredByFieldAccess.Cctor--.
-				VerifyCS.Diagnostic (DiagnosticId.RequiresAssemblyFiles).WithSpan (18, 11, 18, 49).WithArguments ("StaticCtorTriggeredByFieldAccess.StaticCtorTriggeredByFieldAccess()", " Message for --StaticCtorTriggeredByFieldAccess.Cctor--.", "")
-				);
+			return VerifyRequiresAssemblyFilesAnalyzer (src);
 		}
 
 		[Fact]
@@ -849,9 +843,7 @@ class C
 }";
 			return VerifyRequiresAssemblyFilesAnalyzer (src,
 				// (21,3): warning IL3002: Using member 'StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking()' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app. Message for --StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking--.
-				VerifyCS.Diagnostic (DiagnosticId.RequiresAssemblyFiles).WithSpan (21, 3, 21, 69).WithArguments ("StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking()", " Message for --StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking--.", ""),
-				// (21,3): warning IL3002: Using member 'StaticCtorTriggeredByMethodCall.StaticCtorTriggeredByMethodCall()' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app. Message for --StaticCtorTriggeredByMethodCall.Cctor--.
-				VerifyCS.Diagnostic (DiagnosticId.RequiresAssemblyFiles).WithSpan (21, 3, 21, 41).WithArguments ("StaticCtorTriggeredByMethodCall.StaticCtorTriggeredByMethodCall()", " Message for --StaticCtorTriggeredByMethodCall.Cctor--.", "")
+				VerifyCS.Diagnostic (DiagnosticId.RequiresAssemblyFiles).WithSpan (21, 3, 21, 69).WithArguments ("StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking()", " Message for --StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking--.", "")
 				);
 		}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -441,10 +441,7 @@ class StaticCtor
 		_ = new StaticCtor ();
 	}
 }";
-			return VerifyRequiresUnreferencedCodeAnalyzer (src,
-				// (13,7): warning IL2026: Using member 'StaticCtor.StaticCtor()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Message for --TestStaticCtor--.
-				VerifyCS.Diagnostic (DiagnosticId.RequiresUnreferencedCode).WithSpan (13, 7, 13, 24).WithArguments ("StaticCtor.StaticCtor()", " Message for --TestStaticCtor--.", "")
-				);
+			return VerifyRequiresUnreferencedCodeAnalyzer (src);
 		}
 
 		[Fact]
@@ -470,10 +467,7 @@ class C
 		var x = StaticCtorTriggeredByFieldAccess.field + 1;
 	}
 }";
-			return VerifyRequiresUnreferencedCodeAnalyzer (src,
-				// (18,11): warning IL2026: Using member 'StaticCtorTriggeredByFieldAccess.StaticCtorTriggeredByFieldAccess()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Message for --StaticCtorTriggeredByFieldAccess.Cctor--.
-				VerifyCS.Diagnostic (DiagnosticId.RequiresUnreferencedCode).WithSpan (18, 11, 18, 49).WithArguments ("StaticCtorTriggeredByFieldAccess.StaticCtorTriggeredByFieldAccess()", " Message for --StaticCtorTriggeredByFieldAccess.Cctor--.", "")
-				);
+			return VerifyRequiresUnreferencedCodeAnalyzer (src);
 		}
 
 		[Fact]
@@ -504,9 +498,7 @@ class C
 }";
 			return VerifyRequiresUnreferencedCodeAnalyzer (src,
 				// (21,3): warning IL2026: Using member 'StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Message for --StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking--.
-				VerifyCS.Diagnostic (DiagnosticId.RequiresUnreferencedCode).WithSpan (21, 3, 21, 69).WithArguments ("StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking()", " Message for --StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking--.", ""),
-				// (21,3): warning IL2026: Using member 'StaticCtorTriggeredByMethodCall.StaticCtorTriggeredByMethodCall()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Message for --StaticCtorTriggeredByMethodCall.Cctor--.
-				VerifyCS.Diagnostic (DiagnosticId.RequiresUnreferencedCode).WithSpan (21, 3, 21, 41).WithArguments ("StaticCtorTriggeredByMethodCall.StaticCtorTriggeredByMethodCall()", " Message for --StaticCtorTriggeredByMethodCall.Cctor--.", "")
+				VerifyCS.Diagnostic (DiagnosticId.RequiresUnreferencedCode).WithSpan (21, 3, 21, 69).WithArguments ("StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking()", " Message for --StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking--.", "")
 				);
 		}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -39,13 +39,14 @@ namespace ILLink.RoslynAnalyzer.Tests
 		public static IEnumerable<object[]> GetTestData (string testSuiteName)
 		{
 			foreach (var testFile in s_testFiles[testSuiteName]) {
+				var testName = Path.GetFileNameWithoutExtension (testFile);
 				var root = CSharpSyntaxTree.ParseText (File.ReadAllText (testFile)).GetRoot ();
 
 				foreach (var node in root.DescendantNodes ()) {
 					if (node is MemberDeclarationSyntax m) {
 						var attrs = m.AttributeLists.SelectMany (al => al.Attributes.Where (IsWellKnown)).ToList ();
 						if (attrs.Count > 0) {
-							yield return new object[] { m, attrs };
+							yield return new object[] { testName, m, attrs };
 						}
 					}
 				}
@@ -127,7 +128,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			switch (expr.Kind ()) {
 			case SyntaxKind.AddExpression:
 				var addExpr = (BinaryExpressionSyntax) expr;
-				return GetStringFromExpression (addExpr.Left) + GetStringFromExpression (addExpr.Right);
+				return GetStringFromExpression (addExpr.Left, semanticModel) + GetStringFromExpression (addExpr.Right, semanticModel);
 
 			case SyntaxKind.InvocationExpression:
 				var nameofValue = semanticModel!.GetConstantValue (expr);
@@ -143,7 +144,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 				return token.ValueText;
 
 			case SyntaxKind.TypeOfExpression:
-				return semanticModel.GetTypeInfo (expr).Type!.GetDisplayName ();
+				return semanticModel.GetSymbolInfo ((expr as TypeOfExpressionSyntax).Type).Symbol.GetDisplayName ();
 
 			default:
 				Assert.True (false, "Unsupported expr kind " + expr.Kind ());

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -144,7 +144,9 @@ namespace ILLink.RoslynAnalyzer.Tests
 				return token.ValueText;
 
 			case SyntaxKind.TypeOfExpression:
-				return semanticModel.GetSymbolInfo ((expr as TypeOfExpressionSyntax).Type).Symbol.GetDisplayName ();
+				var typeofExpression = (TypeOfExpressionSyntax) expr;
+				var typeSymbol = semanticModel.GetSymbolInfo (typeofExpression.Type).Symbol;
+				return typeSymbol?.GetDisplayName () ?? string.Empty;
 
 			default:
 				Assert.True (false, "Unsupported expr kind " + expr.Kind ());

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -493,11 +493,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			tmp.GetRequiresUnreferencedCode ();
 		}
 
-		// https://github.com/dotnet/linker/issues/2107
-		// Doesn't work in the analyzer because the test infra for analyzer will not build the second assembly
-		// and provide it as a ref assembly to the compilation - so the analyzer actually sees the below
-		// as errors (missing assembly).
-		[ExpectedWarning ("IL2026", "--Method--", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2026", "--Method--")]
 		static void TestRequiresInMethodFromCopiedAssembly ()
 		{
 			var tmp = new RequiresUnreferencedCodeInCopyAssembly ();


### PR DESCRIPTION
This makes the analyzer test validation more similar to the linker test validation and adds extra reporting when tests fail. The change caught a few differences between the linker and analyzer behavior:
- Analyzer was producing cctor warnings - so I removed that
- Analyzer was producing duplicate warnings for RUC properties set in attributes
- Analyzer behavior for reference to a testcase dependency assembly was already fixed

As part of this I also had to tweak the logic for checking whether a diagnostic originates from a particular member.