### PR TITLE
[feature/damAnalyzer] Change linker dataflow to use ValueSet/MultiValue

### DIFF
--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -93,7 +93,7 @@ namespace ILLink.Shared.DataFlow
 
 		ValueSet (EnumerableValues values) => _values = values;
 
-		public static implicit operator ValueSet<TValue>(TValue value) => new (value);
+		public static implicit operator ValueSet<TValue> (TValue value) => new (value);
 
 		public override bool Equals (object? obj) => obj is ValueSet<TValue> other && Equals (other);
 
@@ -162,7 +162,7 @@ namespace ILLink.Shared.DataFlow
 			return new ValueSet<TValue> (values);
 		}
 
-		public bool IsEmpty () => Values == null || Values.Count == 0;
+		public bool IsEmpty () => _values == null;
 
 		public override string ToString ()
 		{

--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -93,6 +93,8 @@ namespace ILLink.Shared.DataFlow
 
 		ValueSet (EnumerableValues values) => _values = values;
 
+		public static implicit operator ValueSet<TValue>(TValue value) => new (value);
+
 		public override bool Equals (object? obj) => obj is ValueSet<TValue> other && Equals (other);
 
 		public bool Equals (ValueSet<TValue> other)
@@ -159,6 +161,8 @@ namespace ILLink.Shared.DataFlow
 			values.UnionWith (right);
 			return new ValueSet<TValue> (values);
 		}
