### PR TITLE
Add a custom flag to disable marking of copy assemblies

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1387,7 +1387,8 @@ namespace Mono.Linker.Steps
 			MarkExportedTypesTarget.ProcessAssembly (assembly, Context);
 
 			if (ProcessReferencesStep.IsFullyPreservedAction (Context.Annotations.GetAction (assembly))) {
-				if (!Context.HasFeatureValue("DisableMarkingOfCopyAssemblies", true))
+				if (!Context.TryGetCustomData("DisableMarkingOfCopyAssemblies", out string? disableMarkingOfCopyAssembliesValue) ||
+					disableMarkingOfCopyAssembliesValue != "true")
 					MarkEntireAssembly (assembly);
 				return;
 			}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1387,7 +1387,7 @@ namespace Mono.Linker.Steps
 			MarkExportedTypesTarget.ProcessAssembly (assembly, Context);
 
 			if (ProcessReferencesStep.IsFullyPreservedAction (Context.Annotations.GetAction (assembly))) {
-				if (!Context.TryGetCustomData("DisableMarkingOfCopyAssemblies", out string? disableMarkingOfCopyAssembliesValue) ||
+				if (!Context.TryGetCustomData ("DisableMarkingOfCopyAssemblies", out string? disableMarkingOfCopyAssembliesValue) ||
 					disableMarkingOfCopyAssembliesValue != "true")
 					MarkEntireAssembly (assembly);
 				return;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1387,7 +1387,8 @@ namespace Mono.Linker.Steps
 			MarkExportedTypesTarget.ProcessAssembly (assembly, Context);
 
 			if (ProcessReferencesStep.IsFullyPreservedAction (Context.Annotations.GetAction (assembly))) {
-				MarkEntireAssembly (assembly);
+				if (!Context.HasFeatureValue("DisableMarkingOfCopyAssemblies", true))
+					MarkEntireAssembly (assembly);
 				return;
 			}
 

--- a/src/linker/Properties/launchSettings.json
+++ b/src/linker/Properties/launchSettings.json
@@ -1,9 +1,0 @@
-{
-  "profiles": {
-    "Mono.Linker": {
-      "commandName": "Project",
-      "commandLineArgs": "@F:\\ILLinker\\repro\\SlowApp\\linker.rsp",
-      "workingDirectory": "F:\\ILLinker\\repro\\SlowApp"
-    }
-  }
-}

--- a/src/linker/Properties/launchSettings.json
+++ b/src/linker/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Mono.Linker": {
+      "commandName": "Project",
+      "commandLineArgs": "@F:\\ILLinker\\repro\\SlowApp\\linker.rsp",
+      "workingDirectory": "F:\\ILLinker\\repro\\SlowApp"
+    }
+  }
+}


### PR DESCRIPTION
For https://github.com/dotnet/linker/issues/2089

Enabled by `--custom-data DisableMarkingOfCopyAssemblies=true` on the command line. Assumes that ALL assemblies on the input are in "copy" action (it doesn't validate this fact).

It disables marking basically fully - linker will go over all assemblies, and process them in "copy" mode (copy the original file over) and will call all the custom steps and so on, but it will do no marking (or very little, depends on descriptors and such which this doesn't disable).

This is intentionally non-discoverable feature, to be used only by the mono AOT toolchain.

/cc @rolfbjarne 