### PR TITLE
Fix Task test which only fails in VS

### DIFF
--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -756,6 +757,24 @@ namespace ILLink.Tasks.Tests
 				RootAssemblyNames = Array.Empty<ITaskItem> ()
 			};
 			task.BuildEngine = new MockBuildEngine ();
+
+			// This won't work in single-file, but it's the simplest way for now
+			string corelibPath = typeof (object).Assembly.Location;
+			if (corelibPath == null)
+				throw new NotSupportedException ("Running this test in single-file mode is not yet supported.");
+
+			string dotnetToolName = OperatingSystem.IsWindows () ? "dotnet.exe" : "dotnet";
+
+			// The path to corelib should be something like <dotnetroot>/shared/Microsoft.NETCore.App/version/System.Private.CoreLib.dll
+			// So get the dotnetroot from this
+			string dotnetRootPath = Path.GetDirectoryName (Path.GetDirectoryName (Path.GetDirectoryName (Path.GetDirectoryName (corelibPath))));
+			string dotnetPath = Path.Combine (dotnetRootPath, dotnetToolName);
+			if (!File.Exists (dotnetPath))
+				throw new NotSupportedException ("Running test in a configuration where we can't figure out dotnet root path.");
+
+			task.ToolPath = dotnetRootPath;
+			task.ToolExe = dotnetToolName;
+
 			Assert.False (task.Execute ());
 			Assert.Contains (task.Messages, message =>
 				message.Line.Contains ("No input files were specified"));


### PR DESCRIPTION
The problem is that we run the task in a way which never happens in SDK. In SDK we always specify ToolPath/ToolExe values, but the test doesn't. The default implementation of these values rely on DOTNET_HOST_PATH which is not set when running from VS.

The fix calculates path to dotnet.exe from the test itself - it's not the most elegant way, but for now should always work as we only support running the tests on .NET Core (NOT on .NET Framework).

This only fixes the test `TestErrorHandling` when ran from VS.

I created a separate issue: https://github.com/dotnet/linker/issues/2452

To track the removal of support for running the task without setting the paths.

This is related to https://github.com/dotnet/linker/issues/806.