### PR TITLE
Enable LinkAttributes.xml to be passed to analyzers in unit tests in AdditionalFiles

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/LinkAttributesTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkAttributesTests.cs
@@ -8,22 +8,25 @@ namespace ILLink.RoslynAnalyzer.Tests
 	{
 		protected override string TestSuiteName => "LinkAttributes";
 
-		//[Fact]
+		[Fact(Skip = "XML Analyzer not implemented")]
 		public Task EmbeddedLinkAttributes ()
 		{
 			return RunTest (nameof (EmbeddedLinkAttributes));
 		}
-		//[Fact]
+
+		[Fact(Skip = "XML Analyzer not implemented")]
 		public Task LinkerAttributeRemoval ()
 		{
 			return RunTest (nameof (LinkerAttributeRemoval));
 		}
-		//[Fact]
+
+		[Fact(Skip = "XML Analyzer not implemented")]
 		public Task TypedArguments ()
 		{
 			return RunTest (nameof (TypedArguments));
 		}
-		//[Fact]
+
+		[Fact(Skip = "XML Analyzer not implemented")]
 		public Task LinkerAttributeRemovalConditional ()
 		{
 			return RunTest (nameof (LinkerAttributeRemovalConditional));

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkAttributesTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkAttributesTests.cs
@@ -1,0 +1,32 @@
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+	public sealed class LinkAttributesTests : LinkerTestBase
+	{
+		protected override string TestSuiteName => "LinkAttributes";
+
+		//[Fact]
+		public Task EmbeddedLinkAttributes ()
+		{
+			return RunTest (nameof (EmbeddedLinkAttributes));
+		}
+		//[Fact]
+		public Task LinkerAttributeRemoval ()
+		{
+			return RunTest (nameof (LinkerAttributeRemoval));
+		}
+		//[Fact]
+		public Task TypedArguments ()
+		{
+			return RunTest (nameof (TypedArguments));
+		}
+		//[Fact]
+		public Task LinkerAttributeRemovalConditional ()
+		{
+			return RunTest (nameof (LinkerAttributeRemovalConditional));
+		}
+	}
+}

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseCompilation.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseCompilation.cs
@@ -30,17 +30,15 @@ namespace ILLink.RoslynAnalyzer.Tests
 			(string, string)[]? globalAnalyzerOptions = null,
 			IEnumerable<MetadataReference>? additionalReferences = null,
 			IEnumerable<SyntaxTree>? additionalSources = null,
-			string? testCaseDirectory = null,
-			string? testCaseName = null)
-			=> CreateCompilation (CSharpSyntaxTree.ParseText (src), globalAnalyzerOptions, additionalReferences, additionalSources, testCaseDirectory, testCaseName);
+			IEnumerable<AdditionalText>? additionalFiles = null)
+			=> CreateCompilation (CSharpSyntaxTree.ParseText (src), globalAnalyzerOptions, additionalReferences, additionalSources, additionalFiles);
 
 		public static async Task<(CompilationWithAnalyzers Compilation, SemanticModel SemanticModel, List<Diagnostic> ExceptionDiagnostics)> CreateCompilation (
 			SyntaxTree src,
 			(string, string)[]? globalAnalyzerOptions = null,
 			IEnumerable<MetadataReference>? additionalReferences = null,
 			IEnumerable<SyntaxTree>? additionalSources = null,
-			string? testCaseDirectory = null,
-			string? testCaseName = null)
+			IEnumerable<AdditionalText>? additionalFiles = null)
 		{
 			var mdRef = MetadataReference.CreateFromFile (typeof (Mono.Linker.Tests.Cases.Expectations.Metadata.BaseMetadataAttribute).Assembly.Location);
 			additionalReferences ??= Array.Empty<MetadataReference> ();
@@ -51,26 +49,8 @@ namespace ILLink.RoslynAnalyzer.Tests
 				syntaxTrees: sources,
 				references: (await TestCaseUtils.GetNet6References ()).Add (mdRef).AddRange (additionalReferences),
 				new CSharpCompilationOptions (OutputKind.DynamicallyLinkedLibrary));
