### PR TITLE
[release/6.0.2xx] Propagate Interfaces annotation through Type.BaseType

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1294,6 +1294,9 @@ namespace Mono.Linker.Dataflow
 
 									if (dynamicallyAccessedMemberNode.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicProperties))
 										propagatedMemberTypes |= DynamicallyAccessedMemberTypes.PublicProperties;
+
+									if (dynamicallyAccessedMemberNode.DynamicallyAccessedMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.Interfaces))
+										propagatedMemberTypes |= DynamicallyAccessedMemberTypes.Interfaces;
 								}
 
 								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethod, propagatedMemberTypes));

--- a/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
@@ -34,6 +34,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestNonPublicNestedTypesAreNotPropagated (typeof (TestType));
 			TestNonPublicPropertiesAreNotPropagated (typeof (TestType));
 
+			TestInterfacesPropagated (typeof (TestType));
+
 			TestCombinationOfPublicsIsPropagated (typeof (TestType));
 			TestCombinationOfNonPublicsIsNotPropagated (typeof (TestType));
 			TestCombinationOfPublicAndNonPublicsPropagatesPublicOnly (typeof (TestType));
@@ -162,6 +164,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void TestNonPublicPropertiesAreNotPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicProperties)] Type derivedType)
 		{
 			derivedType.BaseType.RequiresNonPublicProperties ();
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestInterfacesPropagated ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] Type derivedType)
+		{
+			derivedType.BaseType.RequiresInterfaces ();
 		}
 
 		[RecognizedReflectionAccessPattern]

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -440,7 +440,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			public static void Test()
+			public static void Test ()
 			{
 				ITest t = null;
 				t.Method ();

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -42,6 +42,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestUnkownIgnoreCase3Params (1);
 			TestUnkownIgnoreCase5Params (1);
 			TestGenericTypeWithAnnotations ();
+
+			BaseTypeInterfaces.Test ();
 		}
 
 		[Kept]
@@ -408,6 +410,42 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				"[[Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+GenericTypeWithAnnotations_InnerType, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]," +
 				" test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
 			Type.GetType (reflectionTypeKeptString);
+		}
+
+		[Kept]
+		class BaseTypeInterfaces
+		{
+			[Kept]
+			interface ITest
+			{
+				[Kept]
+				void Method ();
+			}
+
+			[Kept]
+			[KeptInterface (typeof (ITest))]
+			class BaseType : ITest
+			{
+				[Kept]
+				public void Method () { }
+			}
+
+			[Kept]
+			[KeptBaseType (typeof (BaseType))]
+			[KeptInterface (typeof (ITest))]
+			class DerivedType : BaseType, ITest
+			{
+				[Kept]
+				public void Method () { }
+			}
+
+			[Kept]
+			public static void Test()
+			{
+				ITest t = null;
+				t.Method ();
+				typeof (DerivedType).GetInterfaces ();
+			}
 		}
 	}
 }


### PR DESCRIPTION
The Interfaces annotation makes sure the type has all interfaces, meaning `GetInterfaces` reflection call will work on it. That means that all interfaces of the base type are also preserved, so the `Interfaces` annotation should be propagated to the base type as well.

Fixes https://github.com/dotnet/linker/issues/2473.

