### PR TITLE
Make BindingFlagsAreUnsupported more precise

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -2282,7 +2282,33 @@ namespace Mono.Linker.Dataflow
 
 		static BindingFlags? GetBindingFlagsFromValue (ValueNode? parameter) => (BindingFlags?) parameter.AsConstInt ();
 
-		static bool BindingFlagsAreUnsupported (BindingFlags? bindingFlags) => bindingFlags == null || (bindingFlags & BindingFlags.IgnoreCase) == BindingFlags.IgnoreCase || (int) bindingFlags > 255;
+		static bool BindingFlagsAreUnsupported (BindingFlags? bindingFlags)
+		{
+			if (bindingFlags == null)
+				return true;
+
+			// Binding flags we understand
+			const BindingFlags UnderstoodBindingFlags =
+				BindingFlags.DeclaredOnly |
+				BindingFlags.Instance |
+				BindingFlags.Static |
+				BindingFlags.Public |
+				BindingFlags.NonPublic |
+				BindingFlags.FlattenHierarchy |
+				BindingFlags.ExactBinding;
+
+			// Binding flags that don't affect binding outside InvokeMember (that we don't analyze).
+			const BindingFlags IgnorableBindingFlags =
+				BindingFlags.InvokeMethod |
+				BindingFlags.CreateInstance |
+				BindingFlags.GetField |
+				BindingFlags.SetField |
+				BindingFlags.GetProperty |
+				BindingFlags.SetProperty;
+
+			BindingFlags flags = bindingFlags.Value;
+			return (flags & ~(UnderstoodBindingFlags | IgnorableBindingFlags)) != 0;
+		}
 
 		static bool HasBindingFlag (BindingFlags? bindingFlags, BindingFlags? search) => bindingFlags != null && (bindingFlags & search) == search;
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -38,6 +38,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			DerivedAndBase.TestMethodInBaseType ();
 			IgnoreCaseBindingFlags.TestIgnoreCaseBindingFlags ();
 			FailIgnoreCaseBindingFlags.TestFailIgnoreCaseBindingFlags ();
+			IgnorableBindingFlags.TestIgnorableBindingFlags ();
 			UnsupportedBindingFlags.TestUnsupportedBindingFlags ();
 		}
 
@@ -752,6 +753,28 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		class IgnorableBindingFlags
+		{
+			[Kept]
+			public int OnlyCalledViaReflection ()
+			{
+				return 54;
+			}
+
+			private bool Unmarked ()
+			{
+				return true;
+			}
+
+			[Kept]
+			public static void TestIgnorableBindingFlags ()
+			{
+				var method = typeof (IgnorableBindingFlags).GetMethod ("OnlyCalledViaReflection", BindingFlags.Public | BindingFlags.InvokeMethod);
+				method.Invoke (null, new object[] { });
+			}
+		}
+
+		[Kept]
 		class UnsupportedBindingFlags
 		{
 			[Kept]
@@ -761,7 +784,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			private bool MarkedDueToInvokeMethod ()
+			private bool MarkedDueToChangeType ()
 			{
 				return true;
 			}
@@ -769,7 +792,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static void TestUnsupportedBindingFlags ()
 			{
-				var method = typeof (UnsupportedBindingFlags).GetMethod ("OnlyCalledViaReflection", BindingFlags.InvokeMethod);
+				var method = typeof (UnsupportedBindingFlags).GetMethod ("OnlyCalledViaReflection", BindingFlags.Public | BindingFlags.SuppressChangeType);
 				method.Invoke (null, new object[] { });
 			}
 		}

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
@@ -22,6 +22,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (1);
 			TestIgnoreCaseBindingFlags ();
+			TestIgnorableBindingFlags ();
 			TestUnsupportedBindingFlags ();
 		}
 