-			List<AdditionalText> additionalTexts = new ();
-			if (testCaseName != null) {
-				var testClasses = comp.GetSymbolsWithName (testCaseName);
-				foreach (var testClass in testClasses) {
-					var attributeFileAttribute = testClass.GetAttributes ()
-						.Where (attribute => attribute.AttributeClass?.Name == nameof (SetupLinkAttributesFile) || (attribute.AttributeClass?.Name == nameof(SetupCompileResourceAttribute) && (string?) attribute.ConstructorArguments[1].Value == "ILLink.LinkAttributes.xml"));
-					foreach (var attribute in attributeFileAttribute) {
-						var xmlFileName = (string) attribute.ConstructorArguments[0].Value!;
-						var resolver = new XmlFileResolver (testCaseDirectory);
-						var resolvedPath = resolver.ResolveReference (xmlFileName, testCaseDirectory);
-						if (resolvedPath != null) {
-							var stream = resolver.OpenRead (resolvedPath);
-							XmlText text = new ("ILLink.LinkAttributes.xml", stream);
-							additionalTexts.Add (text);
-						}
-					}
-				}
-			}
 			var analyzerOptions = new AnalyzerOptions (
-				additionalFiles: additionalTexts.ToImmutableArray (),
+				additionalFiles: additionalFiles?.ToImmutableArray () ?? ImmutableArray<AdditionalText>.Empty,
 				new SimpleAnalyzerOptions (globalAnalyzerOptions));
 
 			var exceptionDiagnostics = new List<Diagnostic> ();

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -45,7 +45,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		{
 			GetDirectoryPaths (out string rootSourceDir, out string testAssemblyPath);
 			Debug.Assert (Path.GetFileName (rootSourceDir) == MonoLinkerTestsCases);
-			var testDirectory = Path.Combine (rootSourceDir, suiteName);
 			var testPath = Path.Combine (rootSourceDir, suiteName, $"{testName}.cs");
 			Assert.True (File.Exists (testPath));
 			var tree = SyntaxFactory.ParseSyntaxTree (
@@ -72,7 +71,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 
 		private static IEnumerable<string> GetTestDependencies (string rootSourceDir, SyntaxTree testSyntaxTree)
 		{
-			List<AdditionalText> additionalTexts = new ();
 			foreach (var attribute in testSyntaxTree.GetRoot ().DescendantNodes ().OfType<AttributeSyntax> ()) {
 				if (attribute.Name.ToString () != "SetupCompileBefore")
 					continue;

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -43,6 +43,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		{
 			GetDirectoryPaths (out string rootSourceDir, out string testAssemblyPath);
 			Debug.Assert (Path.GetFileName (rootSourceDir) == MonoLinkerTestsCases);
+			var testDirectory = Path.Combine (rootSourceDir, suiteName);
 			var testPath = Path.Combine (rootSourceDir, suiteName, $"{testName}.cs");
 			Assert.True (File.Exists (testPath));
 			var tree = SyntaxFactory.ParseSyntaxTree (
@@ -55,7 +56,9 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var (comp, model, exceptionDiagnostics) = await TestCaseCompilation.CreateCompilation (
 					tree,
 					msbuildProperties,
-					additionalSources: testDependenciesSource);
+					additionalSources: testDependenciesSource,
+					testCaseDirectory: testDirectory,
+					testCaseName: testName);
 
 			// Note that the exception diagnostics will be empty until the analyzer has run,
 			// so be sure to get them after awaiting GetAnalyzerDiagnosticsAsync().

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -14,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Xunit;
 
 namespace ILLink.RoslynAnalyzer.Tests
@@ -52,13 +54,13 @@ namespace ILLink.RoslynAnalyzer.Tests
 
 			var testDependenciesSource = GetTestDependencies (rootSourceDir, tree)
 				.Select (f => SyntaxFactory.ParseSyntaxTree (SourceText.From (File.OpenRead (f))));
+			var additionalFiles = GetAdditionalFiles (rootSourceDir, tree);
 
 			var (comp, model, exceptionDiagnostics) = await TestCaseCompilation.CreateCompilation (
 					tree,
 					msbuildProperties,
 					additionalSources: testDependenciesSource,
-					testCaseDirectory: testDirectory,
-					testCaseName: testName);
+					additionalFiles: additionalFiles);
 
 			// Note that the exception diagnostics will be empty until the analyzer has run,
 			// so be sure to get them after awaiting GetAnalyzerDiagnosticsAsync().
@@ -70,15 +72,33 @@ namespace ILLink.RoslynAnalyzer.Tests
 
 		private static IEnumerable<string> GetTestDependencies (string rootSourceDir, SyntaxTree testSyntaxTree)
 		{
+			List<AdditionalText> additionalTexts = new ();
 			foreach (var attribute in testSyntaxTree.GetRoot ().DescendantNodes ().OfType<AttributeSyntax> ()) {
 				if (attribute.Name.ToString () != "SetupCompileBefore")
 					continue;
-
 				var testNamespace = testSyntaxTree.GetRoot ().DescendantNodes ().OfType<NamespaceDeclarationSyntax> ().Single ().Name.ToString ();
 				var testSuiteName = testNamespace.Substring (testNamespace.LastIndexOf ('.') + 1);
 				var args = LinkerTestBase.GetAttributeArguments (attribute);
 				foreach (var sourceFile in ((ImplicitArrayCreationExpressionSyntax) args["#1"]).DescendantNodes ().OfType<LiteralExpressionSyntax> ())
 					yield return Path.Combine (rootSourceDir, testSuiteName, LinkerTestBase.GetStringFromExpression (sourceFile));
+			}
+		}
+
+		private static IEnumerable<AdditionalText> GetAdditionalFiles(string rootSourceDir, SyntaxTree tree)
+		{
+			var resolver = new XmlFileResolver (rootSourceDir);
+			foreach (var attribute in tree.GetRoot ().DescendantNodes ().OfType<AttributeSyntax> ()) {
+				if (attribute.Name.ToString () == nameof (SetupLinkAttributesFile)
+					|| (attribute.Name.ToString ().Contains ("SetupCompileResource")
+						&& (string?) attribute.ArgumentList?.Arguments[1].ToString () == "\"ILLink.LinkAttributes.xml\"")) {
+					var xmlFileName = attribute.ArgumentList?.Arguments[0].ToString ().Trim ('"') ?? "";
+					var resolvedPath = resolver.ResolveReference (xmlFileName, rootSourceDir);
+					if (resolvedPath != null) {
+						var stream = resolver.OpenRead (resolvedPath);
+						XmlText text = new ("ILLink.LinkAttributes.xml", stream);
+						yield return text;
+					}
+				}
 			}
 		}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/XmlText.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/XmlText.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+	class XmlText : AdditionalText
+	{
+		public override string Path { get; }
+		Stream Doc;
+		public XmlText (string path, Stream data)
+		{
+			Path = path;
+			Doc = data;
+		}
+
+		public override SourceText? GetText(CancellationToken token = default)
+		{
+			return SourceText.From (Doc);
+		}
+	}
+}


### PR DESCRIPTION
Creates a new implementation of the `AdditionalText` class to use when passing xml files to the analyzers and adds test file path parameters to `CreateCompilation` signatures to find the xml files. The names of the test files are found in the `[SetupCompileResourceAttribute]` and `[SetupLinkAttributesFile]` attributes, then the paths are resolved relative to the test files and added to the compilation as "ILLink.LinkAttributes.xml". This does not yet add substitution and descriptor xml files, but it should be easy to add those later.

LinkAttributesTests test cases always fail, but they all include a LinkAttributes.xml file and are good for debugging to check that the ILLink.LinkAttributes.xml file shows up in the analyzers.