### PR TITLE
Fix marking of nested type forwarders

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1443,7 +1443,7 @@ namespace Mono.Linker.Steps
 			protected override void ProcessExportedType (ExportedType exportedType)
 			{
 				markingHelpers.MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, assembly));
-				markingHelpers.MarkForwardedScope (new TypeReference (exportedType.Namespace, exportedType.Name, assembly.MainModule, exportedType.Scope));
+				markingHelpers.MarkForwardedScope (CreateTypeReferenceForExportedTypeTarget (exportedType));
 			}
 
 			protected override void ProcessExtra ()
@@ -1455,6 +1455,18 @@ namespace Mono.Linker.Steps
 						continue;
 					markingHelpers.MarkForwardedScope (typeReference);
 				}
+			}
+
+			TypeReference CreateTypeReferenceForExportedTypeTarget (ExportedType exportedType)
+			{
+				TypeReference? declaringTypeReference = null;
+				if (exportedType.DeclaringType != null) {
+					declaringTypeReference = CreateTypeReferenceForExportedTypeTarget (exportedType.DeclaringType);
+				}
+
+				return new TypeReference (exportedType.Namespace, exportedType.Name, assembly.MainModule, exportedType.Scope) {
+					DeclaringType = declaringTypeReference
+				};
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/NestedForwarderLibrary.il
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/NestedForwarderLibrary.il
@@ -25,7 +25,7 @@
 }
 .class extern ForwardedNestedType
 {
-  .class extern 'Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibrary'
+  .class extern 'Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.AnotherImplementationClass'
 }
 
 .module 'NestedForwarderLibrary.dll'

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/NestedForwarderLibrary_2.il
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/NestedForwarderLibrary_2.il
@@ -25,7 +25,7 @@
 }
 .class extern ForwardedNestedType
 {
-  .class extern 'Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibrary'
+  .class extern 'Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.AnotherImplementationClass'
 }
 
 .module 'NestedForwarderLibrary_2.dll'

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/MultiForwardedTypesWithCopyUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/MultiForwardedTypesWithCopyUsed.cs
@@ -22,13 +22,10 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	[SetupLinkerAction ("copyused", "NestedForwarderLibrary")]
 	[SetupLinkerAction ("copyused", "Implementation")]
 
-	// https://github.com/dotnet/linker/issues/2359
-	// One of the type forwarders in NestedForwarderLibrary will not be kept.
-	// Which one depends on order.
-	//[KeptTypeInAssembly ("NestedForwarderLibrary.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
-	//[KeptTypeInAssembly ("NestedForwarderLibrary.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
-	//[KeptTypeInAssembly ("NestedForwarderLibrary_2.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
-	//[KeptTypeInAssembly ("NestedForwarderLibrary_2.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
+	[KeptTypeInAssembly ("NestedForwarderLibrary.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
+	[KeptTypeInAssembly ("NestedForwarderLibrary.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
+	[KeptTypeInAssembly ("NestedForwarderLibrary_2.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
+	[KeptTypeInAssembly ("NestedForwarderLibrary_2.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
 	[KeptTypeInAssembly ("Implementation.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
 	[KeptTypeInAssembly ("Implementation.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
 

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/MultiForwardedTypesWithLink.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/MultiForwardedTypesWithLink.cs
@@ -22,13 +22,10 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	[SetupLinkerAction ("link", "NestedForwarderLibrary")]
 	[SetupLinkerAction ("link", "Implementation")]
 
-	// https://github.com/dotnet/linker/issues/2359
-	// One of the type forwarders in NestedForwarderLibrary will not be kept.
-	// Which one depends on order.
-	//[KeptTypeInAssembly ("NestedForwarderLibrary.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
-	//[KeptTypeInAssembly ("NestedForwarderLibrary.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
-	//[KeptTypeInAssembly ("NestedForwarderLibrary_2.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
-	//[KeptTypeInAssembly ("NestedForwarderLibrary_2.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
+	[KeptTypeInAssembly ("NestedForwarderLibrary.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
+	[KeptTypeInAssembly ("NestedForwarderLibrary.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
+	[KeptTypeInAssembly ("NestedForwarderLibrary_2.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
+	[KeptTypeInAssembly ("NestedForwarderLibrary_2.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
 	[KeptTypeInAssembly ("Implementation.dll", typeof (ImplementationLibrary.ForwardedNestedType))]
 	[KeptTypeInAssembly ("Implementation.dll", typeof (AnotherImplementationClass.ForwardedNestedType))]
 


### PR DESCRIPTION
When create a type reference for the target of a type forwarder, if the type forwarder is for a nested type, we have to build a whole tree of type references for all of the declaring types and not just the final nested type.

Enabled tests which were already added for this case (and fixed a bug in them)

This is a fix for https://github.com/dotnet/linker/issues/2359