+
+		public bool IsEmpty () => Values == null || Values.Count == 0;
 
 		public override string ToString ()
 		{

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -47,7 +47,7 @@ namespace Mono.Linker.Dataflow
 	abstract partial class MethodBodyScanner
 	{
 		protected readonly LinkContext _context;
-		static ValueSetLattice<ValueNode> MultiValueLattice => default;
+		protected static ValueSetLattice<ValueNode> MultiValueLattice => default;
 
 		protected MethodBodyScanner (LinkContext context)
 		{

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -4,9 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ILLink.Shared.DataFlow;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;
+
+using MultiValue = ILLink.Shared.DataFlow.ValueSet<Mono.Linker.Dataflow.ValueNode>;
 
 namespace Mono.Linker.Dataflow
 {
@@ -15,14 +18,26 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	readonly struct StackSlot
 	{
-		public ValueNode? Value { get; }
+		public MultiValue Value { get; }
 
 		/// <summary>
 		/// True if the value is on the stack as a byref
 		/// </summary>
 		public bool IsByRef { get; }
 
-		public StackSlot (ValueNode? value, bool isByRef = false)
+		public StackSlot ()
+		{
+			Value = new MultiValue (UnknownValue.Instance);
+			IsByRef = false;
+		}
+
+		public StackSlot (ValueNode value, bool isByRef = false)
+		{
+			Value = new MultiValue (value);
+			IsByRef = isByRef;
+		}
+
+		public StackSlot (MultiValue value, bool isByRef = false)
 		{
 			Value = value;
 			IsByRef = isByRef;
@@ -32,13 +47,14 @@ namespace Mono.Linker.Dataflow
 	abstract partial class MethodBodyScanner
 	{
 		protected readonly LinkContext _context;
+		static ValueSetLattice<ValueNode> MultiValueLattice => default;
 
 		protected MethodBodyScanner (LinkContext context)
 		{
 			this._context = context;
 		}
 
-		internal ValueNode? MethodReturnValue { private set; get; }
+		internal MultiValue MethodReturnValue { private set; get; }
 
 		protected virtual void WarnAboutInvalidILInMethod (MethodBody method, int ilOffset)
 		{
@@ -83,16 +99,7 @@ namespace Mono.Linker.Dataflow
 
 		private static StackSlot MergeStackElement (StackSlot a, StackSlot b)
 		{
-			StackSlot mergedSlot;
-			if (b.Value == null) {
-				mergedSlot = a;
-			} else if (a.Value == null) {
-				mergedSlot = b;
-			} else {
-				mergedSlot = new StackSlot (MergePointValue.MergeValues (a.Value, b.Value));
-			}
-
-			return mergedSlot;
+			return new StackSlot (MultiValueLattice.Meet (a.Value, b.Value));
 		}
 
 		// Merge stacks together. This may return the first stack, the stack length must be the same for the two stacks.
@@ -174,7 +181,7 @@ namespace Mono.Linker.Dataflow
 
 		private static void StoreMethodLocalValue<KeyType> (
 			Dictionary<KeyType, ValueBasicBlockPair> valueCollection,
-			ValueNode? valueToStore,
+			in MultiValue valueToStore,
 			KeyType collectionKey,
 			int curBasicBlock,
 			int? maxTrackedValues = null)
@@ -192,7 +199,7 @@ namespace Mono.Linker.Dataflow
 					// If the previous value came from a previous basic block, then some other use of 
 					// the local could see the previous value, so we must merge the new value with the 
 					// old value.
-					newValue.Value = MergePointValue.MergeValues (existingValue.Value, valueToStore);
+					newValue.Value = MultiValueLattice.Meet (existingValue.Value, valueToStore);
 				}
 				valueCollection[collectionKey] = newValue;
 			} else if (maxTrackedValues == null || valueCollection.Count < maxTrackedValues) {
@@ -215,7 +222,7 @@ namespace Mono.Linker.Dataflow
 
 			BasicBlockIterator blockIterator = new BasicBlockIterator (methodBody);
 
-			MethodReturnValue = null;
+			MethodReturnValue = new ();
 			foreach (Instruction operation in methodBody.Instructions) {
 				int curBasicBlock = blockIterator.MoveNext (operation);
 
@@ -426,7 +433,7 @@ namespace Mono.Linker.Dataflow
 
 				case Code.Newarr: {
 						StackSlot count = PopUnknown (currentStack, 1, methodBody, operation.Offset);
-						currentStack.Push (new StackSlot (new ArrayValue (count.Value, (TypeReference) operation.Operand)));
+						currentStack.Push (new StackSlot (ArrayValue.Create (count.Value, (TypeReference) operation.Operand)));
 					}
 					break;
 
@@ -575,7 +582,7 @@ namespace Mono.Linker.Dataflow
 						}
 						if (hasReturnValue) {
 							StackSlot retValue = PopUnknown (currentStack, 1, methodBody, operation.Offset);
-							MethodReturnValue = MergePointValue.MergeValues (MethodReturnValue, retValue.Value);
+							MethodReturnValue = MultiValueLattice.Meet (MethodReturnValue, retValue.Value);
 						}
 						ClearStack (ref currentStack);
 						break;
@@ -705,14 +712,10 @@ namespace Mono.Linker.Dataflow
 			bool isByRef = operation.OpCode.Code == Code.Ldloca || operation.OpCode.Code == Code.Ldloca_S
 				|| localDef.VariableType.IsByRefOrPointer ();
 
-			ValueBasicBlockPair localValue;
-			locals.TryGetValue (localDef, out localValue);
-			if (localValue.Value != null) {
-				ValueNode valueToPush = localValue.Value;
-				currentStack.Push (new StackSlot (valueToPush, isByRef));
-			} else {
-				currentStack.Push (new StackSlot (null, isByRef));
-			}
+			if (!locals.TryGetValue (localDef, out ValueBasicBlockPair localValue))
+				currentStack.Push (new StackSlot (UnknownValue.Instance, isByRef));
+			else
+				currentStack.Push (new StackSlot (localValue.Value, isByRef));
 		}
 
 		void ScanLdtoken (Instruction operation, Stack<StackSlot> currentStack)
@@ -767,7 +770,7 @@ namespace Mono.Linker.Dataflow
 			StackSlot valueToStore = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 			StackSlot destination = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 
-			foreach (var uniqueDestination in destination.Value.UniqueValues ()) {
+			foreach (var uniqueDestination in destination.Value) {
 				if (uniqueDestination.Kind == ValueNodeKind.LoadField) {
 					HandleStoreField (methodBody.Method, ((LoadFieldValue) uniqueDestination).Field, operation, valueToStore.Value);
 				} else if (uniqueDestination.Kind == ValueNodeKind.MethodParameter) {
@@ -777,7 +780,7 @@ namespace Mono.Linker.Dataflow
 
 		}
 
-		protected abstract ValueNode GetFieldValue (MethodDefinition method, FieldDefinition field);
+		protected abstract MultiValue GetFieldValue (MethodDefinition method, FieldDefinition field);
 
 		private void ScanLdfld (
 			Instruction operation,
@@ -801,11 +804,11 @@ namespace Mono.Linker.Dataflow
 			PushUnknown (currentStack);
 		}
 
-		protected virtual void HandleStoreField (MethodDefinition method, FieldDefinition field, Instruction operation, ValueNode? valueToStore)
+		protected virtual void HandleStoreField (MethodDefinition method, FieldDefinition field, Instruction operation, MultiValue valueToStore)
 		{
 		}
 
-		protected virtual void HandleStoreParameter (MethodDefinition method, int index, Instruction operation, ValueNode? valueToStore)
+		protected virtual void HandleStoreParameter (MethodDefinition method, int index, Instruction operation, MultiValue valueToStore)
 		{
 		}
 
@@ -878,7 +881,7 @@ namespace Mono.Linker.Dataflow
 			ValueNodeList methodParams = PopCallArguments (currentStack, calledMethod, callingMethodBody, isNewObj,
 														   operation.Offset, out newObjValue);
 
-			ValueNode? methodReturnValue;
+			MultiValue methodReturnValue;
 			bool handledFunction = HandleCall (
 				callingMethodBody,
 				calledMethod,
@@ -900,12 +903,14 @@ namespace Mono.Linker.Dataflow
 				}
 			}
 
-			if (methodReturnValue != null)
+			if (!methodReturnValue.IsEmpty ())
 				currentStack.Push (new StackSlot (methodReturnValue, calledMethod.ReturnType.IsByRefOrPointer ()));
 
 			foreach (var param in methodParams) {
-				if (param is ArrayValue arr) {
-					MarkArrayValuesAsUnknown (arr, curBasicBlock);
+				foreach (var v in param) {
+					if (v is ArrayValue arr) {
+						MarkArrayValuesAsUnknown (arr, curBasicBlock);
+					}
 				}
 			}
 		}
@@ -934,7 +939,7 @@ namespace Mono.Linker.Dataflow
 			MethodReference calledMethod,
 			Instruction operation,
 			ValueNodeList methodParams,
-			out ValueNode? methodReturnValue);
+			out MultiValue methodReturnValue);
 
 		// Limit tracking array values to 32 values for performance reasons. There are many arrays much longer than 32 elements in .NET, but the interesting ones for the linker are nearly always less than 32 elements.
 		private const int MaxTrackedArrayValues = 32;
@@ -959,7 +964,7 @@ namespace Mono.Linker.Dataflow
 			StackSlot indexToStoreAt = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 			StackSlot arrayToStoreIn = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 			int? indexToStoreAtInt = indexToStoreAt.Value.AsConstInt ();
-			foreach (var array in arrayToStoreIn.Value.UniqueValues ()) {
+			foreach (var array in arrayToStoreIn.Value) {
 				if (array is ArrayValue arrValue) {
 					if (indexToStoreAtInt == null) {
 						MarkArrayValuesAsUnknown (arrValue, curBasicBlock);
@@ -979,7 +984,7 @@ namespace Mono.Linker.Dataflow
 		{
 			StackSlot indexToLoadFrom = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 			StackSlot arrayToLoadFrom = PopUnknown (currentStack, 1, methodBody, operation.Offset);
-			if (arrayToLoadFrom.Value is not ArrayValue arr) {
+			if (arrayToLoadFrom.Value.Count () != 1 || arrayToLoadFrom.Value.Single () is not ArrayValue arr) {
 				PushUnknown (currentStack);
 				return;
 			}
@@ -994,15 +999,8 @@ namespace Mono.Linker.Dataflow
 				return;
 			}
 
-
-			ValueBasicBlockPair arrayIndexValue;
-			arr.IndexValues.TryGetValue (index.Value, out arrayIndexValue);
-			if (arrayIndexValue.Value != null) {
-				ValueNode valueToPush = arrayIndexValue.Value;
-				currentStack.Push (new StackSlot (valueToPush, isByRef));
-			} else {
-				currentStack.Push (new StackSlot (null, isByRef));
-			}
+			arr.IndexValues.TryGetValue (index.Value, out ValueBasicBlockPair arrayIndexValue);
+			currentStack.Push (new StackSlot (arrayIndexValue.Value, isByRef));
 		}
 	}
 }

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -918,7 +918,7 @@ namespace Mono.Linker.Dataflow
 							if (value is SystemTypeValue systemTypeValue) {
 								foreach (var stringParam in methodParams[2]) {
 									if (stringParam is KnownStringValue stringValue) {
-										BindingFlags bindingFlags = methodParams[0].AsSingleValue()?.Kind == ValueNodeKind.Null ? BindingFlags.Static : BindingFlags.Default;
+										BindingFlags bindingFlags = methodParams[0].AsSingleValue ()?.Kind == ValueNodeKind.Null ? BindingFlags.Static : BindingFlags.Default;
 										if (fieldOrPropertyInstrinsic == IntrinsicId.Expression_Property) {
 											MarkPropertiesOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, filter: p => p.Name == stringValue.Contents, bindingFlags);
 										} else {
@@ -1870,7 +1870,7 @@ namespace Mono.Linker.Dataflow
 				}
 				bool allIndicesKnown = true;
 				for (int i = 0; i < size.Value; i++) {
-					if (!array.IndexValues.TryGetValue (i, out ValueBasicBlockPair value) || value.Value.IsEmpty () || value.Value.AsSingleValue() is { Kind: ValueNodeKind.Unknown }) {
+					if (!array.IndexValues.TryGetValue (i, out ValueBasicBlockPair value) || value.Value.IsEmpty () || value.Value.AsSingleValue () is { Kind: ValueNodeKind.Unknown }) {
 						allIndicesKnown = false;
 						break;
 					}

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -21,7 +21,6 @@ namespace Mono.Linker.Dataflow
 	{
 		readonly MarkStep _markStep;
 		readonly MarkScopeStack _scopeStack;
-		static ValueSetLattice<ValueNode> MultiValueLattice => default;
 
 		public static bool RequiresReflectionMethodBodyScannerForCallSite (LinkContext context, MethodReference calledMethod)
 		{
@@ -196,7 +195,7 @@ namespace Mono.Linker.Dataflow
 		{
 			switch (field.Name) {
 			case "EmptyTypes" when field.DeclaringType.IsTypeOf ("System", "Type"): {
-					return ArrayValue.Create (new ConstIntValue (0), field.DeclaringType);
+					return ArrayValue.Create (0, field.DeclaringType);
 				}
 			case "Empty" when field.DeclaringType.IsTypeOf ("System", "String"): {
 					return new KnownStringValue (string.Empty);
@@ -673,7 +672,7 @@ namespace Mono.Linker.Dataflow
 					break;
 
 				case IntrinsicId.Array_Empty: {
-						methodReturnValue = ArrayValue.Create (new ConstIntValue (0), ((GenericInstanceMethod) calledMethod).GenericArguments[0]);
+						methodReturnValue = ArrayValue.Create (0, ((GenericInstanceMethod) calledMethod).GenericArguments[0]);
 					}
 					break;
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -6,11 +6,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared;
+using ILLink.Shared.DataFlow;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker.Steps;
 
 using BindingFlags = System.Reflection.BindingFlags;
+
+using MultiValue = ILLink.Shared.DataFlow.ValueSet<Mono.Linker.Dataflow.ValueNode>;
 
 namespace Mono.Linker.Dataflow
 {
@@ -18,6 +21,7 @@ namespace Mono.Linker.Dataflow
 	{
 		readonly MarkStep _markStep;
 		readonly MarkScopeStack _scopeStack;
+		static ValueSetLattice<ValueNode> MultiValueLattice => default;
 
 		public static bool RequiresReflectionMethodBodyScannerForCallSite (LinkContext context, MethodReference calledMethod)
 		{
@@ -85,11 +89,11 @@ namespace Mono.Linker.Dataflow
 			for (int i = 0; i < method.Parameters.Count; i++) {
 				var annotation = _context.Annotations.FlowAnnotations.GetParameterAnnotation (method, i + paramOffset);
 				if (annotation != DynamicallyAccessedMemberTypes.None) {
-					ValueNode valueNode = GetValueNodeForCustomAttributeArgument (arguments[i]);
+					MultiValue value = GetValueNodeForCustomAttributeArgument (arguments[i]);
 					var methodParameter = method.Parameters[i];
 					var reflectionContext = new ReflectionPatternContext (_context, true, _scopeStack.CurrentScope.Origin, methodParameter);
 					reflectionContext.AnalyzingPattern ();
-					RequireDynamicallyAccessedMembers (ref reflectionContext, annotation, valueNode, methodParameter);
+					RequireDynamicallyAccessedMembers (ref reflectionContext, annotation, value, methodParameter);
 					reflectionContext.Dispose ();
 				}
 			}
@@ -100,14 +104,14 @@ namespace Mono.Linker.Dataflow
 			var annotation = _context.Annotations.FlowAnnotations.GetFieldAnnotation (field);
 			Debug.Assert (annotation != DynamicallyAccessedMemberTypes.None);
 
-			ValueNode valueNode = GetValueNodeForCustomAttributeArgument (value);
+			MultiValue valueNode = GetValueNodeForCustomAttributeArgument (value);
 			var reflectionContext = new ReflectionPatternContext (_context, true, _scopeStack.CurrentScope.Origin, field);
 			reflectionContext.AnalyzingPattern ();
 			RequireDynamicallyAccessedMembers (ref reflectionContext, annotation, valueNode, field);
 			reflectionContext.Dispose ();
 		}
 
-		ValueNode GetValueNodeForCustomAttributeArgument (CustomAttributeArgument argument)
+		MultiValue GetValueNodeForCustomAttributeArgument (CustomAttributeArgument argument)
 		{
 			ValueNode valueNode;
 			if (argument.Type.Name == "Type") {
@@ -132,7 +136,7 @@ namespace Mono.Linker.Dataflow
 			var annotation = _context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter);
 			Debug.Assert (annotation != DynamicallyAccessedMemberTypes.None);
 
-			ValueNode valueNode = GetTypeValueNodeFromGenericArgument (genericArgument);
+			MultiValue valueNode = GetTypeValueNodeFromGenericArgument (genericArgument);
 			var currentScopeOrigin = _scopeStack.CurrentScope.Origin;
 
 			var reflectionContext = new ReflectionPatternContext (_context, ShouldEnableReflectionPatternReporting (), currentScopeOrigin, genericParameter);
@@ -141,7 +145,7 @@ namespace Mono.Linker.Dataflow
 			reflectionContext.Dispose ();
 		}
 
-		ValueNode GetTypeValueNodeFromGenericArgument (TypeReference genericArgument)
+		MultiValue GetTypeValueNodeFromGenericArgument (TypeReference genericArgument)
 		{
 			if (genericArgument is GenericParameter inputGenericParameter) {
 				// Technically this should be a new value node type as it's not a System.Type instance representation, but just the generic parameter
@@ -188,11 +192,11 @@ namespace Mono.Linker.Dataflow
 			return new MethodParameterValue (staticType, parameterIndex, memberTypes, DiagnosticUtilities.GetMethodParameterFromIndex (method, parameterIndex));
 		}
 
-		protected override ValueNode GetFieldValue (MethodDefinition method, FieldDefinition field)
+		protected override MultiValue GetFieldValue (MethodDefinition method, FieldDefinition field)
 		{
 			switch (field.Name) {
 			case "EmptyTypes" when field.DeclaringType.IsTypeOf ("System", "Type"): {
-					return new ArrayValue (new ConstIntValue (0), field.DeclaringType);
+					return ArrayValue.Create (new ConstIntValue (0), field.DeclaringType);
 				}
 			case "Empty" when field.DeclaringType.IsTypeOf ("System", "String"): {
 					return new KnownStringValue (string.Empty);
@@ -205,7 +209,7 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
-		protected override void HandleStoreField (MethodDefinition method, FieldDefinition field, Instruction operation, ValueNode? valueToStore)
+		protected override void HandleStoreField (MethodDefinition method, FieldDefinition field, Instruction operation, MultiValue valueToStore)
 		{
 			var requiredMemberTypes = _context.Annotations.FlowAnnotations.GetFieldAnnotation (field);
 			if (requiredMemberTypes != 0) {
@@ -217,7 +221,7 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
-		protected override void HandleStoreParameter (MethodDefinition method, int index, Instruction operation, ValueNode? valueToStore)
+		protected override void HandleStoreParameter (MethodDefinition method, int index, Instruction operation, MultiValue valueToStore)
 		{
 			var requiredMemberTypes = _context.Annotations.FlowAnnotations.GetParameterAnnotation (method, index);
 			if (requiredMemberTypes != 0) {
@@ -615,9 +619,9 @@ namespace Mono.Linker.Dataflow
 			};
 		}
 
-		public override bool HandleCall (MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams, out ValueNode? methodReturnValue)
+		public override bool HandleCall (MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams, out MultiValue methodReturnValue)
 		{
-			methodReturnValue = null;
+			methodReturnValue = new ();
 
 			var reflectionProcessed = _markStep.ProcessReflectionDependency (callingMethodBody, operation);
 			if (reflectionProcessed)
@@ -669,15 +673,15 @@ namespace Mono.Linker.Dataflow
 					break;
 
 				case IntrinsicId.Array_Empty: {
-						methodReturnValue = new ArrayValue (new ConstIntValue (0), ((GenericInstanceMethod) calledMethod).GenericArguments[0]);
+						methodReturnValue = ArrayValue.Create (new ConstIntValue (0), ((GenericInstanceMethod) calledMethod).GenericArguments[0]);
 					}
 					break;
 
 				case IntrinsicId.Type_GetTypeFromHandle: {
 						// Infrastructure piece to support "typeof(Foo)"
-						if (methodParams[0] is RuntimeTypeHandleValue typeHandle)
+						if (methodParams[0].AsSingleValue () is RuntimeTypeHandleValue typeHandle)
 							methodReturnValue = new SystemTypeValue (typeHandle.TypeRepresented);
-						else if (methodParams[0] is RuntimeTypeHandleForGenericParameterValue typeHandleForGenericParameter) {
+						else if (methodParams[0].AsSingleValue () is RuntimeTypeHandleForGenericParameterValue typeHandleForGenericParameter) {
 							methodReturnValue = new SystemTypeForGenericParameterValue (
 								typeHandleForGenericParameter.GenericParameter,
 								_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (typeHandleForGenericParameter.GenericParameter));
@@ -686,13 +690,13 @@ namespace Mono.Linker.Dataflow
 					break;
 
 				case IntrinsicId.Type_get_TypeHandle: {
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue typeValue)
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new RuntimeTypeHandleValue (typeValue.TypeRepresented));
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, new RuntimeTypeHandleValue (typeValue.TypeRepresented));
 							else if (value == NullValue.Instance)
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, value);
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, value);
 							else
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, UnknownValue.Instance);
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, UnknownValue.Instance);
 						}
 					}
 					break;
@@ -701,7 +705,7 @@ namespace Mono.Linker.Dataflow
 				// System.Reflection.MethodBase.GetMethodFromHandle (RuntimeMethodHandle handle, RuntimeTypeHandle declaringType)
 				case IntrinsicId.MethodBase_GetMethodFromHandle: {
 						// Infrastructure piece to support "ldtoken method -> GetMethodFromHandle"
-						if (methodParams[0] is RuntimeMethodHandleValue methodHandle)
+						if (methodParams[0].AsSingleValue () is RuntimeMethodHandleValue methodHandle)
 							methodReturnValue = new SystemReflectionMethodBaseValue (methodHandle.MethodRepresented);
 					}
 					break;
@@ -713,7 +717,7 @@ namespace Mono.Linker.Dataflow
 				//
 				case IntrinsicId.Type_MakeGenericType: {
 						reflectionContext.AnalyzingPattern ();
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue typeValue) {
 								if (AnalyzeGenericInstantiationTypeArray (methodParams[1], ref reflectionContext, calledMethodDefinition, typeValue.TypeRepresented.GenericParameters)) {
 									reflectionContext.RecordHandledPattern ();
@@ -778,9 +782,9 @@ namespace Mono.Linker.Dataflow
 							_ => throw new InternalErrorException ($"Reflection call '{calledMethod.GetDisplayName ()}' inside '{callingMethodDefinition.GetDisplayName ()}' is of unexpected member type."),
 						};
 
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue systemTypeValue) {
-								foreach (var stringParam in methodParams[1].UniqueValues ()) {
+								foreach (var stringParam in methodParams[1]) {
 									if (stringParam is KnownStringValue stringValue) {
 										switch (getRuntimeMember) {
 										case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeEvent:
@@ -822,10 +826,10 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.AnalyzingPattern ();
 						BindingFlags bindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
 
-						bool hasTypeArguments = (methodParams[2] as ArrayValue)?.Size.AsConstInt () != 0;
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						bool hasTypeArguments = (methodParams[2].AsSingleValue () as ArrayValue)?.Size.AsConstInt () != 0;
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue systemTypeValue) {
-								foreach (var stringParam in methodParams[1].UniqueValues ()) {
+								foreach (var stringParam in methodParams[1]) {
 									if (stringParam is KnownStringValue stringValue) {
 										foreach (var method in systemTypeValue.TypeRepresented.GetMethodsOnTypeHierarchy (_context, m => m.Name == stringValue.Contents, bindingFlags)) {
 											ValidateGenericMethodInstantiation (ref reflectionContext, method, methodParams[2], calledMethod);
@@ -874,7 +878,7 @@ namespace Mono.Linker.Dataflow
 				case IntrinsicId.Expression_Property when calledMethod.HasParameterOfType (1, "System.Reflection", "MethodInfo"): {
 						reflectionContext.AnalyzingPattern ();
 
-						foreach (var value in methodParams[1].UniqueValues ()) {
+						foreach (var value in methodParams[1]) {
 							if (value is SystemReflectionMethodBaseValue methodBaseValue) {
 								// We have one of the accessors for the property. The Expression.Property will in this case search
 								// for the matching PropertyInfo and store that. So to be perfectly correct we need to mark the
@@ -910,11 +914,11 @@ namespace Mono.Linker.Dataflow
 							? DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties
 							: DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields;
 
-						foreach (var value in methodParams[1].UniqueValues ()) {
+						foreach (var value in methodParams[1]) {
 							if (value is SystemTypeValue systemTypeValue) {
-								foreach (var stringParam in methodParams[2].UniqueValues ()) {
+								foreach (var stringParam in methodParams[2]) {
 									if (stringParam is KnownStringValue stringValue) {
-										BindingFlags bindingFlags = methodParams[0]?.Kind == ValueNodeKind.Null ? BindingFlags.Static : BindingFlags.Default;
+										BindingFlags bindingFlags = methodParams[0].AsSingleValue()?.Kind == ValueNodeKind.Null ? BindingFlags.Static : BindingFlags.Default;
 										if (fieldOrPropertyInstrinsic == IntrinsicId.Expression_Property) {
 											MarkPropertiesOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, filter: p => p.Name == stringValue.Contents, bindingFlags);
 										} else {
@@ -941,7 +945,7 @@ namespace Mono.Linker.Dataflow
 				case IntrinsicId.Expression_New: {
 						reflectionContext.AnalyzingPattern ();
 
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue systemTypeValue) {
 								MarkConstructorsOnType (ref reflectionContext, systemTypeValue.TypeRepresented, null, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 								reflectionContext.RecordHandledPattern ();
@@ -958,7 +962,7 @@ namespace Mono.Linker.Dataflow
 				// GetType()
 				//
 				case IntrinsicId.Object_GetType: {
-						foreach (var valueNode in methodParams[0].UniqueValues ()) {
+						foreach (var valueNode in methodParams[0]) {
 							// Note that valueNode can be statically typed in IL as some generic argument type.
 							// For example:
 							//   void Method<T>(T instance) { instance.GetType().... }
@@ -977,7 +981,7 @@ namespace Mono.Linker.Dataflow
 							TypeDefinition? staticType = valueNode.StaticType;
 							if (staticType is null) {
 								// We don't know anything about the type GetType was called on. Track this as a usual result of a method call without any annotations
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethod));
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, CreateMethodReturnValue (calledMethod));
 							} else if (staticType.IsSealed || staticType.IsTypeOf ("System", "Delegate")) {
 								// We can treat this one the same as if it was a typeof() expression
 
@@ -992,7 +996,7 @@ namespace Mono.Linker.Dataflow
 								// This can be seen a little bit as a violation of the annotation, but we already have similar cases
 								// where a parameter is annotated and if something in the method sets a specific known type to it
 								// we will also make it just work, even if the annotation doesn't match the usage.
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (staticType));
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, new SystemTypeValue (staticType));
 							} else {
 								reflectionContext.AnalyzingPattern ();
 
@@ -1008,7 +1012,7 @@ namespace Mono.Linker.Dataflow
 								// Return a value which is "unknown type" with annotation. For now we'll use the return value node
 								// for the method, which means we're loosing the information about which staticType this
 								// started with. For now we don't need it, but we can add it later on.
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethod, annotation));
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, CreateMethodReturnValue (calledMethod, annotation));
 							}
 						}
 					}
@@ -1033,7 +1037,7 @@ namespace Mono.Linker.Dataflow
 							reflectionContext.RecordUnrecognizedPattern (2096, $"Call to '{calledMethod.GetDisplayName ()}' can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types");
 							break;
 						}
-						foreach (var typeNameValue in methodParams[0].UniqueValues ()) {
+						foreach (var typeNameValue in methodParams[0]) {
 							if (typeNameValue is KnownStringValue knownStringValue) {
 								if (!_context.TypeNameResolver.TryResolveTypeName (knownStringValue.Contents, callingMethodDefinition, out TypeReference? foundTypeRef, out AssemblyDefinition? typeAssembly, false)
 									|| ResolveToTypeDefinition (foundTypeRef) is not TypeDefinition foundType) {
@@ -1041,7 +1045,7 @@ namespace Mono.Linker.Dataflow
 									reflectionContext.RecordHandledPattern ();
 								} else {
 									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkTypeVisibleToReflection (foundTypeRef, foundType, new DependencyInfo (DependencyKind.AccessedViaReflection, callingMethodDefinition)));
-									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (foundType));
+									methodReturnValue = MultiValueLattice.Meet (methodReturnValue, new SystemTypeValue (foundType));
 									_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.AccessedViaReflection, foundType));
 								}
 							} else if (typeNameValue == NullValue.Instance) {
@@ -1050,7 +1054,7 @@ namespace Mono.Linker.Dataflow
 								// Propagate the annotation from the type name to the return value. Annotation on a string value will be fullfilled whenever a value is assigned to the string with annotation.
 								// So while we don't know which type it is, we can guarantee that it will fulfill the annotation.
 								reflectionContext.RecordHandledPattern ();
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethodDefinition, valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberTypes));
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, CreateMethodReturnValue (calledMethodDefinition, valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberTypes));
 							} else {
 								reflectionContext.RecordUnrecognizedPattern (2057, $"Unrecognized value passed to the parameter 'typeName' of method '{calledMethod.GetDisplayName ()}'. It's not possible to guarantee the availability of the target type.");
 							}
@@ -1077,15 +1081,15 @@ namespace Mono.Linker.Dataflow
 							bindingFlags = BindingFlags.Public | BindingFlags.Instance;
 
 						int? ctorParameterCount = parameters.Count switch {
-							1 => (methodParams[1] as ArrayValue)?.Size.AsConstInt (),
-							2 => (methodParams[2] as ArrayValue)?.Size.AsConstInt (),
-							4 => (methodParams[3] as ArrayValue)?.Size.AsConstInt (),
-							5 => (methodParams[4] as ArrayValue)?.Size.AsConstInt (),
+							1 => (methodParams[1].AsSingleValue () as ArrayValue)?.Size.AsConstInt (),
+							2 => (methodParams[2].AsSingleValue () as ArrayValue)?.Size.AsConstInt (),
+							4 => (methodParams[3].AsSingleValue () as ArrayValue)?.Size.AsConstInt (),
+							5 => (methodParams[4].AsSingleValue () as ArrayValue)?.Size.AsConstInt (),
 							_ => null,
 						};
 
 						// Go over all types we've seen
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue systemTypeValue) {
 								if (BindingFlagsAreUnsupported (bindingFlags)) {
 									RequireDynamicallyAccessedMembers (ref reflectionContext, DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors, value, calledMethodDefinition);
@@ -1135,9 +1139,9 @@ namespace Mono.Linker.Dataflow
 							// Assume a default value for BindingFlags for methods that don't use BindingFlags as a parameter
 							bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 						var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (bindingFlags);
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue systemTypeValue) {
-								foreach (var stringParam in methodParams[1].UniqueValues ()) {
+								foreach (var stringParam in methodParams[1]) {
 									if (stringParam is KnownStringValue stringValue) {
 										if (BindingFlagsAreUnsupported (bindingFlags)) {
 											RequireDynamicallyAccessedMembers (ref reflectionContext, DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods, value, calledMethodDefinition);
@@ -1175,9 +1179,9 @@ namespace Mono.Linker.Dataflow
 
 						var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForNestedTypes (bindingFlags);
 						bool everyParentTypeHasAll = true;
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue systemTypeValue) {
-								foreach (var stringParam in methodParams[1].UniqueValues ()) {
+								foreach (var stringParam in methodParams[1]) {
 									if (stringParam is KnownStringValue stringValue) {
 										if (BindingFlagsAreUnsupported (bindingFlags))
 											// We have chosen not to populate the methodReturnValue for now
@@ -1187,7 +1191,7 @@ namespace Mono.Linker.Dataflow
 
 											if (matchingNestedTypes != null) {
 												for (int i = 0; i < matchingNestedTypes.Length; i++)
-													methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (matchingNestedTypes[i]));
+													methodReturnValue = MultiValueLattice.Meet (methodReturnValue, new SystemTypeValue (matchingNestedTypes[i]));
 											}
 										}
 										reflectionContext.RecordHandledPattern ();
@@ -1219,7 +1223,7 @@ namespace Mono.Linker.Dataflow
 						// the returned type (the nested type) with DynamicallyAccessedMemberTypes.All as well.
 						// Note it's OK to blindly overwrite any potential annotation on the return value from the method definition
 						// since DynamicallyAccessedMemberTypes.All is a superset of any other annotation.
-						if (everyParentTypeHasAll && methodReturnValue == null)
+						if (everyParentTypeHasAll && methodReturnValue.IsEmpty ())
 							methodReturnValue = CreateMethodReturnValue (calledMethodDefinition, DynamicallyAccessedMemberTypes.All);
 					}
 					break;
@@ -1228,18 +1232,18 @@ namespace Mono.Linker.Dataflow
 				// AssemblyQualifiedName
 				//
 				case IntrinsicId.Type_get_AssemblyQualifiedName: {
-						ValueNode? transformedResult = null;
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						MultiValue transformedResult = new ();
+						foreach (var value in methodParams[0]) {
 							if (value is LeafValueWithDynamicallyAccessedMemberNode dynamicallyAccessedThing) {
 								var annotatedString = new AnnotatedStringValue (dynamicallyAccessedThing.SourceContext, dynamicallyAccessedThing.DynamicallyAccessedMemberTypes);
-								transformedResult = MergePointValue.MergeValues (transformedResult, annotatedString);
+								transformedResult = MultiValueLattice.Meet (transformedResult, annotatedString);
 							} else {
-								transformedResult = null;
+								transformedResult = new ();
 								break;
 							}
 						}
 
-						if (transformedResult != null) {
+						if (!transformedResult.IsEmpty ()) {
 							methodReturnValue = transformedResult;
 						}
 					}
@@ -1258,7 +1262,7 @@ namespace Mono.Linker.Dataflow
 				// Type.BaseType
 				//
 				case IntrinsicId.Type_get_BaseType: {
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is LeafValueWithDynamicallyAccessedMemberNode dynamicallyAccessedMemberNode) {
 								DynamicallyAccessedMemberTypes propagatedMemberTypes = DynamicallyAccessedMemberTypes.None;
 								if (dynamicallyAccessedMemberNode.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.All)
@@ -1283,18 +1287,18 @@ namespace Mono.Linker.Dataflow
 										propagatedMemberTypes |= DynamicallyAccessedMemberTypes.PublicProperties;
 								}
 
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethod, propagatedMemberTypes));
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, CreateMethodReturnValue (calledMethod, propagatedMemberTypes));
 							} else if (value is SystemTypeValue systemTypeValue) {
 								if (systemTypeValue.TypeRepresented.BaseType is TypeReference baseTypeRef && _context.TryResolve (baseTypeRef) is TypeDefinition baseTypeDefinition)
-									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (baseTypeDefinition));
+									methodReturnValue = MultiValueLattice.Meet (methodReturnValue, new SystemTypeValue (baseTypeDefinition));
 								else
-									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethod));
+									methodReturnValue = MultiValueLattice.Meet (methodReturnValue, CreateMethodReturnValue (calledMethod));
 							} else if (value == NullValue.Instance) {
 								// Ignore nulls - null.BaseType will fail at runtime, but it has no effect on static analysis
 								continue;
 							} else {
 								// Unknown input - propagate a return value without any annotation - we know it's a Type but we know nothing about it
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethod));
+								methodReturnValue = MultiValueLattice.Meet (methodReturnValue, CreateMethodReturnValue (calledMethod));
 							}
 						}
 					}
@@ -1334,9 +1338,9 @@ namespace Mono.Linker.Dataflow
 							_ => throw new ArgumentException ($"Reflection call '{calledMethod.GetDisplayName ()}' inside '{callingMethodDefinition.GetDisplayName ()}' is of unexpected member type."),
 						};
 
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue systemTypeValue) {
-								foreach (var stringParam in methodParams[1].UniqueValues ()) {
+								foreach (var stringParam in methodParams[1]) {
 									if (stringParam is KnownStringValue stringValue) {
 										switch (fieldPropertyOrEvent) {
 										case IntrinsicId.Type_GetEvent:
@@ -1422,7 +1426,7 @@ namespace Mono.Linker.Dataflow
 							};
 						}
 
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							RequireDynamicallyAccessedMembers (ref reflectionContext, memberTypes, value, calledMethodDefinition);
 						}
 					}
@@ -1460,7 +1464,7 @@ namespace Mono.Linker.Dataflow
 							requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForMembers (bindingFlags);
 						}
 						// Go over all types we've seen
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							// Mark based on bitfield requirements
 							RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberTypes, value, calledMethodDefinition);
 						}
@@ -1474,7 +1478,7 @@ namespace Mono.Linker.Dataflow
 				case IntrinsicId.Type_GetInterface: {
 						reflectionContext.AnalyzingPattern ();
 
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							// For now no support for marking a single interface by name. We would have to correctly support
 							// mangled names for generics to do that correctly. Simply mark all interfaces on the type for now.
 
@@ -1489,7 +1493,7 @@ namespace Mono.Linker.Dataflow
 								&& annotatedNode.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.All)
 								returnMemberTypes = DynamicallyAccessedMemberTypes.All;
 
-							methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethod, returnMemberTypes));
+							methodReturnValue = MultiValueLattice.Meet (methodReturnValue, CreateMethodReturnValue (calledMethod, returnMemberTypes));
 						}
 					}
 					break;
@@ -1514,10 +1518,7 @@ namespace Mono.Linker.Dataflow
 						if (parameters.Count > 1) {
 							if (parameters[1].ParameterType.MetadataType == MetadataType.Boolean) {
 								// The overload that takes a "nonPublic" bool
-								bool nonPublic = true;
-								if (methodParams[1] is ConstIntValue constInt) {
-									nonPublic = constInt.Value != 0;
-								}
+								bool nonPublic = methodParams[1].AsConstInt () != 0;
 
 								if (nonPublic)
 									bindingFlags |= BindingFlags.NonPublic | BindingFlags.Public;
@@ -1529,10 +1530,10 @@ namespace Mono.Linker.Dataflow
 								int argsParam = parameters.Count == 2 || parameters.Count == 3 ? 1 : 3;
 
 								if (methodParams.Count > argsParam) {
-									if (methodParams[argsParam] is ArrayValue arrayValue &&
+									if (methodParams[argsParam].AsSingleValue () is ArrayValue arrayValue &&
 										arrayValue.Size.AsConstInt () != null)
 										ctorParameterCount = arrayValue.Size.AsConstInt ();
-									else if (methodParams[argsParam] is NullValue)
+									else if (methodParams[argsParam].AsSingleValue () is NullValue)
 										ctorParameterCount = 0;
 								}
 
@@ -1552,7 +1553,7 @@ namespace Mono.Linker.Dataflow
 						}
 
 						// Go over all types we've seen
-						foreach (var value in methodParams[0].UniqueValues ()) {
+						foreach (var value in methodParams[0]) {
 							if (value is SystemTypeValue systemTypeValue) {
 								// Special case known type values as we can do better by applying exact binding flags and parameter count.
 								MarkConstructorsOnType (ref reflectionContext, systemTypeValue.TypeRepresented,
@@ -1667,7 +1668,7 @@ namespace Mono.Linker.Dataflow
 				//
 				case IntrinsicId.RuntimeHelpers_RunClassConstructor: {
 						reflectionContext.AnalyzingPattern ();
-						foreach (var typeHandleValue in methodParams[0].UniqueValues ()) {
+						foreach (var typeHandleValue in methodParams[0]) {
 							if (typeHandleValue is RuntimeTypeHandleValue runtimeTypeHandleValue) {
 								_markStep.MarkStaticConstructorVisibleToReflection (runtimeTypeHandleValue.TypeRepresented, new DependencyInfo (DependencyKind.AccessedViaReflection, reflectionContext.Source));
 								reflectionContext.RecordHandledPattern ();
@@ -1688,7 +1689,7 @@ namespace Mono.Linker.Dataflow
 				case IntrinsicId.MethodInfo_MakeGenericMethod: {
 						reflectionContext.AnalyzingPattern ();
 
-						foreach (var methodValue in methodParams[0].UniqueValues ()) {
+						foreach (var methodValue in methodParams[0]) {
 							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
 								ValidateGenericMethodInstantiation (ref reflectionContext, methodBaseValue.MethodRepresented, methodParams[1], calledMethod);
 							} else if (methodValue == NullValue.Instance) {
@@ -1762,7 +1763,7 @@ namespace Mono.Linker.Dataflow
 			// If we get here, we handled this as an intrinsic.  As a convenience, if the code above
 			// didn't set the return value (and the method has a return value), we will set it to be an
 			// unknown value with the return type of the method.
-			if (methodReturnValue == null) {
+			if (methodReturnValue.IsEmpty ()) {
 				if (GetReturnTypeWithoutModifiers (calledMethod.ReturnType).MetadataType != MetadataType.Void) {
 					methodReturnValue = CreateMethodReturnValue (calledMethodDefinition, returnValueDynamicallyAccessedMemberTypes);
 				}
@@ -1770,7 +1771,7 @@ namespace Mono.Linker.Dataflow
 
 			// Validate that the return value has the correct annotations as per the method return value annotations
 			if (returnValueDynamicallyAccessedMemberTypes != 0) {
-				foreach (var uniqueValue in methodReturnValue.UniqueValues ()) {
+				foreach (var uniqueValue in methodReturnValue) {
 					if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberTypes) {
 						if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (returnValueDynamicallyAccessedMemberTypes))
 							throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
@@ -1844,7 +1845,7 @@ namespace Mono.Linker.Dataflow
 			return false;
 		}
 
-		bool AnalyzeGenericInstantiationTypeArray (ValueNode? arrayParam, ref ReflectionPatternContext reflectionContext, MethodReference calledMethod, IList<GenericParameter> genericParameters)
+		bool AnalyzeGenericInstantiationTypeArray (in MultiValue arrayParam, ref ReflectionPatternContext reflectionContext, MethodReference calledMethod, IList<GenericParameter> genericParameters)
 		{
 			bool hasRequirements = false;
 			foreach (var genericParameter in genericParameters) {
@@ -1858,7 +1859,7 @@ namespace Mono.Linker.Dataflow
 			if (!hasRequirements)
 				return true;
 
-			foreach (var typesValue in arrayParam.UniqueValues ()) {
+			foreach (var typesValue in arrayParam) {
 				if (typesValue.Kind != ValueNodeKind.Array) {
 					return false;
 				}
@@ -1869,7 +1870,7 @@ namespace Mono.Linker.Dataflow
 				}
 				bool allIndicesKnown = true;
 				for (int i = 0; i < size.Value; i++) {
-					if (!array.IndexValues.TryGetValue (i, out ValueBasicBlockPair value) || value.Value is null or { Kind: ValueNodeKind.Unknown }) {
+					if (!array.IndexValues.TryGetValue (i, out ValueBasicBlockPair value) || value.Value.IsEmpty () || value.Value.AsSingleValue() is { Kind: ValueNodeKind.Unknown }) {
 						allIndicesKnown = false;
 						break;
 					}
@@ -1909,9 +1910,9 @@ namespace Mono.Linker.Dataflow
 
 			int methodParamsOffset = calledMethod.HasImplicitThis () ? 1 : 0;
 
-			foreach (var assemblyNameValue in methodParams[methodParamsOffset].UniqueValues ()) {
+			foreach (var assemblyNameValue in methodParams[methodParamsOffset]) {
 				if (assemblyNameValue is KnownStringValue assemblyNameStringValue) {
-					foreach (var typeNameValue in methodParams[methodParamsOffset + 1].UniqueValues ()) {
+					foreach (var typeNameValue in methodParams[methodParamsOffset + 1]) {
 						if (typeNameValue is KnownStringValue typeNameStringValue) {
 							var resolvedAssembly = _context.TryResolve (assemblyNameStringValue.Contents);
 							if (resolvedAssembly == null) {
@@ -1946,12 +1947,12 @@ namespace Mono.Linker.Dataflow
 			TypeDefinition typeDefinition,
 			string methodName,
 			BindingFlags? bindingFlags,
-			ref ValueNode? methodReturnValue)
+			ref MultiValue methodReturnValue)
 		{
 			bool foundAny = false;
 			foreach (var method in typeDefinition.GetMethodsOnTypeHierarchy (_context, m => m.Name == methodName, bindingFlags)) {
 				MarkMethod (ref reflectionContext, method);
-				methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemReflectionMethodBaseValue (method));
+				methodReturnValue = MultiValueLattice.Meet (methodReturnValue, new SystemReflectionMethodBaseValue (method));
 				foundAny = true;
 			}
 
@@ -1960,13 +1961,13 @@ namespace Mono.Linker.Dataflow
 			// This also prevents warnings in such case, since if we don't set the return value it will be
 			// "unknown" and consumers may warn.
 			if (!foundAny)
-				methodReturnValue = MergePointValue.MergeValues (methodReturnValue, NullValue.Instance);
+				methodReturnValue = MultiValueLattice.Meet (methodReturnValue, NullValue.Instance);
 		}
 
 
-		void RequireDynamicallyAccessedMembers (ref ReflectionPatternContext reflectionContext, DynamicallyAccessedMemberTypes requiredMemberTypes, ValueNode? value, IMetadataTokenProvider targetContext)
+		void RequireDynamicallyAccessedMembers (ref ReflectionPatternContext reflectionContext, DynamicallyAccessedMemberTypes requiredMemberTypes, in MultiValue value, IMetadataTokenProvider targetContext)
 		{
-			foreach (var uniqueValue in value.UniqueValues ()) {
+			foreach (var uniqueValue in value) {
 				if (requiredMemberTypes == DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
 					&& uniqueValue is SystemTypeForGenericParameterValue genericParam
 					&& genericParam.GenericParameter.HasDefaultConstructorConstraint) {
@@ -2085,7 +2086,7 @@ namespace Mono.Linker.Dataflow
 			return args;
 		}
 
-		static BindingFlags? GetBindingFlagsFromValue (ValueNode? parameter) => (BindingFlags?) parameter.AsConstInt ();
+		static BindingFlags? GetBindingFlagsFromValue (in MultiValue parameter) => (BindingFlags?) parameter.AsConstInt ();
 
 		static bool BindingFlagsAreUnsupported (BindingFlags? bindingFlags)
 		{
@@ -2219,7 +2220,7 @@ namespace Mono.Linker.Dataflow
 		void ValidateGenericMethodInstantiation (
 			ref ReflectionPatternContext reflectionContext,
 			MethodDefinition genericMethod,
-			ValueNode? genericParametersArray,
+			in MultiValue genericParametersArray,
 			MethodReference reflectionMethod)
 		{
 			if (!genericMethod.HasGenericParameters) {

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -3,14 +3,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using ILLink.Shared.DataFlow;
 using Mono.Cecil;
+
 using FieldDefinition = Mono.Cecil.FieldDefinition;
 using GenericParameter = Mono.Cecil.GenericParameter;
 using TypeDefinition = Mono.Cecil.TypeDefinition;
+
+using MultiValue = ILLink.Shared.DataFlow.ValueSet<Mono.Linker.Dataflow.ValueNode>;
 
 namespace Mono.Linker.Dataflow
 {
@@ -37,7 +40,6 @@ namespace Mono.Linker.Dataflow
 		SystemTypeForGenericParameter,        // symbolic placeholder for generic parameter
 
 		MergePoint,                     // structural, multiplexer - Values
-		GetTypeFromString,              // structural, could be known value - KnownString
 		Array,                          // structural, could be known value - Array
 
 		LoadField,                      // structural, could be known value - InstanceValue
@@ -74,54 +76,6 @@ namespace Mono.Linker.Dataflow
 		/// </summary>
 		public TypeDefinition? StaticType { get; protected set; }
 
-		/// <summary>
-		/// Allows the enumeration of the direct children of this node.  The ChildCollection struct returned here
-		/// supports 'foreach' without allocation.
-		/// </summary>
-		public ChildCollection Children { get { return new ChildCollection (this); } }
-
-		/// <summary>
-		/// This property allows you to enumerate all 'unique values' represented by a given ValueNode.  The basic idea
-		/// is that there will be no MergePointValues in the returned ValueNodes and all structural operations will be
-		/// applied so that each 'unique value' can be considered on its own without regard to the structure that led to
-		/// it.
-		/// </summary>
-		public UniqueValueCollection UniqueValuesInternal {
-			get {
-				return new UniqueValueCollection (this);
-			}
-		}
-
-		/// <summary>
-		/// This protected method is how nodes implement the UniqueValues property.  It is protected because it returns
-		/// an IEnumerable and we want to avoid allocating an enumerator for the exceedingly common case of there being
-		/// only one value in the enumeration.  The UniqueValueCollection returned by the UniqueValues property handles
-		/// this detail.
-		/// </summary>
-		protected abstract IEnumerable<ValueNode> EvaluateUniqueValues ();
-
-		/// <summary>
-		/// RepresentsExactlyOneValue is used by the UniqueValues property to allow us to bypass allocating an
-		/// enumerator to return just one value.  If a node returns 'true' from RepresentsExactlyOneValue, it must also
-		/// return that one value from GetSingleUniqueValue.  If it always returns 'false', it doesn't need to implement
-		/// GetSingleUniqueValue.
-		/// </summary>
-		protected virtual bool RepresentsExactlyOneValue { get { return false; } }
-
-		/// <summary>
-		/// GetSingleUniqueValue is called if, and only if, RepresentsExactlyOneValue returns true.  It allows us to
-		/// bypass the allocation of an enumerator for the common case of returning exactly one value.
-		/// </summary>
-		protected virtual ValueNode GetSingleUniqueValue ()
-		{
-			// Not implemented because RepresentsExactlyOneValue returns false and, therefore, this method should be
-			// unreachable.
-			throw new NotImplementedException ();
-		}
-
-		protected abstract int NumChildren { get; }
-		protected abstract ValueNode ChildAt (int index);
-
 		public virtual bool Equals (ValueNode? other)
 		{
 			return other != null && this.Kind == other.Kind && this.StaticType == other.StaticType;
@@ -149,177 +103,6 @@ namespace Mono.Linker.Dataflow
 
 			return this.Equals ((ValueNode) other);
 		}
-
-		#region Specialized Collection Nested Types
-		/// <summary>
-		/// ChildCollection struct is used to wrap the operations on a node involving its children.  In particular, the
-		/// struct implements a GetEnumerator method that is used to allow "foreach (ValueNode node in myNode.Children)"
-		/// without heap allocations.
-		/// </summary>
-		public struct ChildCollection : IEnumerable<ValueNode>
-		{
-			/// <summary>
-			/// Enumerator for children of a ValueNode.  Allows foreach(var child in node.Children) to work without
-			/// allocating a heap-based enumerator.
-			/// </summary>
-			public struct Enumerator : IEnumerator<ValueNode>
-			{
-				int _index;
-				readonly ValueNode _parent;
-
-				public Enumerator (ValueNode parent)
-				{
-					_parent = parent;
-					_index = -1;
-				}
-
-				public ValueNode Current { get { return _parent.ChildAt (_index); } }
-
-				object System.Collections.IEnumerator.Current { get { return Current; } }
-
-				public bool MoveNext ()
-				{
-					_index++;
-					return (_parent != null) ? (_index < _parent.NumChildren) : false;
-				}
-
-				public void Reset ()
-				{
-					_index = -1;
-				}
-
-				public void Dispose ()
-				{
-				}
-			}
-
-			readonly ValueNode _parentNode;
-
-			public ChildCollection (ValueNode parentNode) { _parentNode = parentNode; }
-
-			// Used by C# 'foreach', when strongly typed, to avoid allocation.
-			public Enumerator GetEnumerator ()
-			{
-				return new Enumerator (_parentNode);
-			}
-
-			IEnumerator<ValueNode> IEnumerable<ValueNode>.GetEnumerator ()
-			{
-				// note the boxing!
-				return new Enumerator (_parentNode);
-			}
-			System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
-			{
-				// note the boxing!
-				return new Enumerator (_parentNode);
-			}
-
-			public int Count { get { return (_parentNode != null) ? _parentNode.NumChildren : 0; } }
-		}
-
-		/// <summary>
-		/// UniqueValueCollection is used to wrap calls to ValueNode.EvaluateUniqueValues.  If a ValueNode represents
-		/// only one value, then foreach(ValueNode value in node.UniqueValues) will not allocate a heap-based enumerator.
-		///
-		/// This is implented by having each ValueNode tell us whether or not it represents exactly one value or not.
-		/// If it does, we fetch it with ValueNode.GetSingleUniqueValue(), otherwise, we fall back to the usual heap-
-		/// based IEnumerable returned by ValueNode.EvaluateUniqueValues.
-		/// </summary>
-		public struct UniqueValueCollection : IEnumerable<ValueNode>
-		{
-			readonly IEnumerable<ValueNode>? _multiValueEnumerable;
-			readonly ValueNode? _treeNode;
-
-			public UniqueValueCollection (ValueNode node)
-			{
-				if (node.RepresentsExactlyOneValue) {
-					_multiValueEnumerable = null;
-					_treeNode = node;
-				} else {
-					_multiValueEnumerable = node.EvaluateUniqueValues ();
-					_treeNode = null;
-				}
-			}
-
-			public Enumerator GetEnumerator ()
-			{
-				return new Enumerator (_treeNode, _multiValueEnumerable);
-			}
-
-			IEnumerator<ValueNode> IEnumerable<ValueNode>.GetEnumerator ()
-			{
-				if (_multiValueEnumerable != null) {
-					return _multiValueEnumerable.GetEnumerator ();
-				}
-
-				// note the boxing!
-				return GetEnumerator ();
-			}
-
-			System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
-			{
-				if (_multiValueEnumerable != null) {
-					return _multiValueEnumerable.GetEnumerator ();
-				}
-
-				// note the boxing!
-				return GetEnumerator ();
-			}
-
-
-			public struct Enumerator : IEnumerator<ValueNode>
-			{
-				readonly IEnumerator<ValueNode>? _multiValueEnumerator;
-				readonly ValueNode? _singleValueNode;
-				int _index;
-
-				public Enumerator (ValueNode? treeNode, IEnumerable<ValueNode>? multiValueEnumerable)
-				{
-					Debug.Assert (treeNode != null || multiValueEnumerable != null);
-					_singleValueNode = treeNode?.GetSingleUniqueValue ();
-					_multiValueEnumerator = multiValueEnumerable?.GetEnumerator ();
-					_index = -1;
-				}
-
-				public void Reset ()
-				{
-					if (_multiValueEnumerator != null) {
-						_multiValueEnumerator.Reset ();
-						return;
-					}
-
-					_index = -1;
-				}
-
-				public bool MoveNext ()
-				{
-					if (_multiValueEnumerator != null)
-						return _multiValueEnumerator.MoveNext ();
-
-					_index++;
-					return _index == 0;
-				}
-
-				public ValueNode Current {
-					get {
-						if (_multiValueEnumerator != null)
-							return _multiValueEnumerator.Current;
-
-						if (_index == 0)
-							return _singleValueNode!;
-
-						throw new InvalidOperationException ();
-					}
-				}
-
-				object System.Collections.IEnumerator.Current { get { return Current; } }
-
-				public void Dispose ()
-				{
-				}
-			}
-		}
-		#endregion
 	}
 
 	/// <summary>
@@ -332,20 +115,6 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	public abstract class LeafValueNode : ValueNode
 	{
-		protected override int NumChildren { get { return 0; } }
-		protected override ValueNode ChildAt (int index) { throw new InvalidOperationException (); }
-
-		protected override bool RepresentsExactlyOneValue { get { return true; } }
-
-		protected override ValueNode GetSingleUniqueValue () { return this; }
-
-
-		protected override IEnumerable<ValueNode> EvaluateUniqueValues ()
-		{
-			// Leaf values should not represent more than one value.  This method should be unreachable as long as
-			// RepresentsExactlyOneValue returns true.
-			throw new NotImplementedException ();
-		}
 	}
 
 	// These are extension methods because we want to allow the use of them on null 'this' pointers.
@@ -398,25 +167,14 @@ namespace Mono.Linker.Dataflow
 			//
 			// Nodes with children
 			//
-			case ValueNodeKind.MergePoint:
-				foreach (ValueNode val in ((MergePointValue) node).Values) {
-					if (val.DetectCycle (seenNodes, allNodesSeen)) {
-						foundCycle = true;
-					}
-				}
-				break;
-
-			case ValueNodeKind.GetTypeFromString:
-				GetTypeFromStringValue gtfsv = (GetTypeFromStringValue) node;
-				foundCycle = gtfsv.AssemblyIdentity.DetectCycle (seenNodes, allNodesSeen);
-				foundCycle |= gtfsv.NameString.DetectCycle (seenNodes, allNodesSeen);
-				break;
 
 			case ValueNodeKind.Array:
 				ArrayValue av = (ArrayValue) node;
 				foundCycle = av.Size.DetectCycle (seenNodes, allNodesSeen);
 				foreach (ValueBasicBlockPair pair in av.IndexValues.Values) {
-					foundCycle |= pair.Value.DetectCycle (seenNodes, allNodesSeen);
+					foreach (var v in pair.Value) {
+						foundCycle |= v.DetectCycle (seenNodes, allNodesSeen);
+					}
 				}
 				break;
 
@@ -428,19 +186,28 @@ namespace Mono.Linker.Dataflow
 			return foundCycle;
 		}
 
-		public static ValueNode.UniqueValueCollection UniqueValues (this ValueNode? node)
-		{
-			if (node == null)
-				return new ValueNode.UniqueValueCollection (UnknownValue.Instance);
-
-			return node.UniqueValuesInternal;
-		}
-
 		public static int? AsConstInt (this ValueNode? node)
 		{
 			if (node is ConstIntValue constInt)
 				return constInt.Value;
+
 			return null;
+		}
+
+		public static int? AsConstInt (this in MultiValue value)
+		{
+			if (value.AsSingleValue() is ConstIntValue constInt)
+				return constInt.Value;
+
+			return null;
+		}
+
+		public static ValueNode? AsSingleValue (this in MultiValue node)
+		{
+			if (node.Count () != 1)
+				return null;
+
+			return node.Single ();
 		}
 	}
 
@@ -463,31 +230,6 @@ namespace Mono.Linker.Dataflow
 			}
 			sb.Append (")");
 			return sb.ToString ();
-		}
-
-		static string GetIndent (int level)
-		{
-			StringBuilder sb = new StringBuilder (level * 2);
-			for (int i = 0; i < level; i++)
-				sb.Append ("  ");
-			return sb.ToString ();
-		}
-
-		public static void DumpTree (this ValueNode node, System.IO.TextWriter? writer = null, int indentLevel = 0)
-		{
-			if (writer == null)
-				writer = Console.Out;
-
-			writer.Write (GetIndent (indentLevel));
-			if (node == null) {
-				writer.WriteLine ("<null>");
-				return;
-			}
-
-			writer.WriteLine (node);
-			foreach (ValueNode child in node.Children) {
-				child.DumpTree (writer, indentLevel + 1);
-			}
 		}
 	}
 
@@ -932,215 +674,6 @@ namespace Mono.Linker.Dataflow
 	}
 
 	/// <summary>
-	/// A merge point commonly occurs due to control flow in a method body.  It represents a set of values
-	/// from different paths through the method.  It is the reason for EvaluateUniqueValues, which essentially
-	/// provides an enumeration over all the concrete values represented by a given ValueNode after 'erasing'
-	/// the merge point nodes.
-	/// </summary>
-	class MergePointValue : ValueNode
-	{
-		private MergePointValue (ValueNode one, ValueNode two)
-		{
-			Kind = ValueNodeKind.MergePoint;
-			StaticType = null;
-			m_values = new ValueNodeHashSet ();
-
-			if (one.Kind == ValueNodeKind.MergePoint) {
-				MergePointValue mpvOne = (MergePointValue) one;
-				foreach (ValueNode value in mpvOne.Values)
-					m_values.Add (value);
-			} else
-				m_values.Add (one);
-
-			if (two.Kind == ValueNodeKind.MergePoint) {
-				MergePointValue mpvTwo = (MergePointValue) two;
-				foreach (ValueNode value in mpvTwo.Values)
-					m_values.Add (value);
-			} else
-				m_values.Add (two);
-		}
-
-		public MergePointValue ()
-		{
-			Kind = ValueNodeKind.MergePoint;
-			m_values = new ValueNodeHashSet ();
-		}
-
-		public void AddValue (ValueNode node)
-		{
-			// we are mutating our state, so we must invalidate any cached knowledge
-			//InvalidateIsOpen ();
-
-			if (node.Kind == ValueNodeKind.MergePoint) {
-				foreach (ValueNode value in ((MergePointValue) node).Values)
-					m_values.Add (value);
-			} else
-				m_values.Add (node);
-
-#if false
-			if (this.DetectCycle(new HashSet<ValueNode>()))
-			{
-				throw new Exception("Found a cycle");
-			}
-#endif
-		}
-
-		readonly ValueNodeHashSet m_values;
-
-		public ValueNodeHashSet Values { get { return m_values; } }
-
-		protected override int NumChildren { get { return Values.Count; } }
-		protected override ValueNode ChildAt (int index)
-		{
-			if (index < NumChildren)
-				return Values.ElementAt (index);
-			throw new InvalidOperationException ();
-		}
-
-		public static ValueNode? MergeValues (ValueNode? one, ValueNode? two)
-		{
-			if (one == null)
-				return two;
-			else if (two == null)
-				return one;
-			else if (one.Equals (two))
-				return one;
-			else
-				return new MergePointValue (one, two);
-		}
-
-		protected override IEnumerable<ValueNode> EvaluateUniqueValues ()
-		{
-			foreach (ValueNode value in Values) {
-				foreach (ValueNode uniqueValue in value.UniqueValuesInternal) {
-					yield return uniqueValue;
-				}
-			}
-		}
-
-		public override bool Equals (ValueNode? other)
-		{
-			if (!base.Equals (other))
-				return false;
-
-			MergePointValue otherMpv = (MergePointValue) other;
-			if (this.Values.Count != otherMpv.Values.Count)
-				return false;
-
-			foreach (ValueNode value in this.Values) {
-				if (!otherMpv.Values.Contains (value))
-					return false;
-			}
-			return true;
-		}
-
-		public override int GetHashCode ()
-		{
-			return HashCode.Combine (Kind, Values);
-		}
-
-		protected override string NodeToString ()
-		{
-			return ValueNodeDump.ValueNodeToString (this);
-		}
-	}
-
-	delegate TypeDefinition TypeResolver (string assemblyString, string typeString);
-
-	/// <summary>
-	/// The result of a Type.GetType.
-	/// AssemblyIdentity is the scope in which to resolve if the type name string is not assembly-qualified.
-	/// </summary>
-
-#pragma warning disable CA1812 // GetTypeFromStringValue is never instantiated
-	class GetTypeFromStringValue : ValueNode
-	{
-		private readonly TypeResolver _resolver;
-
-		public GetTypeFromStringValue (TypeResolver resolver, ValueNode assemblyIdentity, ValueNode nameString)
-		{
-			_resolver = resolver;
-			Kind = ValueNodeKind.GetTypeFromString;
-
-			// Should be System.Type, but we don't have a use case for it
-			StaticType = null;
-
-			AssemblyIdentity = assemblyIdentity;
-			NameString = nameString;
-		}
-
-		public ValueNode AssemblyIdentity { get; private set; }
-
-		public ValueNode NameString { get; private set; }
-
-		protected override int NumChildren { get { return 2; } }
-		protected override ValueNode ChildAt (int index)
-		{
-			if (index == 0) return AssemblyIdentity;
-			if (index == 1) return NameString;
-			throw new InvalidOperationException ();
-		}
-
-		protected override IEnumerable<ValueNode> EvaluateUniqueValues ()
-		{
-			HashSet<string>? names = null;
-
-			foreach (ValueNode nameStringValue in NameString.UniqueValuesInternal) {
-				if (nameStringValue.Kind == ValueNodeKind.KnownString) {
-					if (names == null) {
-						names = new HashSet<string> ();
-					}
-
-					string typeName = ((KnownStringValue) nameStringValue).Contents;
-					names.Add (typeName);
-				}
-			}
-
-			bool foundAtLeastOne = false;
-
-			if (names != null) {
-				foreach (ValueNode assemblyValue in AssemblyIdentity.UniqueValuesInternal) {
-					if (assemblyValue.Kind == ValueNodeKind.KnownString) {
-						string assemblyName = ((KnownStringValue) assemblyValue).Contents;
-
-						foreach (string name in names) {
-							TypeDefinition typeDefinition = _resolver (assemblyName, name);
-							if (typeDefinition != null) {
-								foundAtLeastOne = true;
-								yield return new SystemTypeValue (typeDefinition);
-							}
-						}
-					}
-				}
-			}
-
-			if (!foundAtLeastOne)
-				yield return UnknownValue.Instance;
-		}
-
-		public override bool Equals (ValueNode? other)
-		{
-			if (!base.Equals (other))
-				return false;
-
-			GetTypeFromStringValue otherGtfs = (GetTypeFromStringValue) other;
-
-			return this.AssemblyIdentity.Equals (otherGtfs.AssemblyIdentity) &&
-				this.NameString.Equals (otherGtfs.NameString);
-		}
-
-		public override int GetHashCode ()
-		{
-			return HashCode.Combine (Kind, AssemblyIdentity, NameString);
-		}
-
-		protected override string NodeToString ()
-		{
-			return ValueNodeDump.ValueNodeToString (this, NameString);
-		}
-	}
-
-	/// <summary>
 	/// A representation of a ldfld.  Note that we don't have a representation of objects containing fields
 	/// so there isn't much that can be done with this node type yet.
 	/// </summary>
@@ -1216,27 +749,36 @@ namespace Mono.Linker.Dataflow
 
 	class ArrayValue : ValueNode
 	{
-		protected override int NumChildren => 1 + IndexValues.Count;
+		static ValueSetLattice<ValueNode> MultiValueLattice => default;
+
+		public static MultiValue Create(MultiValue size, TypeReference elementType)
+		{
+			MultiValue result = MultiValueLattice.Top;
+			foreach (var sizeValue in size) {
+				result = MultiValueLattice.Meet (result, new MultiValue (new ArrayValue (sizeValue, elementType)));
+			}
+
+			return result;
+		}
+
+		public static MultiValue Create(ValueNode size, TypeReference elementType)
+		{
+			return new MultiValue (new ArrayValue (size, elementType));
+		}
 
 		/// <summary>
 		/// Constructs an array value of the given size
 		/// </summary>
-		public ArrayValue (ValueNode? size, TypeReference elementType)
+		private ArrayValue (ValueNode size, TypeReference elementType)
 		{
 			Kind = ValueNodeKind.Array;
 
 			// Should be System.Array (or similar), but we don't have a use case for it
 			StaticType = null;
 
-			Size = size ?? UnknownValue.Instance;
+			Size = size;
 			ElementType = elementType;
 			IndexValues = new Dictionary<int, ValueBasicBlockPair> ();
-		}
-
-		private ArrayValue (ValueNode size, TypeReference elementType, Dictionary<int, ValueBasicBlockPair> indexValues)
-			: this (size, elementType)
-		{
-			IndexValues = indexValues;
 		}
 
 		public ValueNode Size { get; }
@@ -1268,28 +810,40 @@ namespace Mono.Linker.Dataflow
 
 		protected override string NodeToString ()
 		{
-			// TODO: Use StringBuilder and remove Linq usage.
-			return $"(Array Size:{ValueNodeDump.ValueNodeToString (this, Size)}, Values:({string.Join (',', IndexValues.Select (v => $"({v.Key},{ValueNodeDump.ValueNodeToString (v.Value.Value)})"))})";
-		}
+			StringBuilder result = new ();
+			result.Append ("Array Size:");
+			result.Append (ValueNodeDump.ValueNodeToString (this, Size));
 
-		protected override IEnumerable<ValueNode> EvaluateUniqueValues ()
-		{
-			foreach (var sizeConst in Size.UniqueValuesInternal)
-				yield return new ArrayValue (sizeConst, ElementType, IndexValues);
-		}
+			result.Append (", Values:(");
+			bool first = true;
+			foreach (var element in IndexValues) {
+				if (!first) {
+					result.Append (",");
+					first = false;
+				}
 
-		protected override ValueNode ChildAt (int index)
-		{
-			if (index == 0) return Size;
-			if (index - 1 <= IndexValues.Count)
-				return IndexValues.Values.ElementAt (index - 1).Value!;
+				result.Append ("(");
+				result.Append (element.Key);
+				result.Append (",(");
+				bool firstValue = true;
+				foreach (var v in element.Value.Value) {
+					if (firstValue) {
+						result.Append (",");
+						firstValue = false;
+					}
 
-			throw new InvalidOperationException ();
+					result.Append (ValueNodeDump.ValueNodeToString (v));
+				}
+				result.Append ("))");
+			}
+			result.Append (')');
+
+			return result.ToString ();
 		}
 	}
 
 	#region ValueNode Collections
-	public class ValueNodeList : List<ValueNode?>
+	public class ValueNodeList : List<MultiValue>
 	{
 		public ValueNodeList ()
 		{
@@ -1300,14 +854,17 @@ namespace Mono.Linker.Dataflow
 		{
 		}
 
-		public ValueNodeList (List<ValueNode> other)
+		public ValueNodeList (List<MultiValue> other)
 			: base (other)
 		{
 		}
 
 		public override int GetHashCode ()
 		{
-			return HashUtils.CalcHashCodeEnumerable (this);
+			HashCode hashCode = new HashCode ();
+			foreach (var item in this)
+				hashCode.Add (item.GetHashCode ());
+			return hashCode.ToHashCode ();
 		}
 
 		public override bool Equals (object? other)
@@ -1319,35 +876,7 @@ namespace Mono.Linker.Dataflow
 				return false;
 
 			for (int i = 0; i < Count; i++) {
-				if (!(otherList[i]?.Equals (this[i]) ?? (this[i] is null)))
-					return false;
-			}
-			return true;
-		}
-	}
-
-	class ValueNodeHashSet : HashSet<ValueNode>
-	{
-		public override int GetHashCode ()
-		{
-			return HashUtils.CalcHashCodeEnumerable (this);
-		}
-
-		public override bool Equals (object? other)
-		{
-			if (!(other is ValueNodeHashSet otherSet))
-				return false;
-
-			if (otherSet.Count != Count)
-				return false;
-
-			IEnumerator<ValueNode> thisEnumerator = this.GetEnumerator ();
-			IEnumerator<ValueNode> otherEnumerator = otherSet.GetEnumerator ();
-
-			for (int i = 0; i < Count; i++) {
-				thisEnumerator.MoveNext ();
-				otherEnumerator.MoveNext ();
-				if (!thisEnumerator.Current.Equals (otherEnumerator.Current))
+				if (!otherList[i].Equals (this[i]))
 					return false;
 			}
 			return true;
@@ -1355,20 +884,10 @@ namespace Mono.Linker.Dataflow
 	}
 	#endregion
 
-	static class HashUtils
-	{
-		public static int CalcHashCodeEnumerable<T> (IEnumerable<T> list) where T : class?
-		{
-			HashCode hashCode = new HashCode ();
-			foreach (var item in list)
-				hashCode.Add (item);
-			return hashCode.ToHashCode ();
-		}
-	}
 
 	public struct ValueBasicBlockPair
 	{
-		public ValueNode? Value;
+		public MultiValue Value;
 		public int BasicBlockIndex;
 	}
 }

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -8,12 +8,10 @@ using System.Linq;
 using System.Text;
 using ILLink.Shared.DataFlow;
 using Mono.Cecil;
-
 using FieldDefinition = Mono.Cecil.FieldDefinition;
 using GenericParameter = Mono.Cecil.GenericParameter;
-using TypeDefinition = Mono.Cecil.TypeDefinition;
-
 using MultiValue = ILLink.Shared.DataFlow.ValueSet<Mono.Linker.Dataflow.ValueNode>;
+using TypeDefinition = Mono.Cecil.TypeDefinition;
 
 namespace Mono.Linker.Dataflow
 {
@@ -196,7 +194,7 @@ namespace Mono.Linker.Dataflow
 
 		public static int? AsConstInt (this in MultiValue value)
 		{
-			if (value.AsSingleValue() is ConstIntValue constInt)
+			if (value.AsSingleValue () is ConstIntValue constInt)
 				return constInt.Value;
 
 			return null;
@@ -751,7 +749,7 @@ namespace Mono.Linker.Dataflow
 	{
 		static ValueSetLattice<ValueNode> MultiValueLattice => default;
 
-		public static MultiValue Create(MultiValue size, TypeReference elementType)
+		public static MultiValue Create (MultiValue size, TypeReference elementType)
 		{
 			MultiValue result = MultiValueLattice.Top;
 			foreach (var sizeValue in size) {
@@ -761,7 +759,7 @@ namespace Mono.Linker.Dataflow
 			return result;
 		}
 
-		public static MultiValue Create(ValueNode size, TypeReference elementType)
+		public static MultiValue Create (ValueNode size, TypeReference elementType)
 		{
 			return new MultiValue (new ArrayValue (size, elementType));
 		}

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -759,9 +759,9 @@ namespace Mono.Linker.Dataflow
 			return result;
 		}
 
-		public static MultiValue Create (ValueNode size, TypeReference elementType)
+		public static MultiValue Create (int size, TypeReference elementType)
 		{
-			return new MultiValue (new ArrayValue (size, elementType));
+			return new MultiValue (new ArrayValue (new ConstIntValue (size), elementType));
 		}
 
 		/// <summary>

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -127,7 +127,7 @@ namespace Mono.Linker.Dataflow
 		/// and should not be used by the caller after returning</param>
 		/// <param name="allNodesSeen">Optional. The set of all nodes encountered during a walk after DetectCycle returns</param>
 		/// <returns></returns>
-		public static bool DetectCycle (this ValueNode? node, HashSet<ValueNode> seenNodes, HashSet<ValueNode>? allNodesSeen)
+		public static bool DetectCycle (this ValueNode node, HashSet<ValueNode> seenNodes, HashSet<ValueNode>? allNodesSeen)
 		{
 			if (node == null)
 				return false;
@@ -184,7 +184,7 @@ namespace Mono.Linker.Dataflow
 			return foundCycle;
 		}
 
-		public static int? AsConstInt (this ValueNode? node)
+		public static int? AsConstInt (this ValueNode node)
 		{
 			if (node is ConstIntValue constInt)
 				return constInt.Value;
@@ -211,7 +211,7 @@ namespace Mono.Linker.Dataflow
 
 	internal static class ValueNodeDump
 	{
-		internal static string ValueNodeToString (ValueNode? node, params object[] args)
+		internal static string ValueNodeToString (ValueNode node, params object[] args)
 		{
 			if (node == null)
 				return "<null>";

--- a/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -189,11 +189,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			return null;
 		}
 
-		// https://github.com/dotnet/linker/issues/2025
-		// Ideally this should not warn
-		[ExpectedWarning ("IL2063",
-			nameof (MethodReturnParameterDataFlow) + "." + nameof (ReturnWithRequirementsAlwaysThrows) + "()",
-			ProducedBy = ProducedBy.Trimmer)]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 		Type ReturnWithRequirementsAlwaysThrows ()
 		{


### PR DESCRIPTION
Currently linker uses ValueNode to represent both single and multi-values. The multi-value is stored as a special value MergePoint. This means that basically every "Reader" should call UniqueValues which enumerates all values in the value. Otherwise it may only react to single-values and not function correctly for multi-values.

Also in order to share more code with the analyzer, we need to switch to the new model, where multi-values is stored in an explicit ValueSet.

This change replaces all the places where multiple values can be stored with MultiValue (=ValueSet<ValueNode>). Then it removes the MergePoint values and the entire infrastructure around it.
Other notable changes:
- Added implicit conversion from single TValue to ValueSet<TValue> to make it much easier to work with
- Changed how ArrayValue is created to use factory methods. Previously ArrayValue could store a multi-value as its size. This meant that it was necessary to enumerate UniqueValues on ArrayValue to get actual sizes (results in multiple ArrayValues). This change introduces a factory method which return a MultiValue which may contain multiple ArrayValues if there are multiple potential sizes. A bit more memory hungry in some cases, but makes the "reader" simpler and less error prone.
- Added IsEmpty on ValueSet - as it's relatively common to check for empty ValueSet
- This actually fixes a bug https://github.com/dotnet/linker/issues/2025 because it now correctly tracks empty MultiValue
- This change finally gets rid of all possible places where ValueNode could be null before - null was used as basically Unknown value, but it sometimes caused nullrefs in weird places. This can't happen anymore, since MultiValue is a struct and thus is always - non-null.

Note: Currently this makes the data flow in linker relatively inefficient as ValueSet always creates a HashSet internally. https://github.com/dotnet/linker/pull/2397 should fix that and store single-values as direct references without a HashSet, basically going back to what linker did before (the only difference is that ValueNode reference is now wrapped in a ValueSet struct).