### PR TITLE
Allow .NET style nested type name

### DIFF
--- a/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -168,6 +168,10 @@ namespace Mono.Linker.Steps
 
 				TypeDefinition type = assembly.MainModule.GetType (fullname);
 
+				// Before giving up, check .NET style nested type naming
+				if (type == null)
+					type = assembly.MainModule.GetType (fullname.Replace ('+', '/'));
+
 				if (type == null && assembly.MainModule.HasExportedTypes) {
 					foreach (var exported in assembly.MainModule.ExportedTypes) {
 						if (fullname == exported.FullName) {

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UnusedNestedTypePreservedByLinkXmlIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UnusedNestedTypePreservedByLinkXmlIsKept.cs
@@ -15,5 +15,20 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 		class Unused
 		{
 		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Unused2
+		{
+			[Kept]
+			class Unused3
+			{
+				[Kept]
+				[KeptMember (".ctor()")]
+				class Unused4
+				{
+				}
+			}
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UnusedNestedTypePreservedByLinkXmlIsKept.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UnusedNestedTypePreservedByLinkXmlIsKept.xml
@@ -1,5 +1,8 @@
 <linker>
   <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
     <type fullname="Mono.Linker.Tests.Cases.LinkXml.UnusedNestedTypePreservedByLinkXmlIsKept/Unused" />
+    <!--Allow .NET style nested type naming-->
+    <type fullname="Mono.Linker.Tests.Cases.LinkXml.UnusedNestedTypePreservedByLinkXmlIsKept+Unused2" />
+    <type fullname="Mono.Linker.Tests.Cases.LinkXml.UnusedNestedTypePreservedByLinkXmlIsKept+Unused2+Unused3+Unused4" />
   </assembly>
 </linker>


### PR DESCRIPTION
A request came in awhile back to allow the .NET style nested type name instead of cecil's nested type naming scheme.

This seems like a sensible request to me.  Someone may copy a fully qualified type name out of a debugger, or print it to stdout at runtime and then paste it into a linker xml file.  To find out that name doesn't work and you have to replace the +'s with /'s would be a negative experience for users.