### PR TITLE
Ruc on type analyzer part 1 (#2330)

### DIFF
--- a/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
@@ -49,14 +49,6 @@ namespace ILLink.RoslynAnalyzer
 		{
 			var sb = new StringBuilder ();
 			switch (symbol) {
-			case IFieldSymbol fieldSymbol:
-				sb.Append (fieldSymbol.Type);
-				sb.Append (" ");
-				sb.Append (fieldSymbol.ContainingSymbol.ToDisplayString ());
-				sb.Append ("::");
-				sb.Append (fieldSymbol.MetadataName);
-				break;
-
 			case IParameterSymbol parameterSymbol:
 				sb.Append (parameterSymbol.Name);
 				break;
@@ -93,5 +85,11 @@ namespace ILLink.RoslynAnalyzer
 
 			return false;
 		}
+
+		public static bool IsConstructor ([NotNullWhen (returnValue: true)] this ISymbol? symbol)
+			=> (symbol as IMethodSymbol)?.MethodKind == MethodKind.Constructor;
+
+		public static bool IsStaticConstructor ([NotNullWhen (returnValue: true)] this ISymbol? symbol)
+			=> (symbol as IMethodSymbol)?.MethodKind == MethodKind.StaticConstructor;
 	}
 }

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -95,6 +95,11 @@ namespace ILLink.RoslynAnalyzer
 				}, OperationKind.ObjectCreation);
 
 				context.RegisterOperationAction (operationContext => {
+					var fieldReference = (IFieldReferenceOperation) operationContext.Operation;
+					CheckCalledMember (operationContext, fieldReference.Field, incompatibleMembers);
+				}, OperationKind.FieldReference);
+
+				context.RegisterOperationAction (operationContext => {
 					var propAccess = (IPropertyReferenceOperation) operationContext.Operation;
 					var prop = propAccess.Property;
 					var usageInfo = propAccess.GetValueUsageInfo (prop);
@@ -111,13 +116,19 @@ namespace ILLink.RoslynAnalyzer
 				context.RegisterOperationAction (operationContext => {
 					var eventRef = (IEventReferenceOperation) operationContext.Operation;
 					var eventSymbol = (IEventSymbol) eventRef.Member;
-					CheckCalledMember (operationContext, eventSymbol, incompatibleMembers);
+					var assignmentOperation = eventRef.Parent as IEventAssignmentOperation;
 
-					if (eventSymbol.AddMethod is IMethodSymbol eventAddMethod)
+					if (assignmentOperation != null && assignmentOperation.Adds && eventSymbol.AddMethod is IMethodSymbol eventAddMethod)
 						CheckCalledMember (operationContext, eventAddMethod, incompatibleMembers);
 
-					if (eventSymbol.RemoveMethod is IMethodSymbol eventRemoveMethod)
+					if (assignmentOperation != null && !assignmentOperation.Adds && eventSymbol.RemoveMethod is IMethodSymbol eventRemoveMethod)
 						CheckCalledMember (operationContext, eventRemoveMethod, incompatibleMembers);
+
+					if (eventSymbol.RaiseMethod is IMethodSymbol eventRaiseMethod)
+						CheckCalledMember (operationContext, eventRaiseMethod, incompatibleMembers);
+
+					if (AnalyzerDiagnosticTargets.HasFlag (DiagnosticTargets.Event))
+						CheckCalledMember (operationContext, eventSymbol, incompatibleMembers);
 				}, OperationKind.EventReference);
 
 				context.RegisterOperationAction (operationContext => {
@@ -163,34 +174,20 @@ namespace ILLink.RoslynAnalyzer
 					ISymbol containingSymbol = FindContainingSymbol (operationContext, AnalyzerDiagnosticTargets);
 
 					// Do not emit any diagnostic if caller is annotated with the attribute too.
-					if (containingSymbol.HasAttribute (RequiresAttributeName))
-						return;
-
-					// Check also for RequiresAttribute in the associated symbol
-					if (containingSymbol is IMethodSymbol methodSymbol && methodSymbol.AssociatedSymbol is not null && methodSymbol.AssociatedSymbol!.HasAttribute (RequiresAttributeName))
+					if (IsMemberInRequiresScope (containingSymbol))
 						return;
 
 					if (ReportSpecialIncompatibleMembersDiagnostic (operationContext, incompatibleMembers, member))
-						return;
-
-					if (!member.HasAttribute (RequiresAttributeName))
 						return;
 
 					// Warn on the most derived base method taking into account covariant returns
 					while (member is IMethodSymbol method && method.OverriddenMethod != null && SymbolEqualityComparer.Default.Equals (method.ReturnType, method.OverriddenMethod.ReturnType))
 						member = method.OverriddenMethod;
 
-					if (TryGetRequiresAttribute (member, out var requiresAttribute)) {
-						if (member is IMethodSymbol eventAccessorMethod && eventAccessorMethod.AssociatedSymbol is IEventSymbol eventSymbol) {
-							// If the annotated member is an event accessor, we warn on the event to match the linker behavior.
-							member = eventAccessorMethod.ContainingSymbol;
-							operationContext.ReportDiagnostic (Diagnostic.Create (RequiresDiagnosticRule,
-								eventSymbol.Locations[0], member.Name, GetMessageFromAttribute (requiresAttribute), GetUrlFromAttribute (requiresAttribute)));
-							return;
-						}
+					if (!TargetHasRequiresAttribute (member, out var requiresAttribute))
+						return;
 
-						ReportRequiresDiagnostic (operationContext, member, requiresAttribute);
-					}
+					ReportRequiresDiagnostic (operationContext, member, requiresAttribute);
 				}
 
 				void CheckMatchingAttributesInOverrides (
@@ -228,7 +225,8 @@ namespace ILLink.RoslynAnalyzer
 			Property = 0x0002,
 			Field = 0x0004,
 			Event = 0x0008,
-			All = MethodOrConstructor | Property | Field | Event
+			Class = 0x0010,
+			All = MethodOrConstructor | Property | Field | Event | Class
 		}
 
 		/// <summary>
@@ -292,6 +290,46 @@ namespace ILLink.RoslynAnalyzer
 		}
 
 		private bool HasMismatchingAttributes (ISymbol member1, ISymbol member2) => member1.HasAttribute (RequiresAttributeName) ^ member2.HasAttribute (RequiresAttributeName);
+
+		// TODO: Consider sharing with linker IsMethodInRequiresUnreferencedCodeScope method
+		/// <summary>
+		/// True if the source of a call is considered to be annotated with the Requires... attribute
+		/// </summary>
+		protected bool IsMemberInRequiresScope (ISymbol containingSymbol)
+		{
+			if (containingSymbol.HasAttribute (RequiresAttributeName) ||
+				containingSymbol.ContainingType.HasAttribute (RequiresAttributeName)) {
+				return true;
+			}
+
+			// Check also for RequiresAttribute in the associated symbol
+			if (containingSymbol is IMethodSymbol { AssociatedSymbol: { } associated } && associated.HasAttribute (RequiresAttributeName))
+				return true;
+
+			return false;
+		}
+
+		// TODO: Consider sharing with linker DoesMethodRequireUnreferencedCode method
+		/// <summary>
+		/// True if the target of a call is considered to be annotated with the Requires... attribute
+		/// </summary>
+		protected bool TargetHasRequiresAttribute (ISymbol member, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttribute)
+		{
+			requiresAttribute = null;
+			if (member.IsStaticConstructor ()) {
+				return false;
+			}
+
+			if (TryGetRequiresAttribute (member, out requiresAttribute)) {
+				return true;
+			}
+
+			// Also check the containing type
+			if (member.IsStatic || member.IsConstructor ()) {
+				return TryGetRequiresAttribute (member.ContainingType, out requiresAttribute);
+			}
+			return false;
+		}
 
 		protected abstract string GetMessageFromAttribute (AttributeData requiresAttribute);
 

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -92,7 +92,7 @@ namespace ILLink.RoslynAnalyzer
 
 		private protected override string RequiresAttributeFullyQualifiedName => FullyQualifiedRequiresUnreferencedCodeAttribute;
 
-		private protected override DiagnosticTargets AnalyzerDiagnosticTargets => DiagnosticTargets.MethodOrConstructor;
+		private protected override DiagnosticTargets AnalyzerDiagnosticTargets => DiagnosticTargets.MethodOrConstructor | DiagnosticTargets.Class;
 
 		private protected override DiagnosticDescriptor RequiresDiagnosticRule => s_requiresUnreferencedCodeRule;
 

--- a/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/linker/Linker/MethodReferenceExtensions.cs
@@ -23,6 +23,20 @@ namespace Mono.Linker
 				return sb.ToString ();
 			}
 
+			if (methodDefinition != null && methodDefinition.IsEventMethod ()) {
+				// Append event name
+				string name = methodDefinition.SemanticsAttributes switch {
+					MethodSemanticsAttributes.AddOn => string.Concat (methodDefinition.Name.AsSpan (4), ".add"),
+					MethodSemanticsAttributes.RemoveOn => string.Concat (methodDefinition.Name.AsSpan (7), ".remove"),
+					MethodSemanticsAttributes.Fire => string.Concat (methodDefinition.Name.AsSpan (6), ".raise"),
+					_ => throw new NotSupportedException (),
+				};
+				sb.Append (name);
+				// Insert declaring type name and namespace
+				sb.Insert (0, '.').Insert (0, method.DeclaringType.GetDisplayName ());
+				return sb.ToString ();
+			}
+
 			// Append parameters
 			sb.Append ("(");
 			if (method.HasParameters) {

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
@@ -744,24 +744,26 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class OnEventMethod
 		{
-			[ExpectedWarning ("IL2026", "--EventToTestRemove.remove--")]
+			[ExpectedWarning ("IL2026", "--EventToTestRemove.remove--", ProducedBy = ProducedBy.Trimmer)]
 			static event EventHandler EventToTestRemove {
 				add { }
 				[RequiresUnreferencedCode ("Message for --EventToTestRemove.remove--")]
 				remove { }
 			}
 
-			[ExpectedWarning ("IL2026", "--EventToTestAdd.add--")]
+			[ExpectedWarning ("IL2026", "--EventToTestAdd.add--", ProducedBy = ProducedBy.Trimmer)]
 			static event EventHandler EventToTestAdd {
 				[RequiresUnreferencedCode ("Message for --EventToTestAdd.add--")]
 				add { }
 				remove { }
 			}
 
+			[ExpectedWarning ("IL2026", "--EventToTestRemove.remove--")]
+			[ExpectedWarning ("IL2026", "--EventToTestAdd.add--")]
 			public static void Test ()
 			{
-				EventToTestRemove += (sender, e) => { };
-				EventToTestAdd -= (sender, e) => { };
+				EventToTestRemove -= (sender, e) => { };
+				EventToTestAdd += (sender, e) => { };
 			}
 		}
 
@@ -924,7 +926,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.StaticCtor.StaticCtor()", "Message for --StaticCtor--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.StaticCtor.StaticCtor()", "Message for --StaticCtor--")]
 			static void TestStaticCctorRequires ()
 			{
 				_ = new StaticCtor ();
@@ -941,13 +943,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static int field;
 			}
 
-			[ExpectedWarning ("IL2026", "StaticCtorTriggeredByFieldAccess.field", "Message for --StaticCtorTriggeredByFieldAccess--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "StaticCtorTriggeredByFieldAccess.field", "Message for --StaticCtorTriggeredByFieldAccess--")]
 			static void TestStaticCtorMarkingIsTriggeredByFieldAccessWrite ()
 			{
 				StaticCtorTriggeredByFieldAccess.field = 1;
 			}
 
-			[ExpectedWarning ("IL2026", "StaticCtorTriggeredByFieldAccess.field", "Message for --StaticCtorTriggeredByFieldAccess--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "StaticCtorTriggeredByFieldAccess.field", "Message for --StaticCtorTriggeredByFieldAccess--")]
 			static void TestStaticCtorMarkingTriggeredOnSecondAccessWrite ()
 			{
 				StaticCtorTriggeredByFieldAccess.field = 2;
@@ -971,7 +973,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static int field = 42;
 			}
 
-			[ExpectedWarning ("IL2026", "StaticCCtorTriggeredByFieldAccessRead.field", "Message for --StaticCCtorTriggeredByFieldAccessRead--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "StaticCCtorTriggeredByFieldAccessRead.field", "Message for --StaticCCtorTriggeredByFieldAccessRead--")]
 			static void TestStaticCtorMarkingIsTriggeredByFieldAccessRead ()
 			{
 				var _ = StaticCCtorTriggeredByFieldAccessRead.field;
@@ -989,7 +991,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "StaticCtorTriggeredByCtorCalls.StaticCtorTriggeredByCtorCalls()", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "StaticCtorTriggeredByCtorCalls.StaticCtorTriggeredByCtorCalls()")]
 			static void TestStaticCtorTriggeredByCtorCall ()
 			{
 				new StaticCtorTriggeredByCtorCalls ();
@@ -1001,7 +1003,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public int field = 42;
 			}
 
-			[ExpectedWarning ("IL2026", "ClassWithInstanceField.ClassWithInstanceField()", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "ClassWithInstanceField.ClassWithInstanceField()")]
 			static void TestInstanceFieldCallDontWarn ()
 			{
 				ClassWithInstanceField instance = new ClassWithInstanceField ();
@@ -1101,13 +1103,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--")]
 			static void TestRequiresInClassAccessedByStaticMethod ()
 			{
 				ClassWithRequires.StaticMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--")]
 			static void TestRequiresInClassAccessedByCctor ()
 			{
 				var classObject = new ClassWithRequires ();
@@ -1118,10 +1120,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				ClassWithRequires.NestedClass.NestedStaticMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--")]
 			// Although we suppress the warning from RequiresOnMethod.MethodWithRequires () we still get a warning because we call CallRequiresMethod() which is an static method on a type with RUC
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.CallMethodWithRequires()", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "ClassWithRequires.Instance", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.CallMethodWithRequires()", "--ClassWithRequires--")]
+			[ExpectedWarning ("IL2026", "ClassWithRequires.Instance", "--ClassWithRequires--")]
 			static void TestRequiresOnBaseButNotOnDerived ()
 			{
 				DerivedWithoutRequires.StaticMethodInInheritedClass ();
@@ -1135,7 +1137,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				DerivedWithoutRequires2.StaticMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires.StaticMethodInInheritedClass()", "--DerivedWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires.StaticMethodInInheritedClass()", "--DerivedWithRequires--")]
 			static void TestRequiresOnDerivedButNotOnBase ()
 			{
 				DerivedWithRequires.StaticMethodInInheritedClass ();
@@ -1144,8 +1146,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				DerivedWithRequires.NestedClass.NestedStaticMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires2.StaticMethodInInheritedClass()", "--DerivedWithRequires2--", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires2.StaticMethodInInheritedClass()", "--DerivedWithRequires2--")]
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.StaticMethod()", "--ClassWithRequires--")]
 			static void TestRequiresOnBaseAndDerived ()
 			{
 				DerivedWithRequires2.StaticMethodInInheritedClass ();
@@ -1154,7 +1156,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				DerivedWithRequires2.NestedClass.NestedStaticMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.TestSuppressions(Type[])", ProducedBy = ProducedBy.Trimmer)]
+			// TODO: Parameter signature differs between linker and analyzer
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequires.TestSuppressions(", "Type[])")]
 			static void TestSuppressionsOnClass ()
 			{
 				ClassWithRequires.TestSuppressions (new[] { typeof (ClassWithRequires) });
@@ -1192,14 +1195,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static int Property { get; set; }
 
 				// These should not be reported https://github.com/mono/linker/issues/2218
-				[ExpectedWarning ("IL2026", "add_Event", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "remove_Event", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Event.add", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Event.remove", ProducedBy = ProducedBy.Trimmer)]
 				public static event EventHandler Event;
 			}
 
-			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.field", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Property.set", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.remove_Event", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.field")]
+			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Property.set")]
+			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Event.remove")]
 			static void TestOtherMemberTypesWithRequires ()
 			{
 				MemberTypesWithRequires.field = 1;
@@ -1340,7 +1343,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[RequiresUnreferencedCode ("--WithRequiresOnlyInstanceFields--")]
 				class WithRequiresOnlyInstanceFields
 				{
-					public int InstnaceField;
+					public int InstanceField;
 				}
 
 				[ExpectedWarning ("IL2109", "ReflectionAccessOnField/DerivedWithoutRequires", "ReflectionAccessOnField.WithRequires", ProducedBy = ProducedBy.Trimmer)]
@@ -1367,20 +1370,22 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 					typeof (DerivedWithRequires).RequiresPublicFields ();
 				}
 
-				[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticField")]
+				// Analyzer does not recognize the binding flags
 				[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticField", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField")]
+				[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField", ProducedBy = ProducedBy.Analyzer)]
 				static void TestDirectReflectionAccess ()
 				{
 					typeof (WithRequires).GetField (nameof (WithRequires.StaticField));
 					typeof (WithRequires).GetField (nameof (WithRequires.InstanceField)); // Doesn't warn
 					typeof (WithRequires).GetField ("PrivateStaticField", BindingFlags.NonPublic);
-					typeof (WithRequiresOnlyInstanceFields).GetField (nameof (WithRequiresOnlyInstanceFields.InstnaceField)); // Doesn't warn
+					typeof (WithRequiresOnlyInstanceFields).GetField (nameof (WithRequiresOnlyInstanceFields.InstanceField)); // Doesn't warn
 					typeof (DerivedWithoutRequires).GetField (nameof (DerivedWithRequires.DerivedStaticField)); // Doesn't warn
 					typeof (DerivedWithRequires).GetField (nameof (DerivedWithRequires.DerivedStaticField));
 				}
 
-				[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "WithRequires.StaticField")]
 				[DynamicDependency (nameof (WithRequires.StaticField), typeof (WithRequires))]
 				[DynamicDependency (nameof (WithRequires.InstanceField), typeof (WithRequires))] // Doesn't warn
 				[DynamicDependency (DynamicallyAccessedMemberTypes.PublicFields, typeof (DerivedWithoutRequires))] // Doesn't warn
@@ -1432,12 +1437,12 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				{
 					// These should be reported only in TestDirectReflectionAccess
 					// https://github.com/mono/linker/issues/2218
-					[ExpectedWarning ("IL2026", "add_StaticEvent", ProducedBy = ProducedBy.Trimmer)]
-					[ExpectedWarning ("IL2026", "remove_StaticEvent", ProducedBy = ProducedBy.Trimmer)]
+					[ExpectedWarning ("IL2026", "StaticEvent.add", ProducedBy = ProducedBy.Trimmer)]
+					[ExpectedWarning ("IL2026", "StaticEvent.remove", ProducedBy = ProducedBy.Trimmer)]
 					public static event EventHandler StaticEvent;
 				}
 
-				[ExpectedWarning ("IL2026", "add_StaticEvent", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "StaticEvent.add", ProducedBy = ProducedBy.Trimmer)]
 				static void TestDirectReflectionAccess ()
 				{
 					typeof (WithRequires).GetEvent (nameof (WithRequires.StaticEvent));

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -679,7 +679,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				bool foundReflectionAccessPatternAttributesToVerify = false;
 				foreach (var attr in attrProvider.CustomAttributes) {
 					if (!IsProducedByLinker (attr))
-						break;
+						continue;
 
 					switch (attr.AttributeType.Name) {
 


### PR DESCRIPTION
Add logic to check some of the Ruc on type analysis warnings
Change field and event signature to match analyzer and linker to a single signature mode
Add class as a diagnostic target
Fix issue where attributes ProducedBy.Trimmer/ProducedBy.All are skipped if they are surrounded by ProducedBy.Analyzer attributes
Bring IsConstructor and IsStaticConstructor from Roslyn source
Remove special case for printing warnings in the event instead of the caller of the event accessor

Scenarios of Ruc on type that are not addressed by this PR:
Dealing with interfaces with RUC and having a class implementing it
DAM interaction with RUC
Reflection patterns, some of the tests work because they use typeof() but in general, they are not supported