### PR TITLE
Ensure trim analysis patterns are additive

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPatternStore.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPatternStore.cs
@@ -3,20 +3,42 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using ILLink.Shared.DataFlow;
 using Microsoft.CodeAnalysis;
+using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
 namespace ILLink.RoslynAnalyzer.TrimAnalysis
 {
 	public readonly struct TrimAnalysisPatternStore : IEnumerable<TrimAnalysisPattern>
 	{
-		readonly Dictionary<IOperation, TrimAnalysisPattern> TrimAnalysisPatterns;
+		readonly Dictionary<(IOperation, bool), TrimAnalysisPattern> TrimAnalysisPatterns;
 
-		public TrimAnalysisPatternStore () => TrimAnalysisPatterns = new Dictionary<IOperation, TrimAnalysisPattern> ();
+		readonly ValueSetLattice<SingleValue> Lattice;
 
-		public void Add (TrimAnalysisPattern trimAnalysisPattern)
+		public TrimAnalysisPatternStore (ValueSetLattice<SingleValue> lattice)
 		{
-			// TODO: check that this doesn't lose warnings (or add instead of replace)
-			TrimAnalysisPatterns[trimAnalysisPattern.Operation] = trimAnalysisPattern;
+			TrimAnalysisPatterns = new Dictionary<(IOperation, bool), TrimAnalysisPattern> ();
+			Lattice = lattice;
+		}
+
+		public void Add (TrimAnalysisPattern trimAnalysisPattern, bool isReturnValue)
+		{
+			// Finally blocks will be analyzed multiple times, once for normal control flow and once
+			// for exceptional control flow, and these separate analyses could produce different
+			// trim analysis patterns.
+			// The current algorithm always does the exceptional analysis last, so the final state for
+			// an operation will include all analysis patterns (since the exceptional state is a superset)
+			// of the normal control-flow state.
+			// We still add patterns to the operation, rather than replacing, to make this resilient to
+			// changes in the analysis algorithm.
+			if (!TrimAnalysisPatterns.TryGetValue ((trimAnalysisPattern.Operation, isReturnValue), out TrimAnalysisPattern existingPattern)) {
+				TrimAnalysisPatterns.Add ((trimAnalysisPattern.Operation, isReturnValue), trimAnalysisPattern);
+				return;
+			}
+
+			MultiValue source = Lattice.Meet (trimAnalysisPattern.Source, existingPattern.Source);
+			MultiValue target = Lattice.Meet (trimAnalysisPattern.Target, existingPattern.Target);
+			TrimAnalysisPatterns[(trimAnalysisPattern.Operation, isReturnValue)] = new TrimAnalysisPattern (source, target, trimAnalysisPattern.Operation);
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -25,7 +25,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			OperationBlockAnalysisContext context
 		) : base (lattice, context)
 		{
-			TrimAnalysisPatterns = new TrimAnalysisPatternStore ();
+			TrimAnalysisPatterns = new TrimAnalysisPatternStore (lattice.Lattice.ValueLattice);
 		}
 
 		// Override visitor methods to create tracked values when visiting operations
@@ -122,7 +122,10 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 			// TODO: consider not tracking patterns unless the target is something
 			// annotated with DAMT.
-			TrimAnalysisPatterns.Add (new TrimAnalysisPattern (source, target, operation));
+			TrimAnalysisPatterns.Add (
+				new TrimAnalysisPattern (source, target, operation),
+				isReturnValue: false
+			);
 		}
 
 		public override void HandleArgument (MultiValue argumentValue, IArgumentOperation operation)
@@ -133,11 +136,10 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 			var parameter = new MethodParameterValue (operation.Parameter);
 
-			TrimAnalysisPatterns.Add (new TrimAnalysisPattern (
-				argumentValue,
-				parameter,
-				operation
-			));
+			TrimAnalysisPatterns.Add (
+				new TrimAnalysisPattern (argumentValue, parameter, operation),
+				isReturnValue: false
+			);
 		}
 
 		// Similar to HandleArgument, for an assignment operation that is really passing an argument to a property setter.
@@ -145,7 +147,9 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 		{
 			var parameter = new MethodParameterValue (setMethod.Parameters[0]);
 
-			TrimAnalysisPatterns.Add (new TrimAnalysisPattern (value, parameter, operation));
+			TrimAnalysisPatterns.Add (
+				new TrimAnalysisPattern (value, parameter, operation),
+				isReturnValue: false);
 		}
 
 		// Can be called for an invocation or a propertyreference
@@ -154,22 +158,20 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 		{
 			MultiValue thisParameter = new MethodThisParameterValue (targetMethod!);
 
-			TrimAnalysisPatterns.Add (new TrimAnalysisPattern (
-				receiverValue,
-				thisParameter,
-				operation
-			));
+			TrimAnalysisPatterns.Add (
+				new TrimAnalysisPattern (receiverValue, thisParameter, operation),
+				isReturnValue: false
+			);
 		}
 
 		public override void HandleReturnValue (MultiValue returnValue, IOperation operation)
 		{
 			var returnParameter = new MethodReturnValue ((IMethodSymbol) Context.OwningSymbol);
 
-			TrimAnalysisPatterns.Add (new TrimAnalysisPattern (
-				returnValue,
-				returnParameter,
-				operation
-			));
+			TrimAnalysisPatterns.Add (
+				new TrimAnalysisPattern (returnValue, returnParameter, operation),
+				isReturnValue: true
+			);
 		}
 	}
 }


### PR DESCRIPTION
During the analysis, we may pass over an operation multiple times with different dataflow states. As we go, we cache the dataflow values that are later used to produce warnings. This change makes the logic more robust by ensuring we never lose cached values.

As part of this I discovered (via some test failures) that caching these by operation isn't enough - for example, in `return Foo();` the `Foo()` may produce warnings both for a mismatch on the implicit receiver (`this`), and for the return value of `Foo()`. To fix this, I think it's enough to cache them by operation and whether it is a returned value.