@@ -100,9 +101,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		static void TestIgnorableBindingFlags ()
+		{
+			var methods = typeof (InvokeMethodClass).GetMethods (BindingFlags.Public | BindingFlags.InvokeMethod);
+		}
+
+		[Kept]
 		static void TestUnsupportedBindingFlags ()
 		{
-			var methods = typeof (InvokeMethodClass).GetMethods (BindingFlags.InvokeMethod);
+			var methods = typeof (SuppressChangeTypeClass).GetMethods (BindingFlags.Public | BindingFlags.SuppressChangeType);
 		}
 
 		[Kept]
@@ -287,8 +294,23 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				return 54;
 			}
 
+			private bool Unmarked ()
+			{
+				return true;
+			}
+		}
+
+		[Kept]
+		private class SuppressChangeTypeClass
+		{
 			[Kept]
-			private bool MarkedDueToInvokeMethod ()
+			public int OnlyCalledViaReflection ()
+			{
+				return 54;
+			}
+
+			[Kept]
+			private bool MarkedDueToSuppressChangeType ()
 			{
 				return true;
 			}

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertiesUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertiesUsedViaReflection.cs
@@ -23,6 +23,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (1);
 			TestIgnoreCaseBindingFlags ();
+			TestIgnorableBindingFlags ();
 			TestUnsupportedBindingFlags ();
 		}
 
@@ -107,9 +108,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[RecognizedReflectionAccessPattern]
+		static void TestIgnorableBindingFlags ()
+		{
+			var properties = typeof (ExactBindingBindingFlagsClass).GetProperties (BindingFlags.Public | BindingFlags.ExactBinding);
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern]
 		static void TestUnsupportedBindingFlags ()
 		{
-			var properties = typeof (ExactBindingBindingFlagsClass).GetProperties (BindingFlags.ExactBinding);
+			var properties = typeof (ChangeTypeBindingFlagsClass).GetProperties (BindingFlags.Public | BindingFlags.SuppressChangeType);
 		}
 
 		[Kept]
@@ -256,8 +264,22 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				set { _field = value; }
 			}
 
+			private static int Unmarked {
+				get { return _field; }
+			}
+		}
+
+		[Kept]
+		class ChangeTypeBindingFlagsClass
+		{
 			[Kept]
-			private static int MarkedDueToExactBinding {
+			public static int SetterOnly {
+				[Kept]
+				set { _field = value; }
+			}
+
+			[Kept]
+			private static int KeptDueToChangeType {
 				[Kept]
 				get { return _field; }
 			}

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -28,6 +28,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestPropertyInBaseType ();
 			TestIgnoreCaseBindingFlags ();
 			TestFailIgnoreCaseBindingFlags ();
+			TestIgnorableBindingFlags ();
 			TestUnsupportedBindingFlags ();
 		}
 
@@ -206,9 +207,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		static void TestIgnorableBindingFlags ()
+		{
+			var property = typeof (ExactBindingBindingFlagsClass).GetProperty ("SetterOnly", BindingFlags.Public | BindingFlags.ExactBinding);
+		}
+
+		[Kept]
 		static void TestUnsupportedBindingFlags ()
 		{
-			var property = typeof (ExactBindingBindingFlagsClass).GetProperty ("SetterOnly", BindingFlags.ExactBinding);
+			var property = typeof (ChangeTypeBindingFlagsClass).GetProperty ("SetterOnly", BindingFlags.Public | BindingFlags.SuppressChangeType);
 		}
 
 		[Kept]
@@ -370,8 +377,22 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				set { _field = value; }
 			}
 
+			public static int Unmarked {
+				get { return _field; }
+			}
+		}
+
+		[Kept]
+		class ChangeTypeBindingFlagsClass
+		{
 			[Kept]
-			public static int MarkedDueToExactBinding {
+			public static int SetterOnly {
+				[Kept]
+				set { _field = value; }
+			}
+
+			[Kept]
+			public static int Marked {
 				[Kept]
 				get { return _field; }
 			}


### PR DESCRIPTION
`IgnorableBindingFlags` are all new - we wouldn't consider them supported in the past. I'm also adding `BindingFlags.ExactBinding` in the first group - that one was considered unsupported in the past but this flag just disallows implicit widening and similar things that don't affect our binding logic (I don't think we would ever want to go in that territory).