### PR TITLE
Remove cecil FullName property from diagnostic messages

### DIFF
--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -256,10 +256,8 @@ namespace Mono.Linker
 			if (Origin?.Provider != null) {
 				if (Origin?.Provider is MethodDefinition method)
 					sb.Append (method.GetDisplayName ());
-				else if (Origin?.Provider is TypeDefinition type)
+				else if (Origin?.Provider is MemberReference type)
 					sb.Append (type.GetDisplayName ());
-				else if (Origin?.Provider is IMemberDefinition member)
-					sb.Append (member.FullName);
 				else if (Origin?.Provider is AssemblyDefinition assembly)
 					sb.Append (assembly.Name.Name);
 				else

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -256,8 +256,10 @@ namespace Mono.Linker
 			if (Origin?.Provider != null) {
 				if (Origin?.Provider is MethodDefinition method)
 					sb.Append (method.GetDisplayName ());
-				else if (Origin?.Provider is MemberReference type)
-					sb.Append (type.GetDisplayName ());
+				else if (Origin?.Provider is MemberReference memberRef)
+					sb.Append (memberRef.GetDisplayName ());
+				else if (Origin?.Provider is IMemberDefinition member)
+					sb.Append(member.FullName);
 				else if (Origin?.Provider is AssemblyDefinition assembly)
 					sb.Append (assembly.Name.Name);
 				else

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -259,7 +259,7 @@ namespace Mono.Linker
 				else if (Origin?.Provider is MemberReference memberRef)
 					sb.Append (memberRef.GetDisplayName ());
 				else if (Origin?.Provider is IMemberDefinition member)
-					sb.Append(member.FullName);
+					sb.Append (member.FullName);
 				else if (Origin?.Provider is AssemblyDefinition assembly)
 					sb.Append (assembly.Name.Name);
 				else


### PR DESCRIPTION
Diagnostic messages would occasionally use the Cecil `FullName` property which uses '/' as a delimiter for nested classes. The standard is to use '.' instead. This fix uses `GetDisplayName()` instead to accomplish this.

Fixes https://github.com/dotnet/linker/issues/2441