### PR TITLE
Fixes a null-ref/NotSupportedException in warning infra

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1054,7 +1054,7 @@ namespace Mono.Linker.Dataflow
 								} else {
 									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkTypeVisibleToReflection (foundTypeRef, foundType, new DependencyInfo (DependencyKind.AccessedViaReflection, callingMethodDefinition)));
 									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (foundType));
-									_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.AccessedViaReflection, foundType));
+									_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.AccessedViaReflection, foundType), reflectionContext.Origin);
 								}
 							} else if (typeNameValue == NullValue.Instance) {
 								reflectionContext.RecordHandledPattern ();
@@ -2234,7 +2234,7 @@ namespace Mono.Linker.Dataflow
 					} else {
 						MarkType (ref reflectionContext, typeRef);
 						MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, foundType, requiredMemberTypes, DependencyKind.DynamicallyAccessedMember);
-						_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType));
+						_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType), reflectionContext.Origin);
 					}
 				} else if (uniqueValue == NullValue.Instance) {
 					// Ignore - probably unreachable path as it would fail at runtime anyway.

--- a/src/linker/Linker.Steps/BodySubstitutionParser.cs
+++ b/src/linker/Linker.Steps/BodySubstitutionParser.cs
@@ -34,7 +34,7 @@ namespace Mono.Linker.Steps
 			ProcessResources (assembly, nav);
 		}
 
-		protected override TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly) => null;
+		protected override TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly, XPathNavigator nav) => null;
 
 		protected override bool ProcessTypePattern (string fullname, AssemblyDefinition assembly, XPathNavigator nav) => false;
 

--- a/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
+++ b/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
@@ -81,7 +81,7 @@ namespace Mono.Linker.Steps
 
 		void MarkOperator (MethodDefinition method)
 		{
-			Context.Annotations.Mark (method, new DependencyInfo (DependencyKind.PreservedOperator, method.DeclaringType));
+			Context.Annotations.Mark (method, new DependencyInfo (DependencyKind.PreservedOperator, method.DeclaringType), new MessageOrigin (method.DeclaringType));
 		}
 
 		bool ProcessCustomOperators (TypeDefinition type, bool mark)

--- a/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
+++ b/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
@@ -13,10 +13,10 @@ namespace Mono.Linker.Steps
 				return;
 
 			foreach (var type in assembly.MainModule.ExportedTypes)
-				InitializeExportedType (type, context);
+				InitializeExportedType (type, context, assembly);
 		}
 
-		static void InitializeExportedType (ExportedType exportedType, LinkContext context)
+		static void InitializeExportedType (ExportedType exportedType, LinkContext context, AssemblyDefinition assembly)
 		{
 			if (!context.Annotations.IsMarked (exportedType))
 				return;
@@ -32,7 +32,7 @@ namespace Mono.Linker.Steps
 				return;
 			}
 
-			context.Annotations.Mark (type, new DependencyInfo (DependencyKind.ExportedType, exportedType));
+			context.Annotations.Mark (type, new DependencyInfo (DependencyKind.ExportedType, exportedType), new MessageOrigin (assembly));
 			context.Annotations.SetMembersPreserve (type, members);
 		}
 	}

