### PR TITLE
Improve ValueSet implementation to avoid HashSet creation every time

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -84,10 +84,7 @@ namespace ILLink.RoslynAnalyzer
 
 		static IEnumerable<Diagnostic> GetDynamicallyAccessedMembersDiagnostics (ValueSet<SingleValue> source, ValueSet<SingleValue> target, Location location)
 		{
-			if (target.Values == null)
-				yield break;
-
-			foreach (var targetValue in target.Values) {
+			foreach (var targetValue in target) {
 				foreach (var diagnostic in GetDynamicallyAccessedMembersDiagnostics (source, targetValue, location))
 					yield return diagnostic;
 			}
@@ -95,10 +92,7 @@ namespace ILLink.RoslynAnalyzer
 
 		static IEnumerable<Diagnostic> GetDynamicallyAccessedMembersDiagnostics (ValueSet<SingleValue> source, SingleValue target, Location location)
 		{
-			if (source.Values == null)
-				yield break;
-
-			foreach (var sourceValue in source.Values) {
+			foreach (var sourceValue in source) {
 				foreach (var diagnostic in GetDynamicallyAccessedMembersDiagnostics (sourceValue, target, location))
 					yield return diagnostic;
 			}

--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -9,49 +10,151 @@ namespace ILLink.Shared.DataFlow
 	public readonly struct ValueSet<TValue> : IEquatable<ValueSet<TValue>>, IEnumerable<TValue>
 		where TValue : notnull
 	{
-		public readonly HashSet<TValue>? Values;
+		// Since we're going to do lot of type checks for this class a lot, it is much more efficient
+		// if the class is sealed (as then the runtime can do a simple method table pointer comparison)
+		class SealedHashSet : HashSet<TValue>
+		{
+			public SealedHashSet () { }
+			public SealedHashSet (IEnumerable<TValue> values) : base (values) { }
+		}
 
-		public ValueSet (HashSet<TValue> values) => Values = values;
+		public struct Enumerator : IEnumerator<TValue>, IDisposable, IEnumerator
+		{
+			readonly object? _value;
+			int _state;  // 0 before begining, 1 at item, 2 after end
+			readonly IEnumerator<TValue>? _enumerator;
 
-		public ValueSet (TValue value) => Values = new HashSet<TValue> () { value };
+			internal Enumerator (object? values)
+			{
+				_state = 0;
+				if (values is SealedHashSet valuesSet) {
+					_enumerator = valuesSet.GetEnumerator ();
+					_value = default (TValue);
+				} else {
+					_enumerator = null;
+					_value = values;
+				}
+			}
+
+			// TODO: How to get this to work - without the '!' at the end this complains that default can return null.
+			// But how does this work for HashSet<T>? That will return null from Current in reality as well... 
+			// It seems that the nullability is not propagated "inside" HashSet (since that one is implemented with TValue being nullable)
+			public TValue Current => (_enumerator is not null ? _enumerator.Current : (_state == 1 ? (TValue)_value! : default))!;
+
+			object? IEnumerator.Current => Current;
+
+			public void Dispose ()
+			{
+			}
+
+			public bool MoveNext ()
+			{
+				if (_enumerator is not null)
+					return _enumerator.MoveNext ();
+
+				if (_value is null)
+					return false;
+
+				if (_state > 1)
+					return false;
+
+				_state++;
+				return _state == 1;
+			}
+
+			public void Reset ()
+			{
+				if (_enumerator is not null)
+					_enumerator.Reset ();
+				else
+					_state = 0;
+			}
+		}
+
+		// This stores the values. By far the most common case will be either no values, or a single value.
+		// Cases where there are multiple values stored are relatively very rare.
+		//   null - no values (empty set)
+		//   TValue - single value itself
+		//   SealedHashSet typed object - multiple values, stored in the hashset
+		private readonly object? _values;
+
+		public ValueSet (TValue value) => _values = value;
+
+		public ValueSet (IEnumerable<TValue> values) => _values = new SealedHashSet (values);
+
+		private ValueSet (SealedHashSet values) => _values = values;
 
 		public override bool Equals (object? obj) => obj is ValueSet<TValue> other && Equals (other);
 
 		public bool Equals (ValueSet<TValue> other)
 		{
-			if (Values == null)
-				return other.Values == null;
-			if (other.Values == null)
+			if (_values == null)
+				return other._values == null;
+			if (other._values == null)
 				return false;
 
-			return Values.SetEquals (other.Values);
+			if (_values is SealedHashSet valuesSet) {
+				Debug.Assert (valuesSet.Count > 1);
+				if (other._values is SealedHashSet otherValuesSet) {
+					Debug.Assert (otherValuesSet.Count > 1);
+					return valuesSet.SetEquals (otherValuesSet);
+				} else
+					return false;
+			} else {
+				if (other._values is SealedHashSet otherValuesSet) {
+					Debug.Assert (otherValuesSet.Count > 1);
+					return false;
+				}
+
+				return EqualityComparer<TValue>.Default.Equals ((TValue)_values, (TValue)other._values);
+			}
 		}
 
 		public override int GetHashCode ()
 		{
-			if (Values == null)
+			if (_values == null)
 				return typeof (ValueSet<TValue>).GetHashCode ();
 
-			int hashCode = 0;
-			foreach (var item in Values)
-				hashCode = HashUtils.Combine (hashCode, item);
-			return hashCode;
+			if (_values is SealedHashSet valuesSet) {
+				int hashCode = 0;
+				foreach (var item in valuesSet)
+					hashCode = HashUtils.Combine (hashCode, item);
+				return hashCode;
+			}
+
+			return _values.GetHashCode ();
 		}
 
-		public IEnumerator<TValue> GetEnumerator ()
-		{
-			return Values?.GetEnumerator () ?? Enumerable.Empty<TValue> ().GetEnumerator ();
-		}
+		public Enumerator GetEnumerator () => new(_values);
+		IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator () => GetEnumerator ();
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 
-		public bool Contains (TValue value) => Values?.Contains (value) ?? false;
+		public bool Contains (TValue value) => _values is null ? false : _values is SealedHashSet valuesSet ? valuesSet.Contains (value) : EqualityComparer <TValue>.Default.Equals (value, (TValue)_values);
+
+		internal static ValueSet<TValue> Meet (ValueSet<TValue> left, ValueSet<TValue> right)
+		{
+			if (left._values == null)
+				return right;
+			if (right._values == null)
+				return left;
+
+			if (left._values is not SealedHashSet && right.Contains ((TValue)left._values))
+				return right;
+				
+			if (right._values is not SealedHashSet && left.Contains ((TValue)right._values))
+				return left;
+
+			var values = new SealedHashSet (left);
+			values.UnionWith (right);
+			return new ValueSet<TValue> (values);
+		}
 
 		public override string ToString ()
 		{
 			StringBuilder sb = new ();
 			sb.Append ("{");
-			sb.Append (string.Join (",", Values?.Select (v => v.ToString ()) ?? Enumerable.Empty<string> ()));
+			sb.Append (string.Join (",", this.Select (v => v.ToString ())));
 			sb.Append ("}");
 			return sb.ToString ();
 		}

--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -46,12 +46,9 @@ namespace ILLink.Shared.DataFlow
 				}
 			}
 
-			// TODO: How to get this to work - without the '!' at the end this complains that default can return null.
-			// But how does this work for HashSet<T>? That will return null from Current in reality as well... 
-			// It seems that the nullability is not propagated "inside" HashSet (since that one is implemented with TValue being nullable)
-			public TValue Current => (_enumerator is not null
+			public TValue Current => _enumerator is not null
 				? _enumerator.Current
-				: (_state == 1 ? (TValue) _value! : default))!;
+				: (_state == 1 ? (TValue) _value! : default!);
 
 			object? IEnumerator.Current => Current;
 

--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -39,7 +39,7 @@ namespace ILLink.Shared.DataFlow
 				_state = 0;
 				if (values is EnumerableValues valuesSet) {
 					_enumerator = valuesSet.GetEnumerator ();
-					_value = default (TValue);
+					_value = null;
 				} else {
 					_enumerator = null;
 					_value = values;

--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -87,7 +87,7 @@ namespace ILLink.Shared.DataFlow
 		// Cases where there are multiple values stored are relatively very rare.
 		//   null - no values (empty set)
 		//   TValue - single value itself
-		//   SealedHashSet typed object - multiple values, stored in the hashset
+		//   EnumerableValues typed object - multiple values, stored in the hashset
 		readonly object? _values;
 
 		public ValueSet (TValue value) => _values = value;

--- a/src/ILLink.Shared/DataFlow/ValueSetLattice.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSetLattice.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 
 namespace ILLink.Shared.DataFlow
 {
@@ -12,16 +11,6 @@ namespace ILLink.Shared.DataFlow
 	{
 		public ValueSet<TValue> Top => default;
 
-		public ValueSet<TValue> Meet (ValueSet<TValue> left, ValueSet<TValue> right)
-		{
-			if (left.Values == null)
-				return right;
-			if (right.Values == null)
-				return left;
-
-			var values = new HashSet<TValue> (left.Values);
-			values.UnionWith (right.Values);
-			return new ValueSet<TValue> (values);
-		}
+		public ValueSet<TValue> Meet (ValueSet<TValue> left, ValueSet<TValue> right) => ValueSet<TValue>.Meet (left, right);
 	}
 }


### PR DESCRIPTION
The idea is simple, store only a single object field.
If the field is null, the set is empty.
If the field is a HashSet, then it contains multiple values in that hashset.
If the field is TValue, then it set contains single value - that value.

I probably went a bit overboard on optimizations here, but I wanted to try what it takes to implement a good collection class. The result should not allocate at all when "Foreached" over if it contains no or single value (by far the most common case).

~~Unfortunately it still has to box the value. Maybe we should store two fields to avoid boxing by adding a cost of a single pointer field.~~
I just realized that all our uses cases will store reference types as values (`SingleValue` is a record class, `ValueNode` in the linker currently is just a normal class). This means that when a single value is stored the ValueSet will have the same memory and GC footprint as a direct reference to the value.