### PR TITLE
Convert ValueNode to record

### DIFF
--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -771,10 +771,10 @@ namespace Mono.Linker.Dataflow
 			StackSlot destination = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 
 			foreach (var uniqueDestination in destination.Value) {
-				if (uniqueDestination.Kind == ValueNodeKind.LoadField) {
-					HandleStoreField (methodBody.Method, ((LoadFieldValue) uniqueDestination).Field, operation, valueToStore.Value);
-				} else if (uniqueDestination.Kind == ValueNodeKind.MethodParameter) {
-					HandleStoreParameter (methodBody.Method, ((MethodParameterValue) uniqueDestination).ParameterIndex, operation, valueToStore.Value);
+				if (uniqueDestination is LoadFieldValue fieldDestination) {
+					HandleStoreField (methodBody.Method, fieldDestination.Field, operation, valueToStore.Value);
+				} else if (uniqueDestination is MethodParameterValue parameterDestination) {
+					HandleStoreParameter (methodBody.Method, parameterDestination.ParameterIndex, operation, valueToStore.Value);
 				}
 			}
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -917,7 +917,7 @@ namespace Mono.Linker.Dataflow
 							if (value is SystemTypeValue systemTypeValue) {
 								foreach (var stringParam in methodParams[2]) {
 									if (stringParam is KnownStringValue stringValue) {
-										BindingFlags bindingFlags = methodParams[0].AsSingleValue ()?.Kind == ValueNodeKind.Null ? BindingFlags.Static : BindingFlags.Default;
+										BindingFlags bindingFlags = methodParams[0].AsSingleValue () is NullValue ? BindingFlags.Static : BindingFlags.Default;
 										if (fieldOrPropertyInstrinsic == IntrinsicId.Expression_Property) {
 											MarkPropertiesOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, filter: p => p.Name == stringValue.Contents, bindingFlags);
 										} else {
@@ -1859,17 +1859,18 @@ namespace Mono.Linker.Dataflow
 				return true;
 
 			foreach (var typesValue in arrayParam) {
-				if (typesValue.Kind != ValueNodeKind.Array) {
+				if (typesValue is not ArrayValue array) {
 					return false;
 				}
-				ArrayValue array = (ArrayValue) typesValue;
+
 				int? size = array.Size.AsConstInt ();
 				if (size == null || size != genericParameters.Count) {
 					return false;
 				}
+
 				bool allIndicesKnown = true;
 				for (int i = 0; i < size.Value; i++) {
-					if (!array.IndexValues.TryGetValue (i, out ValueBasicBlockPair value) || value.Value.IsEmpty () || value.Value.AsSingleValue () is { Kind: ValueNodeKind.Unknown }) {
+					if (!array.IndexValues.TryGetValue (i, out ValueBasicBlockPair value) || value.Value.IsEmpty() || value.Value.AsSingleValue () is UnknownValue) {
 						allIndicesKnown = false;
 						break;
 					}

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared;
-using ILLink.Shared.DataFlow;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker.Steps;
@@ -1870,7 +1869,7 @@ namespace Mono.Linker.Dataflow
 
 				bool allIndicesKnown = true;
 				for (int i = 0; i < size.Value; i++) {
-					if (!array.IndexValues.TryGetValue (i, out ValueBasicBlockPair value) || value.Value.IsEmpty() || value.Value.AsSingleValue () is UnknownValue) {
+					if (!array.IndexValues.TryGetValue (i, out ValueBasicBlockPair value) || value.Value.IsEmpty () || value.Value.AsSingleValue () is UnknownValue) {
 						allIndicesKnown = false;
 						break;
 					}

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -126,7 +126,7 @@ namespace Mono.Linker.Dataflow
 				break;
 
 			default:
-				throw new Exception (String.Format ("Unknown node type: {0}", node.GetType().Name));
+				throw new Exception (String.Format ("Unknown node type: {0}", node.GetType ().Name));
 			}
 			seenNodes.Remove (node);
 
@@ -166,7 +166,7 @@ namespace Mono.Linker.Dataflow
 				return "<null>";
 
 			StringBuilder sb = new StringBuilder ();
-			sb.Append (node.GetType().Name);
+			sb.Append (node.GetType ().Name);
 			sb.Append ("(");
 			if (args != null) {
 				for (int i = 0; i < args.Length; i++) {


### PR DESCRIPTION
This is in preparation to merging the value type system with the analyzer and the `SingleValue` type.

Removes the Kind enum and uses type checks instead (there are not that many places actually since we already used type checks in lot of places).
Cleans up some of the value .ctors and properties.
Remove Equals/GetHashCode implementation where possible (leave it up to record).