### PR TITLE
Changes LinkerAttributesInformation._linkerAttributes to a List instead of a Dictionary

### DIFF
--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Security.Cryptography.X509Certificates;
 using Mono.Cecil;
 
 namespace Mono.Linker

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -21,13 +21,13 @@ namespace Mono.Linker
 
 		private static bool TryFindAttributeList (List<(Type Type, List<Attribute> Attributes)> list, Type type, [NotNullWhen (returnValue: true)] out List<Attribute>? foundAttributes)
 		{
-			foundAttributes = null;
 			foreach (var item in list) {
 				if (item.Type == type) {
 					foundAttributes = item.Attributes;
 					return true;
 				}
 			}
+			foundAttributes = null;
 			return false;
 		}
 


### PR DESCRIPTION
 Fix for issue https://github.com/dotnet/linker/issues/2387 to use a list instead of a dictionary for LinkerAttributesInformation._linkerAttributes since the size of the collection is usually very small.