### PR TITLE
[release/6.0] Fix tlens Mono.Cecil reference

### DIFF
--- a/src/tlens/tlens.csproj
+++ b/src/tlens/tlens.csproj
@@ -10,7 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
+    <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
+    <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="../../external/cecil/Mono.Cecil.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change helps resolve Mono.Cecil in dotnet source-build and also makes the Mono.Cecil reference in tlens the same as the rest of the linker sub-projects.