### PR TITLE
Fix Issue 2416: RUC Analyzer doesn't emit IL2109

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -329,7 +329,7 @@ namespace ILLink.RoslynAnalyzer
 				url));
 		}
 
-		protected void ReportMismatchInAttributesDiagnostic (SymbolAnalysisContext symbolAnalysisContext, ISymbol member, ISymbol baseMember, bool isInterface = false)
+		private void ReportMismatchInAttributesDiagnostic (SymbolAnalysisContext symbolAnalysisContext, ISymbol member, ISymbol baseMember, bool isInterface = false)
 		{
 			string message = MessageFormat.FormatRequiresAttributeMismatch (member.HasAttribute (RequiresAttributeName), isInterface, RequiresAttributeName, member.GetDisplayName (), baseMember.GetDisplayName ());
 			symbolAnalysisContext.ReportDiagnostic (Diagnostic.Create (

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -29,6 +29,7 @@ namespace ILLink.RoslynAnalyzer
 		private protected virtual ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)> ExtraOperationActions { get; } = ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)>.Empty;
 
 		private protected virtual ImmutableArray<(Action<SyntaxNodeAnalysisContext> Action, SyntaxKind[] SyntaxKind)> ExtraSyntaxNodeActions { get; } = ImmutableArray<(Action<SyntaxNodeAnalysisContext> Action, SyntaxKind[] SyntaxKind)>.Empty;
+		private protected virtual ImmutableArray<(Action<SymbolAnalysisContext> Action, SymbolKind[] SymbolKind)> ExtraSymbolActions { get; } = ImmutableArray<(Action<SymbolAnalysisContext> Action, SymbolKind[] SymbolKind)>.Empty;
 
 		public override void Initialize (AnalysisContext context)
 		{
@@ -197,6 +198,9 @@ namespace ILLink.RoslynAnalyzer
 				foreach (var extraSyntaxNodeAction in ExtraSyntaxNodeActions)
 					context.RegisterSyntaxNodeAction (extraSyntaxNodeAction.Action, extraSyntaxNodeAction.SyntaxKind);
 
+				foreach (var extraSymbolAction in ExtraSymbolActions)
+					context.RegisterSymbolAction (extraSymbolAction.Action, extraSymbolAction.SymbolKind);
+
 				void CheckAttributeInstantiation (
 					SymbolAnalysisContext symbolAnalysisContext,
 					ISymbol symbol)
@@ -259,7 +263,6 @@ namespace ILLink.RoslynAnalyzer
 								ReportMismatchInAttributesDiagnostic (symbolAnalysisContext, implementation, member, isInterface: true);
 						}
 					}
-
 				}
 			});
 		}

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -329,7 +329,7 @@ namespace ILLink.RoslynAnalyzer
 				url));
 		}
 