--- a/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -171,7 +171,7 @@ namespace Mono.Linker.Steps
 				if (type == null && assembly.MainModule.HasExportedTypes) {
 					foreach (var exported in assembly.MainModule.ExportedTypes) {
 						if (fullname == exported.FullName) {
-							var resolvedExternal = ProcessExportedType (exported, assembly);
+							var resolvedExternal = ProcessExportedType (exported, assembly, typeNav);
 							if (resolvedExternal != null) {
 								type = resolvedExternal;
 								break;
@@ -190,7 +190,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected virtual TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly) => exported.Resolve ();
+		protected virtual TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly, XPathNavigator nav) => exported.Resolve ();
 
 		void MatchType (TypeDefinition type, Regex regex, XPathNavigator nav)
 		{
@@ -215,7 +215,7 @@ namespace Mono.Linker.Steps
 			if (assembly.MainModule.HasExportedTypes) {
 				foreach (var exported in assembly.MainModule.ExportedTypes) {
 					if (regex.Match (exported.FullName).Success) {
-						var type = ProcessExportedType (exported, assembly);
+						var type = ProcessExportedType (exported, assembly, nav);
 						if (type != null) {
 							ProcessType (type, nav);
 						}
@@ -468,8 +468,8 @@ namespace Mono.Linker.Steps
 		protected MessageOrigin GetMessageOriginForPosition (XPathNavigator position)
 		{
 			return (position is IXmlLineInfo lineInfo)
-					? new MessageOrigin (_xmlDocumentLocation, lineInfo.LineNumber, lineInfo.LinePosition)
-					: new MessageOrigin (_xmlDocumentLocation);
+					? new MessageOrigin (_xmlDocumentLocation, lineInfo.LineNumber, lineInfo.LinePosition, _resource?.Assembly)
+					: new MessageOrigin (_xmlDocumentLocation, 0, 0, _resource?.Assembly);
 		}
 		protected void LogWarning (string message, int warningCode, XPathNavigator position)
 		{

--- a/src/linker/Linker.Steps/ProcessReferencesStep.cs
+++ b/src/linker/Linker.Steps/ProcessReferencesStep.cs
@@ -44,7 +44,7 @@ namespace Mono.Linker.Steps
 				// If the assigned action (now taking into account the IsTrimmable attribute) requires us
 				// to root the assembly, do so.
 				if (IsFullyPreservedAction (Annotations.GetAction (assembly)))
-					Annotations.Mark (assembly.MainModule, new DependencyInfo (DependencyKind.AssemblyAction, assembly));
+					Annotations.Mark (assembly.MainModule, new DependencyInfo (DependencyKind.AssemblyAction, assembly), new MessageOrigin (assembly));
 			}
 		}
 

--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -24,11 +24,12 @@ namespace Mono.Linker.Steps
 				return;
 
 			var di = new DependencyInfo (DependencyKind.RootAssembly, assembly);
+			var origin = new MessageOrigin (assembly);
 
 			AssemblyAction action = Context.Annotations.GetAction (assembly);
 			switch (action) {
 			case AssemblyAction.Copy:
-				Annotations.Mark (assembly.MainModule, di);
+				Annotations.Mark (assembly.MainModule, di, origin);
 				// Mark Step will take care of marking whole assembly
 				return;
 			case AssemblyAction.CopyUsed:
@@ -52,7 +53,7 @@ namespace Mono.Linker.Steps
 					return;
 				}
 
-				Annotations.Mark (ep.DeclaringType, di);
+				Annotations.Mark (ep.DeclaringType, di, origin);
 				Annotations.AddPreservedMethod (ep.DeclaringType, ep);
 				break;
 			case AssemblyRootMode.VisibleMembers:
@@ -153,7 +154,7 @@ namespace Mono.Linker.Steps
 				Annotations.SetMembersPreserve (type, preserve);
 				break;
 			default:
-				Annotations.Mark (type, new DependencyInfo (DependencyKind.RootAssembly, type.Module.Assembly));
+				Annotations.Mark (type, new DependencyInfo (DependencyKind.RootAssembly, type.Module.Assembly), new MessageOrigin (type.Module.Assembly));
 				Annotations.SetMembersPreserve (type, preserve);
 				break;
 			}
@@ -168,8 +169,9 @@ namespace Mono.Linker.Steps
 		void MarkAndPreserve (AssemblyDefinition assembly, ExportedType type, TypePreserveMembers preserve)
 		{
 			var di = new DependencyInfo (DependencyKind.RootAssembly, assembly);
-			Context.Annotations.Mark (type, di);
-			Context.Annotations.Mark (assembly.MainModule, di);
+			var origin = new MessageOrigin (assembly);
+			Context.Annotations.Mark (type, di, origin);
+			Context.Annotations.Mark (assembly.MainModule, di, origin);
 			Annotations.SetMembersPreserve (type, preserve);
 		}
 

--- a/src/linker/Linker/CustomAttributeSource.cs
+++ b/src/linker/Linker/CustomAttributeSource.cs
@@ -40,8 +40,13 @@ namespace Mono.Linker
 			var assembly = GetAssemblyFromCustomAttributeProvider (provider);
 
 			if (!_embeddedXmlInfos.TryGetValue (assembly, out xmlInfo)) {
+				// Add an empty record - this prevents reentrancy
+				// If the embedded XML itself generates warnings, trying to log such warning
+				// may ask for attributes (suppressions) and thus we could end up in this very place again
+				// So first add a dummy record and once processed we will replace it with the real data
+				_embeddedXmlInfos.Add (assembly, new AttributeInfo ());
 				xmlInfo = EmbeddedXmlInfo.ProcessAttributes (assembly, _context);
-				_embeddedXmlInfos.Add (assembly, xmlInfo);
+				_embeddedXmlInfos[assembly] = xmlInfo;
 			}
 
 			return xmlInfo != null;

--- a/src/linker/Linker/MarkingHelpers.cs
+++ b/src/linker/Linker/MarkingHelpers.cs
@@ -11,24 +11,24 @@ namespace Mono.Linker
 			_context = context;
 		}
 
-		public void MarkMatchingExportedType (TypeDefinition typeToMatch, AssemblyDefinition assembly, in DependencyInfo reason)
+		public void MarkMatchingExportedType (TypeDefinition typeToMatch, AssemblyDefinition assembly, in DependencyInfo reason, in MessageOrigin origin)
 		{
 			if (typeToMatch == null || assembly == null)
 				return;
 
 			if (assembly.MainModule.GetMatchingExportedType (typeToMatch, out var exportedType))
-				MarkExportedType (exportedType, assembly.MainModule, reason);
+				MarkExportedType (exportedType, assembly.MainModule, reason, origin);
 		}
 
-		public void MarkExportedType (ExportedType exportedType, ModuleDefinition module, in DependencyInfo reason)
+		public void MarkExportedType (ExportedType exportedType, ModuleDefinition module, in DependencyInfo reason, in MessageOrigin origin)
 		{
 			if (!_context.Annotations.MarkProcessed (exportedType, reason))
 				return;
 
-			_context.Annotations.Mark (module, reason);
+			_context.Annotations.Mark (module, reason, origin);
 		}
 
-		public void MarkForwardedScope (TypeReference typeReference)
+		public void MarkForwardedScope (TypeReference typeReference, in MessageOrigin origin)
 		{
 			if (typeReference == null)
 				return;
@@ -38,7 +38,7 @@ namespace Mono.Linker
 				if (assembly != null &&
 					_context.TryResolve (typeReference) is TypeDefinition typeDefinition &&
 					assembly.MainModule.GetMatchingExportedType (typeDefinition, out var exportedType))
-					MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, typeReference));
+					MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, typeReference), origin);
 			}
 		}
 	}

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -159,15 +159,16 @@ namespace Mono.Linker
 			if (subcategory != MessageSubCategory.TrimAnalysis)
 				return false;
 
