### PR TITLE
[release/6.0.2xx] Add a custom flag to disable marking of copy assemblies

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1387,7 +1387,9 @@ namespace Mono.Linker.Steps
 			MarkExportedTypesTarget.ProcessAssembly (assembly, Context);
 
 			if (ProcessReferencesStep.IsFullyPreservedAction (Context.Annotations.GetAction (assembly))) {
-				MarkEntireAssembly (assembly);
+				if (!Context.TryGetCustomData ("DisableMarkingOfCopyAssemblies", out string? disableMarkingOfCopyAssembliesValue) ||
+					disableMarkingOfCopyAssembliesValue != "true")
+					MarkEntireAssembly (assembly);
 				return;
 			}
 


### PR DESCRIPTION
This is a release/6.0.2xx port of #2370

Enabled by `--custom-data DisableMarkingOfCopyAssemblies=true` on the command line. Assumes that ALL assemblies on the input are in "copy" action (it doesn't validate this fact).

It disables marking basically fully - linker will go over all assemblies, and process them in "copy" mode (copy the original file over) and will call all the custom steps and so on, but it will do no marking (or very little, depends on descriptors and such which this doesn't disable).

This is intentionally non-discoverable feature, to be used only by the mono AOT toolchain.

Fixes https://github.com/dotnet/linker/issues/2089.

### Customer impact
Xamarin "notrim" mode (used in AOT scenarios for debug builds for example) regressed with .NET 6 trimmer. The trimmer used to run quickly (several seconds), now it's much slower (5x slower roughly, sometimes worse). The change allows Xamarin SDK to tell the trimmer to avoid doing most of the expensive work as it won't be trimming anything. The speedup is very visible: Hello world app build went from 19s to 7s.

### Testing
Validated with Xamarin that the change fixes the problem.

### Risk
Low - added new command line option specifically to be used by Xamarin. Undocumented, not to be used by anything else.