-		private void ReportMismatchInAttributesDiagnostic (SymbolAnalysisContext symbolAnalysisContext, ISymbol member, ISymbol baseMember, bool isInterface = false)
+		protected void ReportMismatchInAttributesDiagnostic (SymbolAnalysisContext symbolAnalysisContext, ISymbol member, ISymbol baseMember, bool isInterface = false)
 		{
 			string message = MessageFormat.FormatRequiresAttributeMismatch (member.HasAttribute (RequiresAttributeName), isInterface, RequiresAttributeName, member.GetDisplayName (), baseMember.GetDisplayName ());
 			symbolAnalysisContext.ReportDiagnostic (Diagnostic.Create (

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -38,7 +38,7 @@ namespace ILLink.RoslynAnalyzer
 			get {
 				return symbolAnalysisContext => {
 					if (symbolAnalysisContext.Symbol is INamedTypeSymbol typeSymbol && !typeSymbol.HasAttribute (RequiresUnreferencedCodeAttribute)
-						&& typeSymbol.BaseType is INamedTypeSymbol baseType 
+						&& typeSymbol.BaseType is INamedTypeSymbol baseType
 						&& baseType.TryGetAttribute (RequiresUnreferencedCodeAttribute, out var requiresUnreferencedCodeAttribute)) {
 						var diag = Diagnostic.Create (s_typeDerivesFromRucClassRule,
 							typeSymbol.Locations[0],

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -38,7 +38,7 @@ namespace ILLink.RoslynAnalyzer
 			get {
 				return symbolAnalysisContext => {
 					if (symbolAnalysisContext.Symbol is INamedTypeSymbol typeSymbol && !typeSymbol.HasAttribute (RequiresUnreferencedCodeAttribute)
-						&& typeSymbol.BaseType is INamedTypeSymbol baseType && baseType.HasAttribute (RequiresUnreferencedCodeAttribute)
+						&& typeSymbol.BaseType is INamedTypeSymbol baseType 
 						&& baseType.TryGetAttribute (RequiresUnreferencedCodeAttribute, out var requiresUnreferencedCodeAttribute)) {
 						var diag = Diagnostic.Create (s_typeDerivesFromRucClassRule,
 							typeSymbol.Locations[0],

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -37,18 +37,16 @@ namespace ILLink.RoslynAnalyzer
 		private Action<SymbolAnalysisContext> typeDerivesFromRucBase {
 			get {
 				return symbolAnalysisContext => {
-					if (symbolAnalysisContext.Symbol is INamedTypeSymbol typeSymbol && !typeSymbol.HasAttribute (RequiresUnreferencedCodeAttribute)) {
-						if (typeSymbol.BaseType is INamedTypeSymbol baseType && baseType.HasAttribute (RequiresUnreferencedCodeAttribute)) {
-							if (baseType.TryGetAttribute (RequiresUnreferencedCodeAttribute, out var requiresUnreferencedCodeAttribute)) {
-								var diag = Diagnostic.Create (s_typeDerivesFromRucClassRule,
-									typeSymbol.Locations[0],
-									typeSymbol,
-									baseType.GetDisplayName (),
-									GetMessageFromAttribute (requiresUnreferencedCodeAttribute),
-									GetUrlFromAttribute (requiresUnreferencedCodeAttribute));
-								symbolAnalysisContext.ReportDiagnostic (diag);
-							}
-						}
+					if (symbolAnalysisContext.Symbol is INamedTypeSymbol typeSymbol && !typeSymbol.HasAttribute (RequiresUnreferencedCodeAttribute)
+						&& typeSymbol.BaseType is INamedTypeSymbol baseType && baseType.HasAttribute (RequiresUnreferencedCodeAttribute)
+						&& baseType.TryGetAttribute (RequiresUnreferencedCodeAttribute, out var requiresUnreferencedCodeAttribute)) {
+						var diag = Diagnostic.Create (s_typeDerivesFromRucClassRule,
+							typeSymbol.Locations[0],
+							typeSymbol,
+							baseType.GetDisplayName (),
+							GetMessageFromAttribute (requiresUnreferencedCodeAttribute),
+							GetUrlFromAttribute (requiresUnreferencedCodeAttribute));
+						symbolAnalysisContext.ReportDiagnostic (diag);
 					}
 				};
 			}

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -8,7 +8,7 @@
 		CorrectnessOfCOMCannotBeGuaranteed = 2050,
 		MakeGenericType = 2055,
 		MakeGenericMethod = 2060,
-		DerivedFromBaseWithRequiresUnreferencedCode = 2109,
+		DerivedClassRequiresUnreferencedCodeAttributeMismatch = 2109,
 		RequiresUnreferencedCodeOnStaticConstructor = 2116,
 
 		// Single-file diagnostic ids.

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -8,6 +8,7 @@
 		CorrectnessOfCOMCannotBeGuaranteed = 2050,
 		MakeGenericType = 2055,
 		MakeGenericMethod = 2060,
+		DerivedFromBaseWithRequiresUnreferencedCode = 2109,
 		RequiresUnreferencedCodeOnStaticConstructor = 2116,
 
 		// Single-file diagnostic ids.

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -8,7 +8,7 @@
 		CorrectnessOfCOMCannotBeGuaranteed = 2050,
 		MakeGenericType = 2055,
 		MakeGenericMethod = 2060,
-		DerivedClassRequiresUnreferencedCodeAttributeMismatch = 2109,
+		RequiresOnBaseClass = 2109,
 		RequiresUnreferencedCodeOnStaticConstructor = 2116,
 
 		// Single-file diagnostic ids.

--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -192,8 +192,4 @@
   <data name="CorrectnessOfCOMCannotBeGuaranteedMessage" xml:space="preserve">
     <value>P/invoke method '{0}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.</value>
   </data>
-  <data name="DerivedClassRequiresUnreferencedCodeAttributeMismatchMessage" xml:space="preserve">
-    <value>{0}: Type '{0}' derives from '{1}' which has 'RequiresUnreferencedCodeAttribute'.  --{2}--.</value>
-    <comment>IL2109 for RequiresUnreferenedCode only</comment>
-  </data>
 </root>

--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -150,7 +150,7 @@
   <data name="RequiresAssemblyFilesAttributeMismatchMessage" xml:space="preserve">
     <value>{0}. 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.</value>
   </data>
-	<data name="RequiresAssemblyFilesAttributeMismatchTitle" xml:space="preserve">
+  <data name="RequiresAssemblyFilesAttributeMismatchTitle" xml:space="preserve">
     <value>'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.</value>
   </data>
   <data name="BaseRequiresMismatchMessage" xml:space="preserve">
@@ -191,5 +191,9 @@
   </data>
   <data name="CorrectnessOfCOMCannotBeGuaranteedMessage" xml:space="preserve">
     <value>P/invoke method '{0}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.</value>
+  </data>
+  <data name="DerivedClassRequiresUnreferencedCodeAttributeMismatchMessage" xml:space="preserve">
+    <value>{0}: Type '{0}' derives from '{1}' which has 'RequiresUnreferencedCodeAttribute'.  --{2}--.</value>
+    <comment>IL2109 for RequiresUnreferenedCode only</comment>
   </data>
 </root>

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1900,7 +1900,7 @@ namespace Mono.Linker.Steps
 				string formatString = SharedStrings.RequiresOnBaseClassMessage;
 				string arg1 = MessageFormat.FormatRequiresAttributeMessageArg (effectiveRequiresUnreferencedCode.Message);
 				string arg2 = MessageFormat.FormatRequiresAttributeUrlArg (effectiveRequiresUnreferencedCode.Url);
-				string message = string.Format (formatString, type, type.BaseType.GetDisplayName (), arg1, arg2);
+				string message = string.Format (formatString, type.GetDisplayName (), type.BaseType.GetDisplayName (), arg1, arg2);
 				Context.LogWarning (message, 2109, currentOrigin, MessageSubCategory.TrimAnalysis);
 			}
 

--- a/src/linker/Linker/MemberReferenceExtensions.cs
+++ b/src/linker/Linker/MemberReferenceExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Text;
 using Mono.Cecil;
 

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -256,6 +256,8 @@ namespace Mono.Linker
 			if (Origin?.Provider != null) {
 				if (Origin?.Provider is MethodDefinition method)
 					sb.Append (method.GetDisplayName ());
+				else if (Origin?.Provider is TypeDefinition type)
+					sb.Append (type.GetDisplayName ());
 				else if (Origin?.Provider is IMemberDefinition member)
 					sb.Append (member.FullName);
 				else if (Origin?.Provider is AssemblyDefinition assembly)

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
@@ -1227,7 +1227,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static void MethodWithRequires () { }
 			}
 
-			[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--")]
 			private class DerivedWithoutRequires : ClassWithRequires
 			{
 				public static void StaticMethodInInheritedClass () { }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
@@ -1227,7 +1227,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static void MethodWithRequires () { }
 			}
 
-			[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--")]
+			[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2109", "RequiresOnClass.DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+
 			private class DerivedWithoutRequires : ClassWithRequires
 			{
 				public static void StaticMethodInInheritedClass () { }
@@ -1400,6 +1402,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				// A nested class is not considered a static method nor constructor therefore RequiresUnreferencedCode doesnt apply
 				// and this warning is not suppressed
 				[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithRequires2/DerivedNestedClass", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2109", "RequiresOnClass.DerivedWithRequires2.DerivedNestedClass", "--ClassWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+
 				public class DerivedNestedClass : ClassWithRequires
 				{
 					public static void NestedStaticMethod () { }
@@ -1630,6 +1634,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 
 				[ExpectedWarning ("IL2109", "ReflectionAccessOnCtor/DerivedWithoutRequires", "ReflectionAccessOnCtor.BaseWithRequires", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnCtor.DerivedWithoutRequires", "ReflectionAccessOnCtor.BaseWithRequires", ProducedBy = ProducedBy.Analyzer)]
 				class DerivedWithoutRequires : BaseWithRequires
 				{
 					[ExpectedWarning ("IL2026", "--BaseWithRequires--", ProducedBy = ProducedBy.Trimmer)] // The body has direct call to the base.ctor()
@@ -1704,6 +1709,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 
 				[ExpectedWarning ("IL2109", "ReflectionAccessOnField/DerivedWithoutRequires", "ReflectionAccessOnField.WithRequires", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnField.DerivedWithoutRequires", "ReflectionAccessOnField.WithRequires", ProducedBy = ProducedBy.Analyzer)]
 				class DerivedWithoutRequires : WithRequires
 				{
 					public static int DerivedStaticField;
@@ -1828,6 +1834,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 
 				[ExpectedWarning ("IL2109", "ReflectionAccessOnProperties/DerivedWithoutRequires", "ReflectionAccessOnProperties.WithRequires", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnProperties.DerivedWithoutRequires", "ReflectionAccessOnProperties.WithRequires", ProducedBy = ProducedBy.Analyzer)]
 				class DerivedWithoutRequires : WithRequires
 				{
 					public static int DerivedStaticProperty { get; set; }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
@@ -1227,9 +1227,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static void MethodWithRequires () { }
 			}
 
-			[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2109", "RequiresOnClass.DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-
+			[ExpectedWarning ("IL2109", "RequiresOnClass.DerivedWithoutRequires", "RequiresOnClass.ClassWithRequires", "--ClassWithRequires--")]
 			private class DerivedWithoutRequires : ClassWithRequires
 			{
 				public static void StaticMethodInInheritedClass () { }
@@ -1401,9 +1399,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 				// A nested class is not considered a static method nor constructor therefore RequiresUnreferencedCode doesnt apply
 				// and this warning is not suppressed
-				[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithRequires2/DerivedNestedClass", "--ClassWithRequires--", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2109", "RequiresOnClass.DerivedWithRequires2.DerivedNestedClass", "--ClassWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-
+				[ExpectedWarning ("IL2109", "RequiresOnClass.DerivedWithRequires2.DerivedNestedClass", "--ClassWithRequires--")]
 				public class DerivedNestedClass : ClassWithRequires
 				{
 					public static void NestedStaticMethod () { }
@@ -1633,8 +1629,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 					public BaseWithRequires () { }
 				}
 
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnCtor/DerivedWithoutRequires", "ReflectionAccessOnCtor.BaseWithRequires", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnCtor.DerivedWithoutRequires", "ReflectionAccessOnCtor.BaseWithRequires", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnCtor.DerivedWithoutRequires", "ReflectionAccessOnCtor.BaseWithRequires")]
 				class DerivedWithoutRequires : BaseWithRequires
 				{
 					[ExpectedWarning ("IL2026", "--BaseWithRequires--", ProducedBy = ProducedBy.Trimmer)] // The body has direct call to the base.ctor()
@@ -1708,8 +1703,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 					public int InstanceField;
 				}
 
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnField/DerivedWithoutRequires", "ReflectionAccessOnField.WithRequires", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnField.DerivedWithoutRequires", "ReflectionAccessOnField.WithRequires", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnField.DerivedWithoutRequires", "ReflectionAccessOnField.WithRequires")]
 				class DerivedWithoutRequires : WithRequires
 				{
 					public static int DerivedStaticField;
@@ -1833,8 +1827,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 					public int InstnaceProperty { get; set; }
 				}
 
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnProperties/DerivedWithoutRequires", "ReflectionAccessOnProperties.WithRequires", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2109", "ReflectionAccessOnProperties.DerivedWithoutRequires", "ReflectionAccessOnProperties.WithRequires", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL2109", "ReflectionAccessOnProperties.DerivedWithoutRequires", "ReflectionAccessOnProperties.WithRequires")]
 				class DerivedWithoutRequires : WithRequires
 				{
 					public static int DerivedStaticProperty { get; set; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/linker/issues/2416 by emitting IL2109 (Derived class without RUC derives from base class with RUC). Also modifies the path of nested types in warnings to use dots as type delimiters instead of a slash. (e.g. "namespace1.namespace2.base.nested.nested2" instead of "namespace1.namespace2.base/nested1/nested2")