-			Debug.Assert (origin.Provider != null);
+			// There are valid cases where we can't map the message to an assembly
+			// For example if it's caused by something in an xml file passed on the command line
+			// In that case, give up on single-warn collapse and just print out the warning on its own.
 			var assembly = origin.Provider switch {
 				AssemblyDefinition asm => asm,
 				TypeDefinition type => type.Module.Assembly,
 				IMemberDefinition member => member.DeclaringType.Module.Assembly,
-				_ => throw new NotSupportedException ()
+				_ => null
 			};
 
-			Debug.Assert (assembly != null);
 			if (assembly == null)
 				return false;
 

--- a/src/linker/Linker/MessageOrigin.cs
+++ b/src/linker/Linker/MessageOrigin.cs
@@ -39,11 +39,18 @@ namespace Mono.Linker
 		}
 
 		public MessageOrigin (string fileName, int sourceLine = 0, int sourceColumn = 0)
+			: this (fileName, sourceLine, sourceColumn, null)
+		{
+		}
+
+		// The assembly attribute should be specified if available as it allows assigning the diagnostic
+		// to a an assembly (we group based on assembly).
+		public MessageOrigin (string fileName, int sourceLine, int sourceColumn, AssemblyDefinition? assembly)
 		{
 			FileName = fileName;
 			SourceLine = sourceLine;
 			SourceColumn = sourceColumn;
-			Provider = null;
+			Provider = assembly;
 			_suppressionContextMember = null;
 			ILOffset = null;
 		}

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemovalAndPreserveAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemovalAndPreserveAssembly.cs
@@ -23,12 +23,13 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 
 	[SetupCompileBefore (
 		"lib.dll",
-		new[] { "Dependencies/LinkerAttributeRemovalAndPreserveAssembly_Lib.cs" })]
-	// https://github.com/dotnet/linker/issues/2358 - adding the descriptor currently causes nullref in the linker
-	// resources: new object[] { new string[] { "Dependencies/LinkerAttributeRemovalAndPreserveAssembly_Lib.Descriptor.xml", "ILLink.Descriptors.xml" } })]
+		new[] { "Dependencies/LinkerAttributeRemovalAndPreserveAssembly_Lib.cs" },
+		resources: new object[] { new string[] { "Dependencies/LinkerAttributeRemovalAndPreserveAssembly_Lib.Descriptor.xml", "ILLink.Descriptors.xml" } })]
 
