### PR TITLE
Rename RequiresUnreferencedCode to Requires 

### DIFF
--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/RequiresInCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/RequiresInCopyAssembly.cs
@@ -9,9 +9,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability.Dependencies
 {
-	public class RequiresUnreferencedCodeInCopyAssembly
+	public class RequiresInCopyAssembly
 	{
-		public RequiresUnreferencedCodeInCopyAssembly ()
+		public RequiresInCopyAssembly ()
 		{
 		}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/RequiresOnAttributeCtorAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/RequiresOnAttributeCtorAttribute.cs
@@ -7,10 +7,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability.Dependencies
 {
-	public class RequiresUnreferencedCodeOnAttributeCtorAttribute : Attribute
+	public class RequiresOnAttributeCtorAttribute : Attribute
 	{
 		[RequiresUnreferencedCode ("Message from attribute's ctor.")]
-		public RequiresUnreferencedCodeOnAttributeCtorAttribute ()
+		public RequiresOnAttributeCtorAttribute ()
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.attributes.xml
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.attributes.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <linker>
   <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-    <type fullname="Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability">
+    <type fullname="Mono.Linker.Tests.Cases.RequiresCapability.RequiresCapability">
       <method name="MethodWithDuplicateRequiresAttribute">
         <attribute fullname="System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute">
           <argument>Message for MethodWithDuplicateRequiresAttribute from link attributes XML</argument>

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
@@ -18,10 +18,10 @@ using Mono.Linker.Tests.Cases.RequiresCapability.Dependencies;
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
 	[SetupLinkerAction ("copy", "lib")]
-	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/RequiresUnreferencedCodeInCopyAssembly.cs" })]
+	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/RequiresInCopyAssembly.cs" })]
 	[KeptAllTypesAndMembersInAssembly ("lib.dll")]
-	[SetupLinkAttributesFile ("RequiresUnreferencedCodeCapability.attributes.xml")]
-	[SetupLinkerDescriptorFile ("RequiresUnreferencedCodeCapability.descriptor.xml")]
+	[SetupLinkAttributesFile ("RequiresCapability.attributes.xml")]
+	[SetupLinkerDescriptorFile ("RequiresCapability.descriptor.xml")]
 	[SkipKeptItemsValidation]
 	// Annotated members on a copied assembly should not produce any warnings
 	// unless directly called or referenced through reflection.
@@ -34,13 +34,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 	[LogDoesNotContain ("--IUnusedInterface.UnusedMethod--")]
 	[LogDoesNotContain ("--UnusedImplementationClass.UnusedMethod--")]
 	// [LogDoesNotContain ("UnusedVirtualMethod2")] // https://github.com/dotnet/linker/issues/2106
-	// [LogContains ("--RequiresUnreferencedCodeOnlyViaDescriptor--")]  // https://github.com/dotnet/linker/issues/2103
+	// [LogContains ("--RequiresOnlyViaDescriptor--")]  // https://github.com/dotnet/linker/issues/2103
 	[ExpectedNoWarnings]
-	public class RequiresUnreferencedCodeCapability
+	public class RequiresCapability
 	{
 		[ExpectedWarning ("IL2026", "--IDerivedInterface.MethodInDerivedInterface--", ProducedBy = ProducedBy.Trimmer)]
-		[ExpectedWarning ("IL2026", "--DynamicallyAccessedTypeWithRequiresUnreferencedCode.RequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
-		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2026", "--DynamicallyAccessedTypeWithRequires.MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequires--", ProducedBy = ProducedBy.Trimmer)]
 		[ExpectedWarning ("IL2026", "--IBaseInterface.MethodInBaseInterface--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()
 		{
@@ -51,28 +51,28 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			SuppressMethodBodyReferences.Test ();
 			SuppressGenericParameters<TestType, TestType>.Test ();
 			TestDuplicateRequiresAttribute ();
-			TestRequiresUnreferencedCodeOnlyThroughReflection ();
+			TestRequiresOnlyThroughReflection ();
 			AccessedThroughReflectionOnGenericType<TestType>.Test ();
-			TestBaseTypeVirtualMethodRequiresUnreferencedCode ();
-			TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCode ();
-			TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCodeOnBase ();
-			TestTypeWhichOverridesVirtualPropertyRequiresUnreferencedCode ();
-			TestStaticCctorRequiresUnreferencedCode ();
+			TestBaseTypeVirtualMethodRequires ();
+			TestTypeWhichOverridesMethodVirtualMethodRequires ();
+			TestTypeWhichOverridesMethodVirtualMethodRequiresOnBase ();
+			TestTypeWhichOverridesVirtualPropertyRequires ();
+			TestStaticCctorRequires ();
 			TestStaticCtorMarkingIsTriggeredByFieldAccess ();
 			TestStaticCtorMarkingIsTriggeredByFieldAccessOnExplicitLayout ();
 			TestStaticCtorTriggeredByMethodCall ();
 			TestTypeIsBeforeFieldInit ();
-			TestDynamicallyAccessedMembersWithRequiresUnreferencedCode (typeof (DynamicallyAccessedTypeWithRequiresUnreferencedCode));
-			TestDynamicallyAccessedMembersWithRequiresUnreferencedCode (typeof (TypeWhichOverridesMethod));
-			TestInterfaceMethodWithRequiresUnreferencedCode ();
+			TestDynamicallyAccessedMembersWithRequires (typeof (DynamicallyAccessedTypeWithRequires));
+			TestDynamicallyAccessedMembersWithRequires (typeof (TypeWhichOverridesMethod));
+			TestInterfaceMethodWithRequires ();
 			TestCovariantReturnCallOnDerived ();
 			TestRequiresInMethodFromCopiedAssembly ();
 			TestRequiresThroughReflectionInMethodFromCopiedAssembly ();
-			TestRequiresInDynamicallyAccessedMethodFromCopiedAssembly (typeof (RequiresUnreferencedCodeInCopyAssembly.IDerivedInterface));
+			TestRequiresInDynamicallyAccessedMethodFromCopiedAssembly (typeof (RequiresInCopyAssembly.IDerivedInterface));
 			TestRequiresInDynamicDependency ();
 			TestThatTrailingPeriodIsAddedToMessage ();
 			TestThatTrailingPeriodIsNotDuplicatedInWarningMessage ();
-			WarnIfRequiresUnreferencedCodeOnStaticConstructor.Test ();
+			WarnIfRequiresOnStaticConstructor.Test ();
 			RequiresOnAttribute.Test ();
 			RequiresOnGenerics.Test ();
 			CovariantReturnViaLdftn.Test ();
@@ -144,8 +144,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static Type _unknownType;
 			static Type GetUnknownType () => null;
 
-			[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeMethod--")]
-			static void RequiresUnreferencedCodeMethod ()
+			[RequiresUnreferencedCode ("Message for --MethodWithRequires--")]
+			static void MethodWithRequires ()
 			{
 			}
 
@@ -153,10 +153,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static Type _requiresPublicConstructors;
 
 			[RequiresUnreferencedCode ("")]
-			static void TestRUCMethod ()
+			static void TestMethodWithRequires ()
 			{
 				// Normally this would warn, but with the attribute on this method it should be auto-suppressed
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 			}
 
 			[RequiresUnreferencedCode ("")]
@@ -180,7 +180,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
 			public static void Test ()
 			{
-				TestRUCMethod ();
+				TestMethodWithRequires ();
 				TestParameter ();
 				TestReturnValue ();
 				TestField ();
@@ -261,93 +261,93 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		{
 		}
 
-		[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeOnlyThroughReflection--")]
-		static void RequiresUnreferencedCodeOnlyThroughReflection ()
+		[RequiresUnreferencedCode ("Message for --RequiresOnlyThroughReflection--")]
+		static void RequiresOnlyThroughReflection ()
 		{
 		}
 
-		[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeOnlyThroughReflection--", ProducedBy = ProducedBy.Trimmer)]
-		static void TestRequiresUnreferencedCodeOnlyThroughReflection ()
+		[ExpectedWarning ("IL2026", "--RequiresOnlyThroughReflection--", ProducedBy = ProducedBy.Trimmer)]
+		static void TestRequiresOnlyThroughReflection ()
 		{
-			typeof (RequiresUnreferencedCodeCapability)
-				.GetMethod (nameof (RequiresUnreferencedCodeOnlyThroughReflection), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
+			typeof (RequiresCapability)
+				.GetMethod (nameof (RequiresOnlyThroughReflection), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
 				.Invoke (null, new object[0]);
 		}
 
 		class AccessedThroughReflectionOnGenericType<T>
 		{
-			[RequiresUnreferencedCode ("Message for --GenericType.RequiresUnreferencedCodeOnlyThroughReflection--")]
-			public static void RequiresUnreferencedCodeOnlyThroughReflection ()
+			[RequiresUnreferencedCode ("Message for --GenericType.RequiresOnlyThroughReflection--")]
+			public static void RequiresOnlyThroughReflection ()
 			{
 			}
 
-			[ExpectedWarning ("IL2026", "--GenericType.RequiresUnreferencedCodeOnlyThroughReflection--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--GenericType.RequiresOnlyThroughReflection--", ProducedBy = ProducedBy.Trimmer)]
 			public static void Test ()
 			{
 				typeof (AccessedThroughReflectionOnGenericType<T>)
-					.GetMethod (nameof (RequiresUnreferencedCodeOnlyThroughReflection))
+					.GetMethod (nameof (RequiresOnlyThroughReflection))
 					.Invoke (null, new object[0]);
 			}
 		}
 
 		class BaseType
 		{
-			[RequiresUnreferencedCode ("Message for --BaseType.VirtualMethodRequiresUnreferencedCode--")]
-			public virtual void VirtualMethodRequiresUnreferencedCode ()
+			[RequiresUnreferencedCode ("Message for --BaseType.VirtualMethodRequires--")]
+			public virtual void VirtualMethodRequires ()
 			{
 			}
 		}
 
 		class TypeWhichOverridesMethod : BaseType
 		{
-			[RequiresUnreferencedCode ("Message for --TypeWhichOverridesMethod.VirtualMethodRequiresUnreferencedCode--")]
-			public override void VirtualMethodRequiresUnreferencedCode ()
+			[RequiresUnreferencedCode ("Message for --TypeWhichOverridesMethod.VirtualMethodRequires--")]
+			public override void VirtualMethodRequires ()
 			{
 			}
 		}
 
-		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequiresUnreferencedCode--")]
-		static void TestBaseTypeVirtualMethodRequiresUnreferencedCode ()
+		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequires--")]
+		static void TestBaseTypeVirtualMethodRequires ()
 		{
 			var tmp = new BaseType ();
-			tmp.VirtualMethodRequiresUnreferencedCode ();
+			tmp.VirtualMethodRequires ();
 		}
 
-		[LogDoesNotContain ("TypeWhichOverridesMethod.VirtualMethodRequiresUnreferencedCode")]
-		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequiresUnreferencedCode--")]
-		static void TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCode ()
+		[LogDoesNotContain ("TypeWhichOverridesMethod.VirtualMethodRequires")]
+		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequires--")]
+		static void TestTypeWhichOverridesMethodVirtualMethodRequires ()
 		{
 			var tmp = new TypeWhichOverridesMethod ();
-			tmp.VirtualMethodRequiresUnreferencedCode ();
+			tmp.VirtualMethodRequires ();
 		}
 
-		[LogDoesNotContain ("TypeWhichOverridesMethod.VirtualMethodRequiresUnreferencedCode")]
-		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequiresUnreferencedCode--")]
-		static void TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCodeOnBase ()
+		[LogDoesNotContain ("TypeWhichOverridesMethod.VirtualMethodRequires")]
+		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequires--")]
+		static void TestTypeWhichOverridesMethodVirtualMethodRequiresOnBase ()
 		{
 			BaseType tmp = new TypeWhichOverridesMethod ();
-			tmp.VirtualMethodRequiresUnreferencedCode ();
+			tmp.VirtualMethodRequires ();
 		}
 
 		class PropertyBaseType
 		{
-			public virtual int VirtualPropertyRequiresUnreferencedCode { [RequiresUnreferencedCode ("Message for --PropertyBaseType.VirtualPropertyRequiresUnreferencedCode--")] get; }
+			public virtual int VirtualPropertyRequires { [RequiresUnreferencedCode ("Message for --PropertyBaseType.VirtualPropertyRequires--")] get; }
 		}
 
 		class TypeWhichOverridesProperty : PropertyBaseType
 		{
-			public override int VirtualPropertyRequiresUnreferencedCode {
-				[RequiresUnreferencedCode ("Message for --TypeWhichOverridesProperty.VirtualPropertyRequiresUnreferencedCode--")]
+			public override int VirtualPropertyRequires {
+				[RequiresUnreferencedCode ("Message for --TypeWhichOverridesProperty.VirtualPropertyRequires--")]
 				get { return 1; }
 			}
 		}
 
-		[LogDoesNotContain ("TypeWhichOverridesProperty.VirtualPropertyRequiresUnreferencedCode")]
-		[ExpectedWarning ("IL2026", "--PropertyBaseType.VirtualPropertyRequiresUnreferencedCode--")]
-		static void TestTypeWhichOverridesVirtualPropertyRequiresUnreferencedCode ()
+		[LogDoesNotContain ("TypeWhichOverridesProperty.VirtualPropertyRequires")]
+		[ExpectedWarning ("IL2026", "--PropertyBaseType.VirtualPropertyRequires--")]
+		static void TestTypeWhichOverridesVirtualPropertyRequires ()
 		{
 			var tmp = new TypeWhichOverridesProperty ();
-			_ = tmp.VirtualPropertyRequiresUnreferencedCode;
+			_ = tmp.VirtualPropertyRequires;
 		}
 
 		class StaticCtor
@@ -359,7 +359,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 		}
 
-		static void TestStaticCctorRequiresUnreferencedCode ()
+		static void TestStaticCctorRequires ()
 		{
 			_ = new StaticCtor ();
 		}
@@ -397,16 +397,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class TypeIsBeforeFieldInit
 		{
+			[LogContains ("Message from --TypeIsBeforeFieldInit.AnnotatedMethod--")]
 			public static int field = AnnotatedMethod ();
 
 			[RequiresUnreferencedCode ("Message from --TypeIsBeforeFieldInit.AnnotatedMethod--")]
 			public static int AnnotatedMethod () => 42;
 		}
 
-		[LogContains ("IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability.TypeIsBeforeFieldInit..cctor():" +
-			" Using member 'Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability.TypeIsBeforeFieldInit.AnnotatedMethod()'" +
-			" which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code." +
-			" Message from --TypeIsBeforeFieldInit.AnnotatedMethod--.")]
 		static void TestTypeIsBeforeFieldInit ()
 		{
 			var x = TypeIsBeforeFieldInit.field + 42;
@@ -432,78 +429,78 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			new StaticCtorTriggeredByMethodCall ().TriggerStaticCtorMarking ();
 		}
 
-		public class DynamicallyAccessedTypeWithRequiresUnreferencedCode
+		public class DynamicallyAccessedTypeWithRequires
 		{
-			[RequiresUnreferencedCode ("Message for --DynamicallyAccessedTypeWithRequiresUnreferencedCode.RequiresUnreferencedCode--")]
-			public void RequiresUnreferencedCode ()
+			[RequiresUnreferencedCode ("Message for --DynamicallyAccessedTypeWithRequires.MethodWithRequires--")]
+			public void MethodWithRequires ()
 			{
 			}
 		}
 
-		static void TestDynamicallyAccessedMembersWithRequiresUnreferencedCode (
+		static void TestDynamicallyAccessedMembersWithRequires (
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
 		{
 		}
 
-		[LogDoesNotContain ("ImplementationClass.RequiresUnreferencedCodeMethod")]
-		[ExpectedWarning ("IL2026", "--IRequiresUnreferencedCode.RequiresUnreferencedCodeMethod--")]
-		static void TestInterfaceMethodWithRequiresUnreferencedCode ()
+		[LogDoesNotContain ("ImplementationClass.MethodWithRequires")]
+		[ExpectedWarning ("IL2026", "--IRequires.MethodWithRequires--")]
+		static void TestInterfaceMethodWithRequires ()
 		{
-			IRequiresUnreferencedCode inst = new ImplementationClass ();
-			inst.RequiresUnreferencedCodeMethod ();
+			IRequires inst = new ImplementationClass ();
+			inst.MethodWithRequires ();
 		}
 
 		class BaseReturnType { }
 		class DerivedReturnType : BaseReturnType { }
 
-		interface IRequiresUnreferencedCode
+		interface IRequires
 		{
-			[RequiresUnreferencedCode ("Message for --IRequiresUnreferencedCode.RequiresUnreferencedCodeMethod--")]
-			public void RequiresUnreferencedCodeMethod ();
+			[RequiresUnreferencedCode ("Message for --IRequires.MethodWithRequires--")]
+			public void MethodWithRequires ();
 		}
 
-		class ImplementationClass : IRequiresUnreferencedCode
+		class ImplementationClass : IRequires
 		{
-			[RequiresUnreferencedCode ("Message for --ImplementationClass.RequiresUnreferencedCodeMethod--")]
-			public void RequiresUnreferencedCodeMethod ()
+			[RequiresUnreferencedCode ("Message for --ImplementationClass.RequiresMethod--")]
+			public void MethodWithRequires ()
 			{
 			}
 		}
 
 		abstract class CovariantReturnBase
 		{
-			[RequiresUnreferencedCode ("Message for --CovariantReturnBase.GetRequiresUnreferencedCode--")]
-			public abstract BaseReturnType GetRequiresUnreferencedCode ();
+			[RequiresUnreferencedCode ("Message for --CovariantReturnBase.GetRequires--")]
+			public abstract BaseReturnType GetRequires ();
 		}
 
 		class CovariantReturnDerived : CovariantReturnBase
 		{
-			[RequiresUnreferencedCode ("Message for --CovariantReturnDerived.GetRequiresUnreferencedCode--")]
-			public override DerivedReturnType GetRequiresUnreferencedCode ()
+			[RequiresUnreferencedCode ("Message for --CovariantReturnDerived.GetRequires--")]
+			public override DerivedReturnType GetRequires ()
 			{
 				return null;
 			}
 		}
 
-		[LogDoesNotContain ("--CovariantReturnBase.GetRequiresUnreferencedCode--")]
-		[ExpectedWarning ("IL2026", "--CovariantReturnDerived.GetRequiresUnreferencedCode--")]
+		[LogDoesNotContain ("--CovariantReturnBase.GetRequires--")]
+		[ExpectedWarning ("IL2026", "--CovariantReturnDerived.GetRequires--")]
 		static void TestCovariantReturnCallOnDerived ()
 		{
 			var tmp = new CovariantReturnDerived ();
-			tmp.GetRequiresUnreferencedCode ();
+			tmp.GetRequires ();
 		}
 
 		[ExpectedWarning ("IL2026", "--Method--")]
 		static void TestRequiresInMethodFromCopiedAssembly ()
 		{
-			var tmp = new RequiresUnreferencedCodeInCopyAssembly ();
+			var tmp = new RequiresInCopyAssembly ();
 			tmp.Method ();
 		}
 
 		[ExpectedWarning ("IL2026", "--MethodCalledThroughReflection--", ProducedBy = ProducedBy.Trimmer)]
 		static void TestRequiresThroughReflectionInMethodFromCopiedAssembly ()
 		{
-			typeof (RequiresUnreferencedCodeInCopyAssembly)
+			typeof (RequiresInCopyAssembly)
 				.GetMethod ("MethodCalledThroughReflection", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
 				.Invoke (null, new object[0]);
 		}
@@ -513,16 +510,16 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		{
 		}
 
-		[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeInDynamicDependency--")]
-		static void RequiresUnreferencedCodeInDynamicDependency ()
+		[RequiresUnreferencedCode ("Message for --RequiresInDynamicDependency--")]
+		static void RequiresInDynamicDependency ()
 		{
 		}
 
-		[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeInDynamicDependency--")]
-		[DynamicDependency ("RequiresUnreferencedCodeInDynamicDependency")]
+		[ExpectedWarning ("IL2026", "--RequiresInDynamicDependency--")]
+		[DynamicDependency ("RequiresInDynamicDependency")]
 		static void TestRequiresInDynamicDependency ()
 		{
-			RequiresUnreferencedCodeInDynamicDependency ();
+			RequiresInDynamicDependency ();
 		}
 
 		[RequiresUnreferencedCode ("Linker adds a trailing period to this message")]
@@ -547,54 +544,54 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			WarningMessageEndsWithPeriod ();
 		}
 
-		class WarnIfRequiresUnreferencedCodeOnStaticConstructor
+		class WarnIfRequiresOnStaticConstructor
 		{
-			class ClassWithRequiresUnreferencedCodeOnStaticConstructor
+			class ClassWithRequiresOnStaticConstructor
 			{
 				[ExpectedWarning ("IL2116", ProducedBy = ProducedBy.Trimmer)]
 				[RequiresUnreferencedCode ("This attribute shouldn't be allowed")]
-				static ClassWithRequiresUnreferencedCodeOnStaticConstructor () { }
+				static ClassWithRequiresOnStaticConstructor () { }
 			}
 
 			public static void Test ()
 			{
-				typeof (ClassWithRequiresUnreferencedCodeOnStaticConstructor).RequiresNonPublicConstructors ();
+				typeof (ClassWithRequiresOnStaticConstructor).RequiresNonPublicConstructors ();
 			}
 		}
 
 		[ExpectedNoWarnings]
 		class RequiresOnAttribute
 		{
-			class AttributeWhichRequiresUnreferencedCodeAttribute : Attribute
+			class AttributeWhichRequiresAttribute : Attribute
 			{
-				[RequiresUnreferencedCode ("Message for --AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-				public AttributeWhichRequiresUnreferencedCodeAttribute ()
+				[RequiresUnreferencedCode ("Message for --AttributeWhichRequiresAttribute.ctor--")]
+				public AttributeWhichRequiresAttribute ()
 				{
 				}
 			}
 
-			class AttributeWhichRequiresUnreferencedCodeOnPropertyAttribute : Attribute
+			class AttributeWhichRequiresOnPropertyAttribute : Attribute
 			{
-				public AttributeWhichRequiresUnreferencedCodeOnPropertyAttribute ()
+				public AttributeWhichRequiresOnPropertyAttribute ()
 				{
 				}
 
 				public bool PropertyWhichRequires {
 					get => false;
 
-					[RequiresUnreferencedCode ("--AttributeWhichRequiresUnreferencedCodeOnPropertyAttribute.PropertyWhichRequires--")]
+					[RequiresUnreferencedCode ("--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--")]
 					set { }
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-			class GenericTypeWithAttributedParameter<[AttributeWhichRequiresUnreferencedCode] T>
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--")]
+			class GenericTypeWithAttributedParameter<[AttributeWhichRequires] T>
 			{
 				public static void TestMethod () { }
 			}
 
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-			static void GenericMethodWithAttributedParameter<[AttributeWhichRequiresUnreferencedCode] T> () { }
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--")]
+			static void GenericMethodWithAttributedParameter<[AttributeWhichRequires] T> () { }
 
 			static void TestRequiresOnAttributeOnGenericParameter ()
 			{
@@ -602,34 +599,34 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				GenericMethodWithAttributedParameter<int> ();
 			}
 
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeOnPropertyAttribute.PropertyWhichRequires--")]
-			[AttributeWhichRequiresUnreferencedCode]
-			[AttributeWhichRequiresUnreferencedCodeOnProperty (PropertyWhichRequires = true)]
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--")]
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--")]
+			[AttributeWhichRequires]
+			[AttributeWhichRequiresOnProperty (PropertyWhichRequires = true)]
 			class TypeWithAttributeWhichRequires
 			{
 			}
 
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeOnPropertyAttribute.PropertyWhichRequires--")]
-			[AttributeWhichRequiresUnreferencedCode]
-			[AttributeWhichRequiresUnreferencedCodeOnProperty (PropertyWhichRequires = true)]
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--")]
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--")]
+			[AttributeWhichRequires]
+			[AttributeWhichRequiresOnProperty (PropertyWhichRequires = true)]
 			static void MethodWithAttributeWhichRequires () { }
 
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeOnPropertyAttribute.PropertyWhichRequires--")]
-			[AttributeWhichRequiresUnreferencedCode]
-			[AttributeWhichRequiresUnreferencedCodeOnProperty (PropertyWhichRequires = true)]
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--")]
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--")]
+			[AttributeWhichRequires]
+			[AttributeWhichRequiresOnProperty (PropertyWhichRequires = true)]
 			static int _fieldWithAttributeWhichRequires;
 
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeOnPropertyAttribute.PropertyWhichRequires--")]
-			[AttributeWhichRequiresUnreferencedCode]
-			[AttributeWhichRequiresUnreferencedCodeOnProperty (PropertyWhichRequires = true)]
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--")]
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--")]
+			[AttributeWhichRequires]
+			[AttributeWhichRequiresOnProperty (PropertyWhichRequires = true)]
 			static bool PropertyWithAttributeWhichRequires { get; set; }
 
-			[AttributeWhichRequiresUnreferencedCode]
-			[AttributeWhichRequiresUnreferencedCodeOnProperty (PropertyWhichRequires = true)]
+			[AttributeWhichRequires]
+			[AttributeWhichRequiresOnProperty (PropertyWhichRequires = true)]
 			[RequiresUnreferencedCode ("--MethodWhichRequiresWithAttributeWhichRequires--")]
 			static void MethodWhichRequiresWithAttributeWhichRequires () { }
 
@@ -650,8 +647,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 		}
 
-		[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeOnlyViaDescriptor--")]
-		static void RequiresUnreferencedCodeOnlyViaDescriptor ()
+		[RequiresUnreferencedCode ("Message for --RequiresOnlyViaDescriptor--")]
+		static void RequiresOnlyViaDescriptor ()
 		{
 		}
 
@@ -679,24 +676,24 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		{
 			abstract class Base
 			{
-				[RequiresUnreferencedCode ("Message for --CovariantReturnViaLdftn.Base.GetRequiresUnreferencedCode--")]
-				public abstract BaseReturnType GetRequiresUnreferencedCode ();
+				[RequiresUnreferencedCode ("Message for --CovariantReturnViaLdftn.Base.GetRequires--")]
+				public abstract BaseReturnType GetRequires ();
 			}
 
 			class Derived : Base
 			{
-				[RequiresUnreferencedCode ("Message for --CovariantReturnViaLdftn.Derived.GetRequiresUnreferencedCode--")]
-				public override DerivedReturnType GetRequiresUnreferencedCode ()
+				[RequiresUnreferencedCode ("Message for --CovariantReturnViaLdftn.Derived.GetRequires--")]
+				public override DerivedReturnType GetRequires ()
 				{
 					return null;
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "--CovariantReturnViaLdftn.Derived.GetRequiresUnreferencedCode--")]
+			[ExpectedWarning ("IL2026", "--CovariantReturnViaLdftn.Derived.GetRequires--")]
 			public static void Test ()
 			{
 				var tmp = new Derived ();
-				var _ = new Func<DerivedReturnType> (tmp.GetRequiresUnreferencedCode);
+				var _ = new Func<DerivedReturnType> (tmp.GetRequires);
 			}
 		}
 
@@ -819,44 +816,44 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class RequiresOnClass
 		{
-			[RequiresUnreferencedCode ("Message for --ClassWithRequiresUnreferencedCode--")]
-			class ClassWithRequiresUnreferencedCode
+			[RequiresUnreferencedCode ("Message for --ClassWithRequires--")]
+			class ClassWithRequires
 			{
 				public static object Instance;
 
-				public ClassWithRequiresUnreferencedCode () { }
+				public ClassWithRequires () { }
 
 				public static void StaticMethod () { }
 
 				public void NonStaticMethod () { }
 
-				// RequiresOnMethod.MethodWithRUC generates a warning that gets suppressed because the declaring type has RUC
-				public static void CallRUCMethod () => RequiresOnMethod.MethodWithRUC ();
+				// RequiresOnMethod.MethodWithRequires generates a warning that gets suppressed because the declaring type has RUC
+				public static void CallMethodWithRequires () => RequiresOnMethod.MethodWithRequires ();
 
 				public class NestedClass
 				{
 					public static void NestedStaticMethod () { }
 
-					// This warning doesn't get suppressed since the declaring type NestedClass is not annotated with RequiresUnreferencedCode
-					[ExpectedWarning ("IL2026", "RequiresOnClass.RequiresOnMethod.MethodWithRUC()", "MethodWithRUC")]
-					public static void CallRUCMethod () => RequiresOnMethod.MethodWithRUC ();
+					// This warning doesn't get suppressed since the declaring type NestedClass is not annotated with Requires
+					[ExpectedWarning ("IL2026", "RequiresOnClass.RequiresOnMethod.MethodWithRequires()", "MethodWithRequires")]
+					public static void CallMethodWithRequires () => RequiresOnMethod.MethodWithRequires ();
 				}
 
 				// RequiresUnfereferencedCode on the type will suppress IL2072
-				static ClassWithRequiresUnreferencedCode ()
+				static ClassWithRequires ()
 				{
 					Instance = Activator.CreateInstance (Type.GetType ("SomeText"));
 				}
 
 				public static void TestSuppressions (Type[] types)
 				{
-					// StaticMethod is a static method on a RUC annotated type, so it should warn. But RequiresUnreferencedCode in the
-					// class suppresses other RequiresUnreferencedCode messages
+					// StaticMethod is a static method on a Requires annotated type, so it should warn. But Requires in the
+					// class suppresses other Requires messages
 					StaticMethod ();
 
 					var nested = new NestedClass ();
 
-					// RequiresUnreferencedCode in the class suppresses DynamicallyAccessedMembers messages
+					// Requires in the class suppresses DynamicallyAccessedMembers messages
 					types[1].GetMethods ();
 
 					void LocalFunction (int a) { }
@@ -866,12 +863,12 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			class RequiresOnMethod
 			{
-				[RequiresUnreferencedCode ("MethodWithRUC")]
-				public static void MethodWithRUC () { }
+				[RequiresUnreferencedCode ("MethodWithRequires")]
+				public static void MethodWithRequires () { }
 			}
 
-			[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithoutRequires", "RequiresOnClass.ClassWithRequiresUnreferencedCode", "--ClassWithRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
-			private class DerivedWithoutRequires : ClassWithRequiresUnreferencedCode
+			[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			private class DerivedWithoutRequires : ClassWithRequires
 			{
 				public static void StaticMethodInInheritedClass () { }
 
@@ -882,27 +879,27 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 				public static void ShouldntWarn (object objectToCast)
 				{
-					_ = typeof (ClassWithRequiresUnreferencedCode);
-					var type = (ClassWithRequiresUnreferencedCode) objectToCast;
+					_ = typeof (ClassWithRequires);
+					var type = (ClassWithRequires) objectToCast;
 				}
 			}
 
-			// In order to generate IL2109 the nested class would also need to be annotated with RequiresUnreferencedCode
+			// In order to generate IL2109 the nested class would also need to be annotated with Requires
 			// otherwise we threat the nested class as safe
-			private class DerivedWithoutRequires2 : ClassWithRequiresUnreferencedCode.NestedClass
+			private class DerivedWithoutRequires2 : ClassWithRequires.NestedClass
 			{
 				public static void StaticMethod () { }
 			}
 
 			[UnconditionalSuppressMessage ("trim", "IL2109")]
-			class TestUnconditionalSuppressMessage : ClassWithRequiresUnreferencedCode
+			class TestUnconditionalSuppressMessage : ClassWithRequires
 			{
 				public static void StaticMethodInTestSuppressionClass () { }
 			}
 
-			class ClassWithoutRequiresUnreferencedCode
+			class ClassWithoutRequires
 			{
-				public ClassWithoutRequiresUnreferencedCode () { }
+				public ClassWithoutRequires () { }
 
 				public static void StaticMethod () { }
 
@@ -923,7 +920,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 
 			[ExpectedWarning ("IL2026", "RequiresOnClass.StaticCtor.StaticCtor()", "Message for --StaticCtor--", ProducedBy = ProducedBy.Trimmer)]
-			static void TestStaticCctorRequiresUnreferencedCode ()
+			static void TestStaticCctorRequires ()
 			{
 				_ = new StaticCtor ();
 			}
@@ -951,16 +948,16 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				StaticCtorTriggeredByFieldAccess.field = 2;
 			}
 
-			[RequiresUnreferencedCode ("--TestStaticRUCFieldAccessSuppressedByRUCOnMethod_Inner--")]
-			static void TestStaticRUCFieldAccessSuppressedByRUCOnMethod_Inner ()
+			[RequiresUnreferencedCode ("--TestStaticRequiresFieldAccessSuppressedByRequiresOnMethod_Inner--")]
+			static void TestStaticRequiresFieldAccessSuppressedByRequiresOnMethod_Inner ()
 			{
 				StaticCtorTriggeredByFieldAccess.field = 3;
 			}
 
 			[UnconditionalSuppressMessage ("test", "IL2026")]
-			static void TestStaticRUCFieldAccessSuppressedByRUCOnMethod ()
+			static void TestStaticRequiresFieldAccessSuppressedByRequiresOnMethod ()
 			{
-				TestStaticRUCFieldAccessSuppressedByRUCOnMethod_Inner ();
+				TestStaticRequiresFieldAccessSuppressedByRequiresOnMethod_Inner ();
 			}
 
 			[RequiresUnreferencedCode ("Message for --StaticCCtorTriggeredByFieldAccessRead--")]
@@ -1025,7 +1022,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 
 			[RequiresUnreferencedCode ("Message for --DerivedWithRequires--")]
-			private class DerivedWithRequires : ClassWithoutRequiresUnreferencedCode
+			private class DerivedWithRequires : ClassWithoutRequires
 			{
 				public static void StaticMethodInInheritedClass () { }
 
@@ -1036,14 +1033,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 
 			[RequiresUnreferencedCode ("Message for --DerivedWithRequires2--")]
-			private class DerivedWithRequires2 : ClassWithRequiresUnreferencedCode
+			private class DerivedWithRequires2 : ClassWithRequires
 			{
 				public static void StaticMethodInInheritedClass () { }
 
 				// A nested class is not considered a static method nor constructor therefore RequiresUnreferencedCode doesnt apply
 				// and this warning is not suppressed
-				[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithRequires2/DerivedNestedClass", "--ClassWithRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
-				public class DerivedNestedClass : ClassWithRequiresUnreferencedCode
+				[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithRequires2/DerivedNestedClass", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+				public class DerivedNestedClass : ClassWithRequires
 				{
 					public static void NestedStaticMethod () { }
 				}
@@ -1099,35 +1096,35 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.StaticMethod()", "--ClassWithRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
 			static void TestRequiresInClassAccessedByStaticMethod ()
 			{
-				ClassWithRequiresUnreferencedCode.StaticMethod ();
+				ClassWithRequires.StaticMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode", "--ClassWithRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
 			static void TestRequiresInClassAccessedByCctor ()
 			{
-				var classObject = new ClassWithRequiresUnreferencedCode ();
+				var classObject = new ClassWithRequires ();
 			}
 
 			static void TestRequiresInParentClassAccesedByStaticMethod ()
 			{
-				ClassWithRequiresUnreferencedCode.NestedClass.NestedStaticMethod ();
+				ClassWithRequires.NestedClass.NestedStaticMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.StaticMethod()", "--ClassWithRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
-			// Although we suppress the warning from RequiresOnMethod.MethodWithRUC () we still get a warning because we call CallRUCMethod() which is an static method on a type with RUC
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.CallRUCMethod()", "--ClassWithRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "ClassWithRequiresUnreferencedCode.Instance", "--ClassWithRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			// Although we suppress the warning from RequiresOnMethod.MethodWithRequires () we still get a warning because we call CallRequiresMethod() which is an static method on a type with RUC
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.CallMethodWithRequires()", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "ClassWithRequires.Instance", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
 			static void TestRequiresOnBaseButNotOnDerived ()
 			{
 				DerivedWithoutRequires.StaticMethodInInheritedClass ();
 				DerivedWithoutRequires.StaticMethod ();
-				DerivedWithoutRequires.CallRUCMethod ();
+				DerivedWithoutRequires.CallMethodWithRequires ();
 				DerivedWithoutRequires.DerivedNestedClass.NestedStaticMethod ();
 				DerivedWithoutRequires.NestedClass.NestedStaticMethod ();
-				DerivedWithoutRequires.NestedClass.CallRUCMethod ();
+				DerivedWithoutRequires.NestedClass.CallMethodWithRequires ();
 				DerivedWithoutRequires.ShouldntWarn (null);
 				DerivedWithoutRequires.Instance.ToString ();
 				DerivedWithoutRequires2.StaticMethod ();
@@ -1143,7 +1140,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 
 			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires2.StaticMethodInInheritedClass()", "--DerivedWithRequires2--", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.StaticMethod()", "--ClassWithRequiresUnreferencedCode--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
 			static void TestRequiresOnBaseAndDerived ()
 			{
 				DerivedWithRequires2.StaticMethodInInheritedClass ();
@@ -1152,39 +1149,39 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				DerivedWithRequires2.NestedClass.NestedStaticMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.TestSuppressions(Type[])", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.TestSuppressions(Type[])", ProducedBy = ProducedBy.Trimmer)]
 			static void TestSuppressionsOnClass ()
 			{
-				ClassWithRequiresUnreferencedCode.TestSuppressions (new[] { typeof (ClassWithRequiresUnreferencedCode) });
+				ClassWithRequires.TestSuppressions (new[] { typeof (ClassWithRequires) });
 				TestUnconditionalSuppressMessage.StaticMethodInTestSuppressionClass ();
 			}
 
-			[RequiresUnreferencedCode ("--StaticMethodOnRUCTypeSuppressedByRUCOnMethod--")]
-			static void StaticMethodOnRUCTypeSuppressedByRUCOnMethod ()
+			[RequiresUnreferencedCode ("--StaticMethodOnRequiresTypeSuppressedByRequiresOnMethod--")]
+			static void StaticMethodOnRequiresTypeSuppressedByRequiresOnMethod ()
 			{
 				DerivedWithRequires.StaticMethodInInheritedClass ();
 			}
 
 			[UnconditionalSuppressMessage ("test", "IL2026")]
-			static void TestStaticMethodOnRUCTypeSuppressedByRUCOnMethod ()
+			static void TestStaticMethodOnRequiresTypeSuppressedByRequiresOnMethod ()
 			{
-				StaticMethodOnRUCTypeSuppressedByRUCOnMethod ();
+				StaticMethodOnRequiresTypeSuppressedByRequiresOnMethod ();
 			}
 
 			static void TestStaticConstructorCalls ()
 			{
-				TestStaticCctorRequiresUnreferencedCode ();
+				TestStaticCctorRequires ();
 				TestStaticCtorMarkingIsTriggeredByFieldAccessWrite ();
 				TestStaticCtorMarkingTriggeredOnSecondAccessWrite ();
-				TestStaticRUCFieldAccessSuppressedByRUCOnMethod ();
+				TestStaticRequiresFieldAccessSuppressedByRequiresOnMethod ();
 				TestStaticCtorMarkingIsTriggeredByFieldAccessRead ();
 				TestStaticCtorTriggeredByMethodCall ();
 				TestStaticCtorTriggeredByCtorCall ();
 				TestInstanceFieldCallDontWarn ();
 			}
 
-			[RequiresUnreferencedCode ("--MemberTypesWithRUC--")]
-			class MemberTypesWithRUC
+			[RequiresUnreferencedCode ("--MemberTypesWithRequires--")]
+			class MemberTypesWithRequires
 			{
 				public static int field;
 				public static int Property { get; set; }
@@ -1195,14 +1192,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static event EventHandler Event;
 			}
 
-			[ExpectedWarning ("IL2026", "MemberTypesWithRUC.field", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "MemberTypesWithRUC.Property.set", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "MemberTypesWithRUC.remove_Event", ProducedBy = ProducedBy.Trimmer)]
-			static void TestOtherMemberTypesWithRUC ()
+			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.field", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Property.set", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.remove_Event", ProducedBy = ProducedBy.Trimmer)]
+			static void TestOtherMemberTypesWithRequires ()
 			{
-				MemberTypesWithRUC.field = 1;
-				MemberTypesWithRUC.Property = 1;
-				MemberTypesWithRUC.Event -= null;
+				MemberTypesWithRequires.field = 1;
+				MemberTypesWithRequires.Property = 1;
+				MemberTypesWithRequires.Event -= null;
 			}
 
 			class ReflectionAccessOnMethod
@@ -1239,10 +1236,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[ExpectedWarning ("IL2026", "ImplementationWithRequiresOnType.Method()", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDirectReflectionAccess ()
 				{
-					// RUC on the method itself
+					// Requires on the method itself
 					typeof (BaseWithoutRequiresOnType).GetMethod (nameof (BaseWithoutRequiresOnType.Method));
 
-					// RUC on the method itself
+					// Requires on the method itself
 					typeof (InterfaceWithoutRequires).GetMethod (nameof (InterfaceWithoutRequires.Method));
 
 					// Warns because ImplementationWithRequiresOnType.Method is a static public method on a RUC type
@@ -1261,61 +1258,61 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			class ReflectionAccessOnCtor
 			{
-				[RequiresUnreferencedCode ("--BaseWithRUC--")]
-				class BaseWithRUC
+				[RequiresUnreferencedCode ("--BaseWithRequires--")]
+				class BaseWithRequires
 				{
-					public BaseWithRUC () { }
+					public BaseWithRequires () { }
 				}
 
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnCtor/DerivedWithoutRUC", "ReflectionAccessOnCtor.BaseWithRUC", ProducedBy = ProducedBy.Trimmer)]
-				class DerivedWithoutRUC : BaseWithRUC
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnCtor/DerivedWithoutRequires", "ReflectionAccessOnCtor.BaseWithRequires", ProducedBy = ProducedBy.Trimmer)]
+				class DerivedWithoutRequires : BaseWithRequires
 				{
-					[ExpectedWarning ("IL2026", "--BaseWithRUC--", ProducedBy = ProducedBy.Trimmer)] // The body has direct call to the base.ctor()
-					public DerivedWithoutRUC () { }
+					[ExpectedWarning ("IL2026", "--BaseWithRequires--", ProducedBy = ProducedBy.Trimmer)] // The body has direct call to the base.ctor()
+					public DerivedWithoutRequires () { }
 				}
 
-				[RequiresUnreferencedCode ("--DerivedWithRUCOnBaseWithRUC--")]
-				class DerivedWithRUCOnBaseWithRUC : BaseWithRUC
+				[RequiresUnreferencedCode ("--DerivedWithRequiresOnBaseWithRequires--")]
+				class DerivedWithRequiresOnBaseWithRequires : BaseWithRequires
 				{
-					// No warning - suppressed by the RUC on this type
-					private DerivedWithRUCOnBaseWithRUC () { }
+					// No warning - suppressed by the Requires on this type
+					private DerivedWithRequiresOnBaseWithRequires () { }
 				}
 
-				class BaseWithoutRUC { }
+				class BaseWithoutRequires { }
 
-				[RequiresUnreferencedCode ("--DerivedWithRUCOnBaseWithout--")]
-				class DerivedWithRUCOnBaseWithoutRuc : BaseWithoutRUC
+				[RequiresUnreferencedCode ("--DerivedWithRequiresOnBaseWithout--")]
+				class DerivedWithRequiresOnBaseWithoutRequires : BaseWithoutRequires
 				{
-					public DerivedWithRUCOnBaseWithoutRuc () { }
+					public DerivedWithRequiresOnBaseWithoutRequires () { }
 				}
 
-				[ExpectedWarning ("IL2026", "BaseWithRUC.BaseWithRUC()", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUCOnBaseWithRUC.DerivedWithRUCOnBaseWithRUC()", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUCOnBaseWithoutRuc.DerivedWithRUCOnBaseWithoutRuc()", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "BaseWithRequires.BaseWithRequires()", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequiresOnBaseWithRequires.DerivedWithRequiresOnBaseWithRequires()", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequiresOnBaseWithoutRequires.DerivedWithRequiresOnBaseWithoutRequires()", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDAMAccess ()
 				{
-					// Warns because the type has RUC
-					typeof (BaseWithRUC).RequiresPublicConstructors ();
+					// Warns because the type has Requires
+					typeof (BaseWithRequires).RequiresPublicConstructors ();
 
-					// Doesn't warn since there's no RUC on this type
-					typeof (DerivedWithoutRUC).RequiresPublicParameterlessConstructor ();
+					// Doesn't warn since there's no Requires on this type
+					typeof (DerivedWithoutRequires).RequiresPublicParameterlessConstructor ();
 
-					// Warns - RUC on the type
-					typeof (DerivedWithRUCOnBaseWithRUC).RequiresNonPublicConstructors ();
+					// Warns - Requires on the type
+					typeof (DerivedWithRequiresOnBaseWithRequires).RequiresNonPublicConstructors ();
 
-					// Warns - RUC On the type
-					typeof (DerivedWithRUCOnBaseWithoutRuc).RequiresPublicConstructors ();
+					// Warns - Requires On the type
+					typeof (DerivedWithRequiresOnBaseWithoutRequires).RequiresPublicConstructors ();
 				}
 
-				[ExpectedWarning ("IL2026", "BaseWithRUC.BaseWithRUC()", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUCOnBaseWithRUC.DerivedWithRUCOnBaseWithRUC()", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUCOnBaseWithoutRuc.DerivedWithRUCOnBaseWithoutRuc()", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "BaseWithRequires.BaseWithRequires()", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequiresOnBaseWithRequires.DerivedWithRequiresOnBaseWithRequires()", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequiresOnBaseWithoutRequires.DerivedWithRequiresOnBaseWithoutRequires()", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDirectReflectionAccess ()
 				{
-					typeof (BaseWithRUC).GetConstructor (Type.EmptyTypes);
-					typeof (DerivedWithoutRUC).GetConstructor (Type.EmptyTypes);
-					typeof (DerivedWithRUCOnBaseWithRUC).GetConstructor (BindingFlags.NonPublic, Type.EmptyTypes);
-					typeof (DerivedWithRUCOnBaseWithoutRuc).GetConstructor (Type.EmptyTypes);
+					typeof (BaseWithRequires).GetConstructor (Type.EmptyTypes);
+					typeof (DerivedWithoutRequires).GetConstructor (Type.EmptyTypes);
+					typeof (DerivedWithRequiresOnBaseWithRequires).GetConstructor (BindingFlags.NonPublic, Type.EmptyTypes);
+					typeof (DerivedWithRequiresOnBaseWithoutRequires).GetConstructor (Type.EmptyTypes);
 				}
 
 				public static void Test ()
@@ -1327,63 +1324,63 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			class ReflectionAccessOnField
 			{
-				[RequiresUnreferencedCode ("--WithRUC--")]
-				class WithRUC
+				[RequiresUnreferencedCode ("--WithRequires--")]
+				class WithRequires
 				{
 					public int InstanceField;
 					public static int StaticField;
 					private static int PrivateStaticField;
 				}
 
-				[RequiresUnreferencedCode ("--WithRUCOnlyInstanceFields--")]
-				class WithRUCOnlyInstanceFields
+				[RequiresUnreferencedCode ("--WithRequiresOnlyInstanceFields--")]
+				class WithRequiresOnlyInstanceFields
 				{
 					public int InstnaceField;
 				}
 
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnField/DerivedWithoutRUC", "ReflectionAccessOnField.WithRUC", ProducedBy = ProducedBy.Trimmer)]
-				class DerivedWithoutRUC : WithRUC
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnField/DerivedWithoutRequires", "ReflectionAccessOnField.WithRequires", ProducedBy = ProducedBy.Trimmer)]
+				class DerivedWithoutRequires : WithRequires
 				{
 					public static int DerivedStaticField;
 				}
 
-				[RequiresUnreferencedCode ("--DerivedWithRUC--")]
-				class DerivedWithRUC : WithRUC
+				[RequiresUnreferencedCode ("--DerivedWithRequires--")]
+				class DerivedWithRequires : WithRequires
 				{
 					public static int DerivedStaticField;
 				}
 
-				[ExpectedWarning ("IL2026", "WithRUC.StaticField", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.PrivateStaticField", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDAMAccess ()
 				{
-					typeof (WithRUC).RequiresPublicFields ();
-					typeof (WithRUC).RequiresNonPublicFields ();
-					typeof (WithRUCOnlyInstanceFields).RequiresPublicFields ();
-					typeof (DerivedWithoutRUC).RequiresPublicFields ();
-					typeof (DerivedWithRUC).RequiresPublicFields ();
+					typeof (WithRequires).RequiresPublicFields ();
+					typeof (WithRequires).RequiresNonPublicFields ();
+					typeof (WithRequiresOnlyInstanceFields).RequiresPublicFields ();
+					typeof (DerivedWithoutRequires).RequiresPublicFields ();
+					typeof (DerivedWithRequires).RequiresPublicFields ();
 				}
 
-				[ExpectedWarning ("IL2026", "WithRUC.StaticField", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.PrivateStaticField", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDirectReflectionAccess ()
 				{
-					typeof (WithRUC).GetField (nameof (WithRUC.StaticField));
-					typeof (WithRUC).GetField (nameof (WithRUC.InstanceField)); // Doesn't warn
-					typeof (WithRUC).GetField ("PrivateStaticField", BindingFlags.NonPublic);
-					typeof (WithRUCOnlyInstanceFields).GetField (nameof (WithRUCOnlyInstanceFields.InstnaceField)); // Doesn't warn
-					typeof (DerivedWithoutRUC).GetField (nameof (DerivedWithRUC.DerivedStaticField)); // Doesn't warn
-					typeof (DerivedWithRUC).GetField (nameof (DerivedWithRUC.DerivedStaticField));
+					typeof (WithRequires).GetField (nameof (WithRequires.StaticField));
+					typeof (WithRequires).GetField (nameof (WithRequires.InstanceField)); // Doesn't warn
+					typeof (WithRequires).GetField ("PrivateStaticField", BindingFlags.NonPublic);
+					typeof (WithRequiresOnlyInstanceFields).GetField (nameof (WithRequiresOnlyInstanceFields.InstnaceField)); // Doesn't warn
+					typeof (DerivedWithoutRequires).GetField (nameof (DerivedWithRequires.DerivedStaticField)); // Doesn't warn
+					typeof (DerivedWithRequires).GetField (nameof (DerivedWithRequires.DerivedStaticField));
 				}
 
-				[ExpectedWarning ("IL2026", "WithRUC.StaticField", ProducedBy = ProducedBy.Trimmer)]
-				[DynamicDependency (nameof (WithRUC.StaticField), typeof (WithRUC))]
-				[DynamicDependency (nameof (WithRUC.InstanceField), typeof (WithRUC))] // Doesn't warn
-				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicFields, typeof (DerivedWithoutRUC))] // Doesn't warn
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
-				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicFields, typeof (DerivedWithRUC))]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
+				[DynamicDependency (nameof (WithRequires.StaticField), typeof (WithRequires))]
+				[DynamicDependency (nameof (WithRequires.InstanceField), typeof (WithRequires))] // Doesn't warn
+				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicFields, typeof (DerivedWithoutRequires))] // Doesn't warn
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
+				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicFields, typeof (DerivedWithRequires))]
 				static void TestDynamicDependencyAccess ()
 				{
 				}
@@ -1425,8 +1422,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				// Most of the tests in this run into https://github.com/dotnet/linker/issues/2218
 				// So for now keeping just a very simple test
 
-				[RequiresUnreferencedCode ("--WithRUC--")]
-				class WithRUC
+				[RequiresUnreferencedCode ("--WithRequires--")]
+				class WithRequires
 				{
 					// These should be reported only in TestDirectReflectionAccess
 					// https://github.com/mono/linker/issues/2218
@@ -1438,7 +1435,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[ExpectedWarning ("IL2026", "add_StaticEvent", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDirectReflectionAccess ()
 				{
-					typeof (WithRUC).GetEvent (nameof (WithRUC.StaticEvent));
+					typeof (WithRequires).GetEvent (nameof (WithRequires.StaticEvent));
 				}
 
 				public static void Test ()
@@ -1449,71 +1446,71 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			class ReflectionAccessOnProperties
 			{
-				[RequiresUnreferencedCode ("--WithRUC--")]
-				class WithRUC
+				[RequiresUnreferencedCode ("--WithRequires--")]
+				class WithRequires
 				{
 					public int InstanceProperty { get; set; }
 					public static int StaticProperty { get; set; }
 					private static int PrivateStaticProperty { get; set; }
 				}
 
-				[RequiresUnreferencedCode ("--WithRUCOnlyInstanceProperties--")]
-				class WithRUCOnlyInstanceProperties
+				[RequiresUnreferencedCode ("--WithRequiresOnlyInstanceProperties--")]
+				class WithRequiresOnlyInstanceProperties
 				{
 					public int InstnaceProperty { get; set; }
 				}
 
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnProperties/DerivedWithoutRUC", "ReflectionAccessOnProperties.WithRUC", ProducedBy = ProducedBy.Trimmer)]
-				class DerivedWithoutRUC : WithRUC
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnProperties/DerivedWithoutRequires", "ReflectionAccessOnProperties.WithRequires", ProducedBy = ProducedBy.Trimmer)]
+				class DerivedWithoutRequires : WithRequires
 				{
 					public static int DerivedStaticProperty { get; set; }
 				}
 
-				[RequiresUnreferencedCode ("--DerivedWithRUC--")]
-				class DerivedWithRUC : WithRUC
+				[RequiresUnreferencedCode ("--DerivedWithRequires--")]
+				class DerivedWithRequires : WithRequires
 				{
 					public static int DerivedStaticProperty { get; set; }
 				}
 
-				[ExpectedWarning ("IL2026", "WithRUC.StaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.StaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.PrivateStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.PrivateStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDAMAccess ()
 				{
-					typeof (WithRUC).RequiresPublicProperties ();
-					typeof (WithRUC).RequiresNonPublicProperties ();
-					typeof (WithRUCOnlyInstanceProperties).RequiresPublicProperties ();
-					typeof (DerivedWithoutRUC).RequiresPublicProperties ();
-					typeof (DerivedWithRUC).RequiresPublicProperties ();
+					typeof (WithRequires).RequiresPublicProperties ();
+					typeof (WithRequires).RequiresNonPublicProperties ();
+					typeof (WithRequiresOnlyInstanceProperties).RequiresPublicProperties ();
+					typeof (DerivedWithoutRequires).RequiresPublicProperties ();
+					typeof (DerivedWithRequires).RequiresPublicProperties ();
 				}
 
-				[ExpectedWarning ("IL2026", "WithRUC.StaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.StaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.PrivateStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.PrivateStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDirectReflectionAccess ()
 				{
-					typeof (WithRUC).GetProperty (nameof (WithRUC.StaticProperty));
-					typeof (WithRUC).GetProperty (nameof (WithRUC.InstanceProperty)); // Doesn't warn
-					typeof (WithRUC).GetProperty ("PrivateStaticProperty", BindingFlags.NonPublic);
-					typeof (WithRUCOnlyInstanceProperties).GetProperty (nameof (WithRUCOnlyInstanceProperties.InstnaceProperty)); // Doesn't warn
-					typeof (DerivedWithoutRUC).GetProperty (nameof (DerivedWithRUC.DerivedStaticProperty)); // Doesn't warn
-					typeof (DerivedWithRUC).GetProperty (nameof (DerivedWithRUC.DerivedStaticProperty));
+					typeof (WithRequires).GetProperty (nameof (WithRequires.StaticProperty));
+					typeof (WithRequires).GetProperty (nameof (WithRequires.InstanceProperty)); // Doesn't warn
+					typeof (WithRequires).GetProperty ("PrivateStaticProperty", BindingFlags.NonPublic);
+					typeof (WithRequiresOnlyInstanceProperties).GetProperty (nameof (WithRequiresOnlyInstanceProperties.InstnaceProperty)); // Doesn't warn
+					typeof (DerivedWithoutRequires).GetProperty (nameof (DerivedWithRequires.DerivedStaticProperty)); // Doesn't warn
+					typeof (DerivedWithRequires).GetProperty (nameof (DerivedWithRequires.DerivedStaticProperty));
 				}
 
-				[ExpectedWarning ("IL2026", "WithRUC.StaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "WithRUC.StaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
-				[DynamicDependency (nameof (WithRUC.StaticProperty), typeof (WithRUC))]
-				[DynamicDependency (nameof (WithRUC.InstanceProperty), typeof (WithRUC))] // Doesn't warn
-				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicProperties, typeof (DerivedWithoutRUC))] // Doesn't warn
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRUC.DerivedStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
-				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicProperties, typeof (DerivedWithRUC))]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+				[DynamicDependency (nameof (WithRequires.StaticProperty), typeof (WithRequires))]
+				[DynamicDependency (nameof (WithRequires.InstanceProperty), typeof (WithRequires))] // Doesn't warn
+				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicProperties, typeof (DerivedWithoutRequires))] // Doesn't warn
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicProperties, typeof (DerivedWithRequires))]
 				static void TestDynamicDependencyAccess ()
 				{
 				}
@@ -1560,21 +1557,21 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 
 			[RequiresUnreferencedCode ("The attribute is dangerous")]
-			public class AttributeWithRUC : Attribute
+			public class AttributeWithRequires : Attribute
 			{
 				public static int field;
 
 				// `field` cannot be used as named attribute argument because is static, and if accessed via
 				// a property the property will be the one generating the warning, but then the warning will 
-				// be suppresed by the RequiresUnreferencedCode on the declaring type
+				// be suppresed by the Requires on the declaring type
 				public int PropertyOnAttribute {
 					get { return field; }
 					set { field = value; }
 				}
 			}
 
-			[AttributeWithRUC (PropertyOnAttribute = 42)]
-			[ExpectedWarning ("IL2026", "AttributeWithRUC.AttributeWithRUC()", ProducedBy = ProducedBy.Trimmer)]
+			[AttributeWithRequires (PropertyOnAttribute = 42)]
+			[ExpectedWarning ("IL2026", "AttributeWithRequires.AttributeWithRequires()", ProducedBy = ProducedBy.Trimmer)]
 			static void KeepFieldOnAttribute () { }
 
 			public static void Test ()
@@ -1586,9 +1583,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				TestRequiresOnDerivedButNotOnBase ();
 				TestRequiresOnBaseAndDerived ();
 				TestSuppressionsOnClass ();
-				TestStaticMethodOnRUCTypeSuppressedByRUCOnMethod ();
+				TestStaticMethodOnRequiresTypeSuppressedByRequiresOnMethod ();
 				TestStaticConstructorCalls ();
-				TestOtherMemberTypesWithRUC ();
+				TestOtherMemberTypesWithRequires ();
 				ReflectionAccessOnMethod.Test ();
 				ReflectionAccessOnCtor.Test ();
 				ReflectionAccessOnField.Test ();

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.descriptor.xml
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.descriptor.xml
@@ -1,0 +1,7 @@
+﻿<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.RequiresCapability.RequiresCapability">
+      <method name="RequiresOnlyViaDescriptor" />
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapabilityFromCopiedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapabilityFromCopiedAssembly.cs
@@ -9,11 +9,11 @@ using Mono.Linker.Tests.Cases.RequiresCapability.Dependencies;
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
 	[SetupLinkerAction ("copy", "lib")]
-	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/RequiresUnreferencedCodeInCopyAssembly.cs" })]
+	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/RequiresInCopyAssembly.cs" })]
 	[KeptAllTypesAndMembersInAssembly ("lib.dll")]
 	[LogDoesNotContain ("IL2026")]
 	[LogDoesNotContain ("IL2027")]
-	public class RequiresUnreferencedCodeCapabilityFromCopiedAssembly
+	public class RequiresCapabilityFromCopiedAssembly
 	{
 		public static void Main ()
 		{
@@ -23,7 +23,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[Kept]
 		static void Test ()
 		{
-			var x = new RequiresUnreferencedCodeInCopyAssembly ();
+			var x = new RequiresInCopyAssembly ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapabilityReflectionAnalysisEnabled.cs
@@ -8,24 +8,24 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
-	public class RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled
+	public class RequiresCapabilityReflectionAnalysisEnabled
 	{
 		[LogContains ("-- DynamicallyAccessedMembersEnabled --")]
 		[LogContains ("-- ReflectionPattern --")]
 		[LogContains ("-- DynamicallyAccessedMembersOnGenericsEnabled --")]
 		public static void Main ()
 		{
-			TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersEnabled ();
-			TestRequiresUnreferencedCodeAttributeWithReflectionPattern ();
-			TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersOnGenericsEnabled ();
-			TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers.Test ();
+			TestRequiresAttributeWithDynamicallyAccessedMembersEnabled ();
+			TestRequiresAttributeWithReflectionPattern ();
+			TestRequiresAttributeWithDynamicallyAccessedMembersOnGenericsEnabled ();
+			TestRequiresAndDynamicallyAccessedMembers.Test ();
 		}
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
 		[RequiresUnreferencedCode ("-- DynamicallyAccessedMembersEnabled --")]
 		[RecognizedReflectionAccessPattern]
-		static void TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersEnabled ()
+		static void TestRequiresAttributeWithDynamicallyAccessedMembersEnabled ()
 		{
 			typeof (TypeWithPublicFieldsAccessed).RequiresPublicFields ();
 		}
@@ -43,7 +43,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
 		[RequiresUnreferencedCode ("-- ReflectionPattern --")]
 		[RecognizedReflectionAccessPattern]
-		static void TestRequiresUnreferencedCodeAttributeWithReflectionPattern ()
+		static void TestRequiresAttributeWithReflectionPattern ()
 		{
 			typeof (TypeWithMethodAccessed).GetMethod ("PublicMethod");
 		}
@@ -61,7 +61,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
 		[RequiresUnreferencedCode ("-- DynamicallyAccessedMembersOnGenericsEnabled --")]
 		[RecognizedReflectionAccessPattern]
-		static void TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersOnGenericsEnabled ()
+		static void TestRequiresAttributeWithDynamicallyAccessedMembersOnGenericsEnabled ()
 		{
 			TypeRequiresPublicFields<TypeWithPublicFieldsForGenericType>.Method ();
 			MethodRequiresPublicFields<TypeWithPublicFieldsForGenericMethod> ();
@@ -105,22 +105,22 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		[Kept]
 		[ExpectedNoWarnings]
-		class TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers
+		class TestRequiresAndDynamicallyAccessedMembers
 		{
 			[Kept]
 			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
-			[RequiresUnreferencedCode ("--- RequiresUnreferencedCodeAndPublicMethods ---")]
+			[RequiresUnreferencedCode ("--- RequiresAndPublicMethods ---")]
 			[RecognizedReflectionAccessPattern]
-			static void RequiresUnreferencedCodeAndPublicMethods (
+			static void RequiresAndPublicMethods (
 				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 				Type type)
 			{
-				// This should not produce a warning since the method is annotated with RequiresUnreferencedCode
+				// This should not produce a warning since the method is annotated with Requires
 				type.RequiresPublicFields ();
 
 				// This will still "work" in that it will apply the PublicFields requirement onto the specified type
-				typeof (TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers).RequiresPublicFields ();
+				typeof (TestRequiresAndDynamicallyAccessedMembers).RequiresPublicFields ();
 			}
 
 			[Kept]
@@ -137,10 +137,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static int PrivateStaticField;
 
 			[Kept]
-			[ExpectedWarning ("IL2026", "--- RequiresUnreferencedCodeAndPublicMethods ---")]
+			[ExpectedWarning ("IL2026", "--- RequiresAndPublicMethods ---")]
 			public static void Test ()
 			{
-				RequiresUnreferencedCodeAndPublicMethods (typeof (TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers));
+				RequiresAndPublicMethods (typeof (TestRequiresAndDynamicallyAccessedMembers));
 			}
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -13,7 +13,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
 	[SkipKeptItemsValidation]
 	[ExpectedNoWarnings]
-	public class RequiresUnreferencedCodeInCompilerGeneratedCode
+	public class RequiresInCompilerGeneratedCode
 	{
 		public static void Main ()
 		{
@@ -37,49 +37,49 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			StateMachinesOnlyReferencedViaReflection.Test ();
 
-			ComplexCases.AsyncBodyCallingRUCMethod.Test ();
-			ComplexCases.GenericAsyncBodyCallingRUCMethod.Test ();
-			ComplexCases.GenericAsyncEnumerableBodyCallingRUCWithAnnotations.Test ();
+			ComplexCases.AsyncBodyCallingMethodWithRequires.Test ();
+			ComplexCases.GenericAsyncBodyCallingMethodWithRequires.Test ();
+			ComplexCases.GenericAsyncEnumerableBodyCallingRequiresWithAnnotations.Test ();
 		}
 
 		class WarnInIteratorBody
 		{
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static IEnumerable<int> TestCallBeforeYieldReturn ()
 			{
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				yield return 0;
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static IEnumerable<int> TestCallAfterYieldReturn ()
 			{
 				yield return 0;
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static IEnumerable<int> TestReflectionAccess ()
 			{
 				yield return 0;
-				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+				typeof (RequiresInCompilerGeneratedCode)
+					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 				yield return 1;
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static IEnumerable<int> TestLdftn ()
 			{
 				yield return 0;
 				yield return 1;
-				var action = new Action (RequiresUnreferencedCodeMethod);
+				var action = new Action (MethodWithRequires);
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static IEnumerable<int> TestDynamicallyAccessedMethod ()
 			{
-				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				yield return 0;
 				yield return 1;
 			}
@@ -99,9 +99,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static IEnumerable<int> TestCall ()
 			{
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				yield return 0;
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				yield return 1;
 			}
 
@@ -109,8 +109,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static IEnumerable<int> TestReflectionAccess ()
 			{
 				yield return 0;
-				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+				typeof (RequiresInCompilerGeneratedCode)
+					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 				yield return 1;
 			}
@@ -120,13 +120,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				yield return 0;
 				yield return 1;
-				var action = new Action (RequiresUnreferencedCodeMethod);
+				var action = new Action (MethodWithRequires);
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static IEnumerable<int> TestDynamicallyAccessedMethod ()
 			{
-				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				yield return 0;
 				yield return 1;
 			}
@@ -167,41 +167,41 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class WarnInAsyncBody
 		{
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static async void TestCallBeforeYieldReturn ()
 			{
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				await MethodAsync ();
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static async void TestCallAfterYieldReturn ()
 			{
 				await MethodAsync ();
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static async void TestReflectionAccess ()
 			{
 				await MethodAsync ();
-				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+				typeof (RequiresInCompilerGeneratedCode)
+					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 				await MethodAsync ();
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static async void TestLdftn ()
 			{
 				await MethodAsync ();
-				var action = new Action (RequiresUnreferencedCodeMethod);
+				var action = new Action (MethodWithRequires);
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static async void TestDynamicallyAccessedMethod ()
 			{
-				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				await MethodAsync ();
 			}
 
@@ -220,9 +220,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static async void TestCall ()
 			{
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				await MethodAsync ();
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				await MethodAsync ();
 			}
 
@@ -230,8 +230,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static async void TestReflectionAccess ()
 			{
 				await MethodAsync ();
-				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+				typeof (RequiresInCompilerGeneratedCode)
+					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 				await MethodAsync ();
 			}
@@ -240,13 +240,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static async void TestLdftn ()
 			{
 				await MethodAsync ();
-				var action = new Action (RequiresUnreferencedCodeMethod);
+				var action = new Action (MethodWithRequires);
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static async void TestDynamicallyAccessedMethod ()
 			{
-				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				await MethodAsync ();
 			}
 
@@ -286,46 +286,46 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class WarnInAsyncIteratorBody
 		{
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static async IAsyncEnumerable<int> TestCallBeforeYieldReturn ()
 			{
 				await MethodAsync ();
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				yield return 0;
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static async IAsyncEnumerable<int> TestCallAfterYieldReturn ()
 			{
 				yield return 0;
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				await MethodAsync ();
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static async IAsyncEnumerable<int> TestReflectionAccess ()
 			{
 				yield return 0;
 				await MethodAsync ();
-				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+				typeof (RequiresInCompilerGeneratedCode)
+					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 				await MethodAsync ();
 				yield return 1;
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static async IAsyncEnumerable<int> TestLdftn ()
 			{
 				await MethodAsync ();
 				yield return 0;
-				var action = new Action (RequiresUnreferencedCodeMethod);
+				var action = new Action (MethodWithRequires);
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static async IAsyncEnumerable<int> TestDynamicallyAccessedMethod ()
 			{
-				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				yield return 0;
 				await MethodAsync ();
 			}
@@ -345,10 +345,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static async IAsyncEnumerable<int> TestCall ()
 			{
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				await MethodAsync ();
 				yield return 0;
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 				await MethodAsync ();
 			}
 
@@ -357,8 +357,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				await MethodAsync ();
 				yield return 0;
-				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+				typeof (RequiresInCompilerGeneratedCode)
+					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 				await MethodAsync ();
 				yield return 0;
@@ -368,14 +368,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static async IAsyncEnumerable<int> TestLdftn ()
 			{
 				await MethodAsync ();
-				var action = new Action (RequiresUnreferencedCodeMethod);
+				var action = new Action (MethodWithRequires);
 				yield return 0;
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static async IAsyncEnumerable<int> TestDynamicallyAccessedMethod ()
 			{
-				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				yield return 0;
 				await MethodAsync ();
 			}
@@ -419,15 +419,15 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class WarnInLocalFunction
 		{
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static void TestCall ()
 			{
 				LocalFunction ();
 
-				void LocalFunction () => RequiresUnreferencedCodeMethod ();
+				void LocalFunction () => MethodWithRequires ();
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static void TestCallWithClosure (int p = 0)
 			{
 				LocalFunction ();
@@ -435,37 +435,37 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				void LocalFunction ()
 				{
 					p++;
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static void TestReflectionAccess ()
 			{
 				LocalFunction ();
 
-				void LocalFunction () => typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+				void LocalFunction () => typeof (RequiresInCompilerGeneratedCode)
+					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static void TestLdftn ()
 			{
 				LocalFunction ();
 
 				void LocalFunction ()
 				{
-					var action = new Action (RequiresUnreferencedCodeMethod);
+					var action = new Action (MethodWithRequires);
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static void TestDynamicallyAccessedMethod ()
 			{
 				LocalFunction ();
 
-				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				void LocalFunction () => typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 			}
 
 			public static void Test ()
@@ -480,7 +480,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class SuppressInLocalFunction
 		{
-			// RequiresUnreferencedCode doesn't propagate into local functions yet
+			// Requires doesn't propagate into local functions yet
 			// so its suppression effect also doesn't propagate
 
 			[RequiresUnreferencedCode ("Suppress in body")]
@@ -489,7 +489,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				LocalFunction ();
 
 				[ExpectedWarning ("IL2026")]
-				void LocalFunction () => RequiresUnreferencedCodeMethod ();
+				void LocalFunction () => MethodWithRequires ();
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
@@ -501,7 +501,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				void LocalFunction ()
 				{
 					p++;
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 				}
 			}
 
@@ -511,8 +511,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				LocalFunction ();
 
 				[ExpectedWarning ("IL2026")]
-				void LocalFunction () => typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+				void LocalFunction () => typeof (RequiresInCompilerGeneratedCode)
+					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 			}
 
@@ -524,7 +524,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[ExpectedWarning ("IL2026")]
 				void LocalFunction ()
 				{
-					var action = new Action (RequiresUnreferencedCodeMethod);
+					var action = new Action (MethodWithRequires);
 				}
 			}
 
@@ -534,7 +534,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				LocalFunction ();
 
 				[ExpectedWarning ("IL2026")]
-				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				void LocalFunction () => typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
@@ -612,35 +612,35 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
-			static void TestCallRUCMethodInLtftnLocalFunction ()
+			static void TestCallMethodWithRequiresInLtftnLocalFunction ()
 			{
 				var _ = new Action (LocalFunction);
 
 				[ExpectedWarning ("IL2026")]
-				void LocalFunction () => RequiresUnreferencedCodeMethod ();
+				void LocalFunction () => MethodWithRequires ();
 			}
 
 			class DynamicallyAccessedLocalFunction
 			{
 				[RequiresUnreferencedCode ("Suppress in body")]
-				public static void TestCallRUCMethodInDynamicallyAccessedLocalFunction ()
+				public static void TestCallMethodWithRequiresInDynamicallyAccessedLocalFunction ()
 				{
 					typeof (DynamicallyAccessedLocalFunction).RequiresNonPublicMethods ();
 
 					[ExpectedWarning ("IL2026")]
-					void LocalFunction () => RequiresUnreferencedCodeMethod ();
+					void LocalFunction () => MethodWithRequires ();
 				}
 			}
 
 			[ExpectedWarning ("IL2026")]
 			static void TestSuppressionLocalFunction ()
 			{
-				LocalFunction (); // This will produce a warning since the location function has RUC on it
+				LocalFunction (); // This will produce a warning since the location function has Requires on it
 
 				[RequiresUnreferencedCode ("Suppress in body")]
 				void LocalFunction (Type unknownType = null)
 				{
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 					unknownType.RequiresNonPublicMethods ();
 				}
 			}
@@ -653,7 +653,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[RequiresUnreferencedCode ("Suppress in body")]
 				void LocalFunction (Type unknownType = null)
 				{
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 					unknownType.RequiresNonPublicMethods ();
 				}
 			}
@@ -673,8 +673,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				TestGenericLocalFunctionInner<TestType> ();
 				TestGenericLocalFunctionWithAnnotations<TestType> ();
 				TestGenericLocalFunctionWithAnnotationsAndClosure<TestType> ();
-				TestCallRUCMethodInLtftnLocalFunction ();
-				DynamicallyAccessedLocalFunction.TestCallRUCMethodInDynamicallyAccessedLocalFunction ();
+				TestCallMethodWithRequiresInLtftnLocalFunction ();
+				DynamicallyAccessedLocalFunction.TestCallMethodWithRequiresInDynamicallyAccessedLocalFunction ();
 				TestSuppressionLocalFunction ();
 				TestSuppressionOnOuterAndLocalFunction ();
 			}
@@ -682,44 +682,44 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class WarnInLambda
 		{
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static void TestCall ()
 			{
-				Action _ = () => RequiresUnreferencedCodeMethod ();
+				Action _ = () => MethodWithRequires ();
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static void TestCallWithClosure (int p = 0)
 			{
 				Action _ = () => {
 					p++;
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 				};
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static void TestReflectionAccess ()
 			{
 				Action _ = () => {
-					typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-						.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					typeof (RequiresInCompilerGeneratedCode)
+						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 						.Invoke (null, new object[] { });
 				};
 			}
 
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static void TestLdftn ()
 			{
 				Action _ = () => {
-					var action = new Action (RequiresUnreferencedCodeMethod);
+					var action = new Action (MethodWithRequires);
 				};
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ = () => {
-					typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				};
 			}
 
@@ -735,17 +735,17 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class SuppressInLambda
 		{
-			// RequiresUnreferencedCode doesn't propagate into lambdas
+			// Requires doesn't propagate into lambdas
 
 			// C# currently doesn't allow attributes on lambdas
-			// - This would be useful as a workaround for the limitation as RUC could be applied to the lambda directly
+			// - This would be useful as a workaround for the limitation as Requires could be applied to the lambda directly
 			// - Would be useful for testing - have to use the CompilerGeneratedCode = true trick instead
 
 			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static void TestCall ()
 			{
-				Action _ = () => RequiresUnreferencedCodeMethod ();
+				Action _ = () => MethodWithRequires ();
 			}
 
 			// The warning is currently not detected by roslyn analyzer since it doesn't analyze DAM yet
@@ -753,7 +753,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static void TestCallWithReflectionAnalysisWarning ()
 			{
-				// This should not produce warning because the RUC
+				// This should not produce warning because the Requires
 				Action<Type> _ = (t) => t.RequiresPublicMethods ();
 			}
 
@@ -763,7 +763,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				Action _ = () => {
 					p++;
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 				};
 			}
 
@@ -773,8 +773,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestReflectionAccess ()
 			{
 				Action _ = () => {
-					typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
-						.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					typeof (RequiresInCompilerGeneratedCode)
+						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 						.Invoke (null, new object[] { });
 				};
 			}
@@ -784,7 +784,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestLdftn ()
 			{
 				Action _ = () => {
-					var action = new Action (RequiresUnreferencedCodeMethod);
+					var action = new Action (MethodWithRequires);
 				};
 			}
 
@@ -794,7 +794,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ = () => {
-					typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				};
 			}
 
@@ -843,7 +843,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class WarnInComplex
 		{
-			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
 			static async void TestIteratorLocalFunctionInAsync ()
 			{
 				await MethodAsync ();
@@ -853,16 +853,16 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 					yield return 1;
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static IEnumerable<int> TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ()
 			{
 				yield return 1;
-				MethodWithGenericWhichRequiresMethods<TypeWithRUCMethod> ();
+				MethodWithGenericWhichRequiresMethods<TypeWithMethodWithRequires> ();
 			}
 
 			public static void Test ()
@@ -885,7 +885,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 					yield return 1;
 				}
 			}
@@ -901,7 +901,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;
-					RequiresUnreferencedCodeMethod ();
+					MethodWithRequires ();
 					yield return 1;
 				}
 			}
@@ -909,7 +909,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[RequiresUnreferencedCode ("Suppress in body")]
 			static IEnumerable<int> TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ()
 			{
-				MethodWithGenericWhichRequiresMethods<TypeWithRUCMethod> ();
+				MethodWithGenericWhichRequiresMethods<TypeWithMethodWithRequires> ();
 				yield return 0;
 			}
 
@@ -924,35 +924,35 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class StateMachinesOnlyReferencedViaReflection
 		{
-			[RequiresUnreferencedCode ("RUC to suppress")]
+			[RequiresUnreferencedCode ("Requires to suppress")]
 			static IEnumerable<int> TestIteratorOnlyReferencedViaReflectionWhichShouldSuppress ()
 			{
 				yield return 0;
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 			}
 
-			[RequiresUnreferencedCode ("RUC to suppress")]
+			[RequiresUnreferencedCode ("Requires to suppress")]
 			static async void TestAsyncOnlyReferencedViaReflectionWhichShouldSuppress ()
 			{
 				await MethodAsync ();
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 			}
 
 			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			static IEnumerable<int> TestIteratorOnlyReferencedViaReflectionWhichShouldWarn ()
 			{
 				yield return 0;
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 			}
 
 			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			static async void TestAsyncOnlyReferencedViaReflectionWhichShouldWarn ()
 			{
 				await MethodAsync ();
-				RequiresUnreferencedCodeMethod ();
+				MethodWithRequires ();
 			}
 
-			[ExpectedWarning ("IL2026", "RUC to suppress", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "Requires to suppress", ProducedBy = ProducedBy.Trimmer)]
 			public static void Test ()
 			{
 				// This is not a 100% reliable test, since in theory it can be marked in any order and so it could happen that the
@@ -964,64 +964,64 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class ComplexCases
 		{
-			public class AsyncBodyCallingRUCMethod
+			public class AsyncBodyCallingMethodWithRequires
 			{
 				[RequiresUnreferencedCode ("")]
-				static Task<object> MethodWithRUCAsync (Type type)
+				static Task<object> MethodWithRequiresAsync (Type type)
 				{
 					return Task.FromResult (new object ());
 				}
 
 				[RequiresUnreferencedCode ("ParentSuppression")]
-				static async Task<object> AsyncMethodCallingRUC (Type type)
+				static async Task<object> AsyncMethodCallingRequires (Type type)
 				{
 					using (var diposable = await GetDisposableAsync ()) {
-						return await MethodWithRUCAsync (type);
+						return await MethodWithRequiresAsync (type);
 					}
 				}
 
 				[ExpectedWarning ("IL2026", "ParentSuppression")]
 				public static void Test ()
 				{
-					AsyncMethodCallingRUC (typeof (object));
+					AsyncMethodCallingRequires (typeof (object));
 				}
 			}
 
-			public class GenericAsyncBodyCallingRUCMethod
+			public class GenericAsyncBodyCallingMethodWithRequires
 			{
 				[RequiresUnreferencedCode ("")]
-				static ValueTask<TValue> MethodWithRUCAsync<TValue> ()
+				static ValueTask<TValue> MethodWithRequiresAsync<TValue> ()
 				{
 					return ValueTask.FromResult (default (TValue));
 				}
 
 				[RequiresUnreferencedCode ("ParentSuppression")]
-				static async Task<T> AsyncMethodCallingRUC<T> ()
+				static async Task<T> AsyncMethodCallingRequires<T> ()
 				{
 					using (var disposable = await GetDisposableAsync ()) {
-						return await MethodWithRUCAsync<T> ();
+						return await MethodWithRequiresAsync<T> ();
 					}
 				}
 
 				[ExpectedWarning ("IL2026", "ParentSuppression")]
 				public static void Test ()
 				{
-					AsyncMethodCallingRUC<object> ();
+					AsyncMethodCallingRequires<object> ();
 				}
 			}
 
-			public class GenericAsyncEnumerableBodyCallingRUCWithAnnotations
+			public class GenericAsyncEnumerableBodyCallingRequiresWithAnnotations
 			{
-				class RUCOnCtor
+				class RequiresOnCtor
 				{
 					[RequiresUnreferencedCode ("")]
-					public RUCOnCtor ()
+					public RequiresOnCtor ()
 					{
 					}
 				}
 
 				[RequiresUnreferencedCode ("ParentSuppression")]
-				static IAsyncEnumerable<TValue> AsyncEnumMethodCallingRUC<
+				static IAsyncEnumerable<TValue> AsyncEnumMethodCallingRequires<
 					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] TValue> ()
 				{
 					return CreateAsync ();
@@ -1030,7 +1030,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 					static async IAsyncEnumerable<TValue> CreateAsync ()
 					{
 						await MethodAsync ();
-						new RUCOnCtor ();
+						new RequiresOnCtor ();
 						yield return default (TValue);
 					}
 				}
@@ -1038,7 +1038,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[ExpectedWarning ("IL2026", "ParentSuppression")]
 				public static void Test ()
 				{
-					AsyncEnumMethodCallingRUC<object> ();
+					AsyncEnumMethodCallingRequires<object> ();
 				}
 			}
 
@@ -1052,15 +1052,15 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			return await Task.FromResult (0);
 		}
 
-		[RequiresUnreferencedCode ("--RequiresUnreferencedCodeMethod--")]
-		static void RequiresUnreferencedCodeMethod ()
+		[RequiresUnreferencedCode ("--MethodWithRequires--")]
+		static void MethodWithRequires ()
 		{
 		}
 
-		class TypeWithRUCMethod
+		class TypeWithMethodWithRequires
 		{
-			[RequiresUnreferencedCode ("--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--")]
-			static void RequiresUnreferencedCodeMethod ()
+			[RequiresUnreferencedCode ("--TypeWithMethodWithRequires.MethodWithRequires--")]
+			static void MethodWithRequires ()
 			{
 			}
 		}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttributeCtor.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttributeCtor.cs
@@ -11,17 +11,17 @@ using Mono.Linker.Tests.Cases.RequiresCapability.Dependencies;
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
 	[SetupLinkerAction ("link", "test.exe")]
-	[SetupCompileBefore ("RUCOnAttributeCtor.dll", new[] { "Dependencies/RequiresUnreferencedCodeOnAttributeCtorAttribute.cs" })]
+	[SetupCompileBefore ("RequiresOnAttributeCtor.dll", new[] { "Dependencies/RequiresOnAttributeCtorAttribute.cs" })]
 	[SkipKeptItemsValidation]
 	[ExpectedNoWarnings]
-	public class RequiresUnreferencedCodeOnAttributeCtor
+	public class RequiresOnAttributeCtor
 	{
 		[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
 		public static void Main ()
 		{
 			var type = new Type ();
 			type.Method ();
-			type.MethodAnnotatedWithRUC ();
+			type.MethodAnnotatedWithRequires ();
 			type.Field = 0;
 			_ = type.PropertyGetter;
 			type.PropertySetter = 0;
@@ -31,54 +31,54 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
-		[RequiresUnreferencedCodeOnAttributeCtor]
+		[RequiresOnAttributeCtor]
 		[KeptMember (".ctor()")]
 		public class Type
 		{
 			[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
-			[RequiresUnreferencedCodeOnAttributeCtor]
+			[RequiresOnAttributeCtor]
 			public void Method ()
 			{
 			}
 
 			[RequiresUnreferencedCode ("Message from attribute's ctor.")]
-			[RequiresUnreferencedCodeOnAttributeCtor]
-			public void MethodAnnotatedWithRUC ()
+			[RequiresOnAttributeCtor]
+			public void MethodAnnotatedWithRequires ()
 			{
 			}
 
 			[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
-			[RequiresUnreferencedCodeOnAttributeCtor]
+			[RequiresOnAttributeCtor]
 			public int Field;
 
 			public int PropertyGetter {
 				[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
-				[RequiresUnreferencedCodeOnAttributeCtor]
+				[RequiresOnAttributeCtor]
 				get { return 0; }
 			}
 
 			public int PropertySetter {
 				[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
-				[RequiresUnreferencedCodeOnAttributeCtor]
+				[RequiresOnAttributeCtor]
 				set { throw new NotImplementedException (); }
 			}
 
 			public event EventHandler EventAdd {
 				add { }
 				[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
-				[RequiresUnreferencedCodeOnAttributeCtor]
+				[RequiresOnAttributeCtor]
 				remove { }
 			}
 
 			public event EventHandler EventRemove {
 				[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
-				[RequiresUnreferencedCodeOnAttributeCtor]
+				[RequiresOnAttributeCtor]
 				add { }
 				remove { }
 			}
 
 			[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
-			[RequiresUnreferencedCodeOnAttributeCtor]
+			[RequiresOnAttributeCtor]
 			public interface Interface
 			{
 			}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.descriptor.xml
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.descriptor.xml
@@ -1,7 +1,0 @@
-﻿<linker>
-  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-    <type fullname="Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability">
-      <method name="RequiresUnreferencedCodeOnlyViaDescriptor" />
-    </type>
-  </assembly>
-</linker>


### PR DESCRIPTION
Rename RequiresUnreferencedCode to Requires to make the file agnostic of the attribute that is using, this is to later on use other Requires attributes in the same files

Only making changes to names since renaming files causes github to flag everything as conflicts. This will make it easier to make future changes