### PR TITLE
Fixing a null ref exception related to function pointers and interfaces

### DIFF
--- a/src/linker/Linker/TypeMapInfo.cs
+++ b/src/linker/Linker/TypeMapInfo.cs
@@ -369,6 +369,9 @@ namespace Mono.Linker
 			if (a is IModifierType mta)
 				return TypeMatch (mta, (IModifierType) b);
 
+			if (a is FunctionPointerType fpta)
+				return TypeMatch (fpta, (FunctionPointerType) b);
+
 			return TypeMatch (a.ElementType, b.ElementType);
 		}
 
@@ -407,6 +410,39 @@ namespace Mono.Linker
 			return true;
 		}
 
+		static bool TypeMatch (FunctionPointerType a, FunctionPointerType b)
+		{
+			if (a.HasParameters != b.HasParameters)
+				return false;
+
+			if (a.CallingConvention != b.CallingConvention)
+				return false;
+
+			// we need to track what the generic parameter represent - as we cannot allow it to
+			// differ between the return type or any parameter
+			if (a.ReturnType is not TypeReference aReturnType ||
+				b.ReturnType is not TypeReference bReturnType ||
+				!TypeMatch (aReturnType, bReturnType))
+				return false;
+
+			if (!a.HasParameters)
+				return true;
+
+			var ap = a.Parameters;
+			var bp = b.Parameters;
+			if (ap.Count != bp.Count)
+				return false;
+
+			for (int i = 0; i < ap.Count; i++) {
+				if (a.Parameters[i].ParameterType is not TypeReference aParameterType ||
+					b.Parameters[i].ParameterType is not TypeReference bParameterType ||
+					!TypeMatch (aParameterType, bParameterType))
+					return false;
+			}
+
+			return true;
+		}
+
 		static bool TypeMatch (TypeReference a, TypeReference b)
 		{
 			if (a is TypeSpecification || b is TypeSpecification) {
@@ -418,6 +454,9 @@ namespace Mono.Linker
 
 			if (a is GenericParameter genericParameterA && b is GenericParameter genericParameterB)
 				return TypeMatch (genericParameterA, genericParameterB);
+
+			if ((a is null) || (b is null))
+				return a == b;
 
 			return a.FullName == b.FullName;
 		}

--- a/src/linker/Linker/TypeMapInfo.cs
+++ b/src/linker/Linker/TypeMapInfo.cs
@@ -455,9 +455,6 @@ namespace Mono.Linker
 			if (a is GenericParameter genericParameterA && b is GenericParameter genericParameterB)
 				return TypeMatch (genericParameterA, genericParameterB);
 
-			if ((a is null) || (b is null))
-				return a == b;
-
 			return a.FullName == b.FullName;
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/FunctionPointers/CanCompileInterfaceWithFunctionPointerParameter.cs
+++ b/test/Mono.Linker.Tests.Cases/FunctionPointers/CanCompileInterfaceWithFunctionPointerParameter.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.FunctionPointers
+{
+	[SetupCompileArgument ("/unsafe")]
+	unsafe class CanCompileInterfaceWithFunctionPointerParameter
+	{
+		public static void Main()
+		{
+			new CanCompileInterfaceWithFunctionPointerParameter.B ().Method (null);
+		}
+
+		[KeptMember (".ctor()")]
+		class B : I
+		{
+			public void Unused (delegate* unmanaged<void> fnptr)
+			{
+			}
+
+			[Kept]
+			public void Method (delegate* unmanaged<void> fnptr)
+			{
+			}
+		}
+
+		interface I
+		{
+			void Unused (delegate* unmanaged<void> fnptr);
+
+			void Method (delegate* unmanaged<void> fnptr);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/FunctionPointers/CanCompileInterfaceWithFunctionPointerParameter.cs
+++ b/test/Mono.Linker.Tests.Cases/FunctionPointers/CanCompileInterfaceWithFunctionPointerParameter.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.FunctionPointers
 	[SetupCompileArgument ("/unsafe")]
 	unsafe class CanCompileInterfaceWithFunctionPointerParameter
 	{
-		public static void Main()
+		public static void Main ()
 		{
 			new CanCompileInterfaceWithFunctionPointerParameter.B ().Method (null);
 		}

--- a/test/Mono.Linker.Tests.Cases/FunctionPointers/CanCompileMethodWithFunctionPointerParameter.cs
+++ b/test/Mono.Linker.Tests.Cases/FunctionPointers/CanCompileMethodWithFunctionPointerParameter.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.FunctionPointers
 	[SetupCompileArgument ("/unsafe")]
 	unsafe class CanCompileMethodWithFunctionPointerParameter
 	{
-		public static void Main()
+		public static void Main ()
 		{
 			new CanCompileMethodWithFunctionPointerParameter.B ().Method (null);
 		}

--- a/test/Mono.Linker.Tests.Cases/FunctionPointers/CanCompileMethodWithFunctionPointerParameter.cs
+++ b/test/Mono.Linker.Tests.Cases/FunctionPointers/CanCompileMethodWithFunctionPointerParameter.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.FunctionPointers
+{
+	[SetupCompileArgument ("/unsafe")]
+	unsafe class CanCompileMethodWithFunctionPointerParameter
+	{
+		public static void Main()
+		{
+			new CanCompileMethodWithFunctionPointerParameter.B ().Method (null);
+		}
+
+		[KeptMember (".ctor()")]
+		class B
+		{
+			public void Unused (delegate* unmanaged<void> fnptr)
+			{
+			}
+
+			[Kept]
+			public void Method (delegate* unmanaged<void> fnptr)
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -86,6 +86,11 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesBySuiteName ("FeatureSettings");
 		}
 
+		public static IEnumerable<TestCaseData> FunctionPointersTests ()
+		{
+			return NUnitCasesBySuiteName ("FunctionPointers");
+		}
+
 		public static IEnumerable<TestCaseData> GenericsTests ()
 		{
 			return NUnitCasesBySuiteName ("Generics");

--- a/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -103,6 +103,12 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.FunctionPointersTests))]
+		public void FunctionPointerTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+
 		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.GenericsTests))]
 		public void GenericsTests (TestCase testCase)
 		{


### PR DESCRIPTION
One of my projects was throwing a `NullReferenceException` in .NET 6 RC2:
```
All projects are up-to-date for restore.
TerraFX.Interop.Windows -> C:\Users\tagoo\Source\repos\terrafx.interop.windows\artifacts\bin\sources\TerraFX.Interop.Windows\Release\net6.0\TerraFX.Interop.Windows.dll
TerraFX.Samples.DirectX -> C:\Users\tagoo\Source\repos\terrafx.interop.windows\artifacts\bin\samples\TerraFX.Samples.DirectX\Release\net6.0\win-x64\TerraFX.Samples.DirectX.dll
ILLink : error IL1012: IL Linker has encountered an unexpected error. Please report the issue at https://github.com/mono/linker/issues [C:\Users\tagoo\Source\repos\terrafx.interop.windows\samples\DirectX\TerraFX.Samples.DirectX.csproj]
Fatal error in IL Linker
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
at Mono.Linker.TypeMapInfo.TypeMatch(TypeReference a, TypeReference b)
at Mono.Linker.TypeMapInfo.MethodMatch(MethodReference candidate, MethodReference method)
at Mono.Linker.TypeMapInfo.TryMatchMethod(TypeReference type, MethodReference method)
at Mono.Linker.TypeMapInfo.MapInterfaceMethodsInTypeHierarchy(TypeDefinition type)
at Mono.Linker.TypeMapInfo.MapType(TypeDefinition type)
at Mono.Linker.TypeMapInfo.EnsureProcessed(AssemblyDefinition assembly)
at Mono.Linker.TypeMapInfo.GetBaseMethods(MethodDefinition method)
at Mono.Linker.Steps.MarkStep.IsVirtualNeededByInstantiatedTypeDueToPreservedScope(MethodDefinition method)
at Mono.Linker.Steps.MarkStep.GetRequiredMethodsForInstantiatedType(TypeDefinition type)+MoveNext()
at Mono.Linker.Steps.MarkStep.MarkRequirementsForInstantiatedTypes(TypeDefinition type)
at Mono.Linker.Steps.MarkStep.MarkType(TypeReference reference, DependencyInfo reason, Nullable`1 origin)
at Mono.Linker.Steps.MarkStep.MarkField(FieldDefinition field, DependencyInfo& reason)
at Mono.Linker.Steps.MarkStep.MarkEntireType(TypeDefinition type, DependencyInfo& reason)
at Mono.Linker.Steps.MarkStep.MarkEntireAssembly(AssemblyDefinition assembly)
at Mono.Linker.Steps.MarkStep.MarkAssembly(AssemblyDefinition assembly, DependencyInfo reason)
at Mono.Linker.Steps.MarkStep.ProcessMarkedPending()
at Mono.Linker.Steps.MarkStep.Initialize()
at Mono.Linker.Steps.MarkStep.Process(LinkContext context)
at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step)
at Mono.Linker.Pipeline.Process(LinkContext context)
at Mono.Linker.Driver.Run(ILogger customLogger)
at Mono.Linker.Driver.Main(String[] args)
Optimizing assemblies for size, which may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
C:\Program Files\dotnet\sdk\6.0.100-rc.2.21505.57\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ILLink.targets(108,5): error NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false. [C:\Users\tagoo\Source\repos\terrafx.interop.windows\samples\DirectX\TerraFX.Samples.DirectX.csproj]
```

This was ultimately because the types that were being matched were `FunctionPointerType` for which `.ElementType` returns `null`. This updates the `TypeMatch` to account for `FunctionPointerType` and do a comparison of calling convention, return type, and parameter types.