+	[ExpectedWarning ("IL2045", FileName = "ILLink.Descriptors.xml in lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken")]
 	[ExpectedNoWarnings]
 
+	[KeptMember (".ctor()")]
 	class LinkerAttributeRemovalAndPreserveAssembly
 	{
 		public static void Main ()
@@ -44,5 +45,10 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 		}
 	}
 
+	// The attribute is kept (partially) because we found out about it too late
+	// It does report a warning though
+	[Kept]
+	[KeptBaseType (typeof (Attribute))]
+	[KeptMember (".ctor()")]
 	public class AttributeToRemoveAttribute : Attribute { }
 }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
@@ -37,6 +37,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 	[LogDoesNotContain ("--UnusedImplementationClass.UnusedMethod--")]
 	// [LogDoesNotContain ("UnusedVirtualMethod2")] // https://github.com/dotnet/linker/issues/2106
 	// [LogContains ("--RequiresOnlyViaDescriptor--")]  // https://github.com/dotnet/linker/issues/2103
+
+	[ExpectedWarning ("IL2026", "RequiresOnFieldOnlyViaDescriptor.Field", FileName = "RequiresCapability.descriptor.xml", ProducedBy = ProducedBy.Trimmer)]
+
 	[ExpectedNoWarnings]
 	public class RequiresCapability
 	{
@@ -730,6 +733,12 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[RequiresUnreferencedCode ("Message for --RequiresOnlyViaDescriptor--")]
 		static void RequiresOnlyViaDescriptor ()
 		{
+		}
+
+		[RequiresUnreferencedCode ("Message for --RequiresOnFieldOnlyViaDescriptor--")]
+		class RequiresOnFieldOnlyViaDescriptor
+		{
+			public static int Field;
 		}
 
 		class RequiresOnGenerics

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.descriptor.xml
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.descriptor.xml
@@ -3,5 +3,8 @@
     <type fullname="Mono.Linker.Tests.Cases.RequiresCapability.RequiresCapability">
       <method name="RequiresOnlyViaDescriptor" />
     </type>
+    <type fullname="Mono.Linker.Tests.Cases.RequiresCapability.RequiresCapability/RequiresOnFieldOnlyViaDescriptor">
+      <field name="Field" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
If we end up marking a type due to descriptor and the type marking will cause a warning (for example a removed attribute type does this in some cases), the warning infra would fail.

This is because it requires all warnings to have a valid origin including which assembly it came from. But descriptors didn't provide this information.

Most of the change here are to fix that lack of information. When marking through annotations, we now store the message origin for the mark operation along with the target of the marking. This is then restored on the scope stack to be used when reporting warnings caused by such marking.

This required lot of changes to pass the message origin in all places which end up marking things in annotations.

This also required some small fixes as it uncovered previously unseen issues.

Additionally, it can still happen that there's really no origin (for example copy action specified on command line will mark entire assembly - there's nothing to blame, but the command line) for a message or we can't assign an assembly (descriptor file pass on the command line, we can blame the file, but we still don't have an assembly).

So this change tweaks the warning infra to allow messages without assembly of origin.

Enabled a test whcih validated the behavior around removed attribute being marked via descriptor (this now produces warning with fully valid origin).
Added another test where the warning is due to a descriptor on command line (no associated assembly for such warning).

This fixes the linker issue found in https://github.com/dotnet/linker/issues/2358.