### PR TITLE
[DAM analyzer] Always recurse into child operations in visitor

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -17,9 +17,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 	// - field
 	// - parameter
 	// - method return
-	public abstract class LocalDataFlowVisitor<TValue, TValueLattice> : OperationVisitor<LocalState<TValue>, TValue>,
+	public abstract class LocalDataFlowVisitor<TValue, TValueLattice> : OperationWalker<LocalState<TValue>, TValue>,
 		ITransfer<BlockProxy, LocalState<TValue>, LocalStateLattice<TValue, TValueLattice>>
-		where TValue : IEquatable<TValue>
+		// This struct constraint prevents warnings due to possible null returns from the visitor methods.
+		where TValue : struct, IEquatable<TValue>
 		where TValueLattice : ILattice<TValue>
 	{
 		protected readonly LocalStateLattice<TValue, TValueLattice> LocalStateLattice;
@@ -90,16 +91,18 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		// may (must?) come from BranchValue of an operation whose FallThroughSuccessor is the exit block.
 		public abstract void HandleReturnValue (TValue returnValue, IOperation operation);
 
-		// Override with a non-nullable return value to prevent some warnings.
-		// The interface constraint on TValue ensures that it's not a nullable type, so this is safe as long
-		// as no overrides return default(TValue).
-		public override TValue Visit (IOperation? operation, LocalState<TValue> argument) => operation != null ? operation.Accept (this, argument)! : TopValue;
-
-		internal virtual TValue VisitNoneOperation (IOperation operation, LocalState<TValue> argument) => TopValue;
+		public override TValue Visit (IOperation? operation, LocalState<TValue> state)
+		{
+			return base.Visit (operation, state) ?? TopValue;
+		}
 
 		// The default visitor preserves the local state. Any unimplemented operations will not
 		// have their effects reflected in the tracked state.
-		public override TValue DefaultVisit (IOperation operation, LocalState<TValue> state) => TopValue;
+		public override TValue DefaultVisit (IOperation operation, LocalState<TValue> state)
+		{
+			base.DefaultVisit (operation, state);
+			return TopValue;
+		}
 
 		public override TValue VisitLocalReference (ILocalReferenceOperation operation, LocalState<TValue> state)
 		{

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -20,6 +20,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 	public abstract class LocalDataFlowVisitor<TValue, TValueLattice> : OperationWalker<LocalState<TValue>, TValue>,
 		ITransfer<BlockProxy, LocalState<TValue>, LocalStateLattice<TValue, TValueLattice>>
 		// This struct constraint prevents warnings due to possible null returns from the visitor methods.
+		// Note that this assumes that default(TValue) is equal to the TopValue.
 		where TValue : struct, IEquatable<TValue>
 		where TValueLattice : ILattice<TValue>
 	{
@@ -90,19 +91,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		// This takes an IOperation rather than an IReturnOperation because the return value
 		// may (must?) come from BranchValue of an operation whose FallThroughSuccessor is the exit block.
 		public abstract void HandleReturnValue (TValue returnValue, IOperation operation);
-
-		public override TValue Visit (IOperation? operation, LocalState<TValue> state)
-		{
-			return base.Visit (operation, state) ?? TopValue;
-		}
-
-		// The default visitor preserves the local state. Any unimplemented operations will not
-		// have their effects reflected in the tracked state.
-		public override TValue DefaultVisit (IOperation operation, LocalState<TValue> state)
-		{
-			base.DefaultVisit (operation, state);
-			return TopValue;
-		}
 
 		public override TValue VisitLocalReference (ILocalReferenceOperation operation, LocalState<TValue> state)
 		{

--- a/src/ILLink.RoslynAnalyzer/DataFlow/OperationWalker.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/OperationWalker.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace ILLink.RoslynAnalyzer.DataFlow
+{
+	// Adapted from https://github.com/dotnet/roslyn/
+	public abstract class OperationWalker<TArgument, TResult> : OperationVisitor<TArgument, TResult>
+	{
+		private int _recursionDepth;
+
+		private void VisitChildOperations (IOperation operation, TArgument argument)
+		{
+			// https://github.com/dotnet/roslyn/issues/49475 would let us use ChildOperations, a struct enumerable.
+			foreach (var child in operation.Children)
+				Visit (child, argument);
+		}
+
+		public override TResult? Visit (IOperation? operation, TArgument argument)
+		{
+			if (operation != null) {
+				_recursionDepth++;
+				try {
+					StackGuard.EnsureSufficientExecutionStack (_recursionDepth);
+					return operation.Accept (this, argument);
+				} finally {
+					_recursionDepth--;
+				}
+			}
+			return default;
+		}
+
+		public override TResult? DefaultVisit (IOperation operation, TArgument argument)
+		{
+			VisitChildOperations (operation, argument);
+			return default;
+		}
+	}
+}

--- a/src/ILLink.RoslynAnalyzer/DataFlow/StackGuard.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/StackGuard.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.CodeAnalysis
+{
+	// Copied from https://github.com/dotnet/roslyn
+	internal static class StackGuard
+	{
+		public const int MaxUncheckedRecursionDepth = 20;
+
+		/// <summary>
+		///     Ensures that the remaining stack space is large enough to execute
+		///     the average function.
+		/// </summary>
+		/// <param name="recursionDepth">how many times the calling function has recursed</param>
+		/// <exception cref="InsufficientExecutionStackException">
+		///     The available stack space is insufficient to execute
+		///     the average function.
+		/// </exception>
+		[DebuggerStepThrough]
+		public static void EnsureSufficientExecutionStack (int recursionDepth)
+		{
+			if (recursionDepth > MaxUncheckedRecursionDepth) {
+				RuntimeHelpers.EnsureSufficientExecutionStack ();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Thanks @vitek-karas for pointing this out!