### PR TITLE
Improve test failure message when a fatal linker error exception happens

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -763,7 +763,7 @@ namespace Mono.Linker
 		// to the error code.
 		// May propagate exceptions, which will result in the process getting an
 		// exit code determined by dotnet.
-		public int Run (ILogger? customLogger = null)
+		public int Run (ILogger? customLogger = null, bool throwOnFatalLinkerException = false)
 		{
 			int setupStatus = SetupContext (customLogger);
 			if (setupStatus > 0)
@@ -782,6 +782,8 @@ namespace Mono.Linker
 				Debug.Assert (lex.MessageContainer.Category == MessageCategory.Error);
 				Debug.Assert (lex.MessageContainer.Code != null);
 				Debug.Assert (lex.MessageContainer.Code.Value != 0);
+				if (throwOnFatalLinkerException)
+					throw;
 				return lex.MessageContainer.Code ?? 1;
 			} catch (ResolutionException e) {
 				Context.LogError ($"{e.Message}", 1040);

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerDriver.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerDriver.cs
@@ -25,7 +25,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		{
 			Driver.ProcessResponseFile (args, out var queue);
 			using (var driver = new TestDriver (queue, customizations)) {
-				driver.Run (logger);
+				driver.Run (logger, throwOnFatalLinkerException: true);
 			}
 		}
 	}


### PR DESCRIPTION
When a test hits a `LinkerFatalErrorException` the test will fail with the following error
```
The linked output assembly was not found.  Expected at C:\Unity\dev\unity-monolinker-2\artifacts\testcases\illink\Attributes\GenericEnumInAttribute\...

  The linked output assembly was not found.  Expected at C:\Unity\dev\unity-monolinker-2\artifacts\testcases\illink\Attributes\GenericEnumInAttribute\output\test.exe
  Expected: True
  But was:  False
```

This is not helpful and is very confusing.

Instead, when running tests, rethrow the `LinkerFatalErrorException` so that the tests correctly report an error.  Ex:
```
Mono.Linker.LinkerFatalErrorException : ILLink: error IL1005: Mono.Linker.Tests.Cases.Attributes.GenericEnumInAttribute.Main(): Error processing method 'Mono.Linker.Tests.Cases.Attributes.GenericEnumInAttribute.Method()' in assembly 'test.exe'
  ----> System.NotImplementedException : GenericInst
   at Mono.Linker.Steps.MarkStep.ProcessQueue() in C:\Unity\dev\unity-monolinker-2\src\linker\Linker.Steps\MarkStep.cs:line 515
```