### PR TITLE
[release/6.0.2xx] Fix analyzer nullref on assembly attribute

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -54,7 +54,8 @@ namespace ILLink.RoslynAnalyzer
 			if (member is ISymbol containingSymbol) {
 				if (containingSymbol.HasAttribute (requiresAttribute)
 					|| (containingSymbol is not ITypeSymbol &&
-						 containingSymbol.ContainingType.HasAttribute (requiresAttribute))) {
+						containingSymbol.ContainingType is ITypeSymbol containingType &&
+						containingType.HasAttribute (requiresAttribute))) {
 					return true;
 				}
 			}

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -423,5 +423,20 @@ class C
 
 			return VerifyRequiresUnreferencedCodeAnalyzer (source);
 		}
+
+		[Fact]
+		public Task TestPropertyAssignmentInAssemblyAttribute ()
+		{
+			var source = @"
+using System;
+[assembly: MyAttribute (Value = 5)]
+
+class MyAttribute : Attribute
+{
+	public int Value { get; set; }
+}
+";
+			return VerifyRequiresUnreferencedCodeAnalyzer (source);
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttributeCtor.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttributeCtor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -15,7 +15,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 	[ExpectedNoWarnings]
 	public class RequiresOnAttributeCtor
 	{
-		[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
+		[ExpectedWarning ("IL2026", "RUC on MethodAnnotatedWithRequires")]
+		[ExpectedWarning ("IL2026", "RUC on TestTypeWithRequires")]
 		public static void Main ()
 		{
 			var type = new Type ();
@@ -27,6 +28,17 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			type.EventAdd -= (sender, e) => { };
 			type.EventRemove += (sender, e) => { };
 			Type.Interface annotatedInterface = new Type.NestedType ();
+
+			TestTypeWithRequires ();
+		}
+
+		[RequiresUnreferencedCode ("RUC on TestTypeWithRequires")]
+		public static void TestTypeWithRequires ()
+		{
+			var typeWithRequires = new TypeWithRequires ();
+			typeWithRequires.Method ();
+			TypeWithRequires.StaticMethod ();
+			TypeWithRequires.Interface annotatedInterface = new TypeWithRequires.NestedType ();
 		}
 
 		[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
@@ -40,7 +52,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 			}
 
-			[RequiresUnreferencedCode ("Message from attribute's ctor.")]
+			[RequiresUnreferencedCode ("RUC on MethodAnnotatedWithRequires")]
 			[RequiresOnAttributeCtor]
 			public void MethodAnnotatedWithRequires ()
 			{
@@ -82,6 +94,41 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 			}
 
+			[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
+			[RequiresOnAttributeCtor]
+			public class NestedType : Interface
+			{
+			}
+		}
+
+		// https://github.com/dotnet/linker/issues/2529
+		[ExpectedWarning ("IL2026", "Message from attribute's ctor.", ProducedBy = ProducedBy.Trimmer)]
+		[RequiresUnreferencedCode ("RUC on TypeWithRequires")]
+		[RequiresOnAttributeCtor]
+		public class TypeWithRequires
+		{
+			// https://github.com/dotnet/linker/issues/2529
+			[ExpectedWarning ("IL2026", "Message from attribute's ctor.", ProducedBy = ProducedBy.Analyzer)]
+			[RequiresOnAttributeCtor]
+			public void Method ()
+			{
+			}
+
+			// https://github.com/dotnet/linker/issues/2529
+			[ExpectedWarning ("IL2026", "Message from attribute's ctor.", ProducedBy = ProducedBy.Analyzer)]
+			[RequiresOnAttributeCtor]
+			public static void StaticMethod ()
+			{
+			}
+
+			[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
+			[RequiresOnAttributeCtor]
+			public interface Interface
+			{
+			}
+
+			[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
+			[RequiresOnAttributeCtor]
 			public class NestedType : Interface
 			{
 			}


### PR DESCRIPTION
The analyzer runs for property assignment operations, including those in
attributes. To check whether the property assignment should warn, we
look for RUC on the containing symbol. However, assembly-level attributes
are contained in the global namespace, which has a null containing type.

## Customer Impact

Assembly-level attribute with property assignment causes a crash in the RequiresAttribute analyzers. https://github.com/dotnet/linker/issues/2563 hits what is likely this issue.

## Testing

Unit tests added in this change. This was originally discovered as part of running the analyzer over the existing linker tests as part of https://github.com/dotnet/linker/pull/2523.

## Risk

Very low risk - the change adds an extra null check without impacting other code paths.
