### PR TITLE
Migrate to 1ES hosted pools

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -55,8 +55,8 @@ stages:
           ${{ if eq(variables.officialBuild, 'false') }}:
             name: Hosted VS2017
           ${{ if eq(variables.officialBuild, 'true') }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2017
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
         variables:
           - ${{ if eq(variables.officialBuild, 'false') }}:
             - _SignType: test


### PR DESCRIPTION
We are migrating the build pools to 1ES hosted pools. This PR updates pipeline to use the new pools.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276