### PR TITLE
Title and message resources should be enforced to exist to prevent printing empty messages

### DIFF
--- a/src/ILLink.Shared/DiagnosticString.cs
+++ b/src/ILLink.Shared/DiagnosticString.cs
@@ -13,15 +13,15 @@ namespace ILLink.Shared
 		public DiagnosticString (DiagnosticId diagnosticId)
 		{
 			var resourceManager = SharedStrings.ResourceManager;
-			_titleFormat = resourceManager.GetString ($"{diagnosticId}Title") ?? throw new NullReferenceException($"{diagnosticId} does not have a matching resource called {diagnosticId}Title");
-			_messageFormat = resourceManager.GetString ($"{diagnosticId}Message") ?? throw new NullReferenceException($"{diagnosticId} does not have a matching resource called {diagnosticId}Message");
+			_titleFormat = resourceManager.GetString ($"{diagnosticId}Title") ?? throw new InvalidOperationException ($"{diagnosticId} does not have a matching resource called {diagnosticId}Title");
+			_messageFormat = resourceManager.GetString ($"{diagnosticId}Message") ?? throw new InvalidOperationException ($"{diagnosticId} does not have a matching resource called {diagnosticId}Message");
 		}
 
 		public DiagnosticString (string diagnosticResourceStringName)
 		{
 			var resourceManager = SharedStrings.ResourceManager;
-			_titleFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Title") ?? throw new NullReferenceException ($"{diagnosticResourceStringName} does not have a matching resource called {diagnosticResourceStringName}Title");
-			_messageFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Message") ?? throw new NullReferenceException ($"{diagnosticResourceStringName} does not have a matching resource called {diagnosticResourceStringName}Message");
+			_titleFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Title") ?? throw new InvalidOperationException ($"{diagnosticResourceStringName} does not have a matching resource called {diagnosticResourceStringName}Title");
+			_messageFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Message") ?? throw new InvalidOperationException ($"{diagnosticResourceStringName} does not have a matching resource called {diagnosticResourceStringName}Message");
 		}
 
 		public string GetMessage (params string[] args) =>

--- a/src/ILLink.Shared/DiagnosticString.cs
+++ b/src/ILLink.Shared/DiagnosticString.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace ILLink.Shared
 {
 	public readonly struct DiagnosticString
@@ -11,15 +13,15 @@ namespace ILLink.Shared
 		public DiagnosticString (DiagnosticId diagnosticId)
 		{
 			var resourceManager = SharedStrings.ResourceManager;
-			_titleFormat = resourceManager.GetString ($"{diagnosticId}Title") ?? string.Empty;
-			_messageFormat = resourceManager.GetString ($"{diagnosticId}Message") ?? string.Empty;
+			_titleFormat = resourceManager.GetString ($"{diagnosticId}Title") ?? throw new NullReferenceException($"{diagnosticId} does not have a matching resource called {diagnosticId}Title");
+			_messageFormat = resourceManager.GetString ($"{diagnosticId}Message") ?? throw new NullReferenceException($"{diagnosticId} does not have a matching resource called {diagnosticId}Message");
 		}
 
 		public DiagnosticString (string diagnosticResourceStringName)
 		{
 			var resourceManager = SharedStrings.ResourceManager;
-			_titleFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Title") ?? string.Empty;
-			_messageFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Message") ?? string.Empty;
+			_titleFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Title") ?? throw new NullReferenceException ($"{diagnosticResourceStringName} does not have a matching resource called {diagnosticResourceStringName}Title");
+			_messageFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Message") ?? throw new NullReferenceException ($"{diagnosticResourceStringName} does not have a matching resource called {diagnosticResourceStringName}Message");
 		}
 
 		public string GetMessage (params string[] args) =>

--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -117,212 +117,422 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="XmlFeatureDoesNotSpecifyFeatureValueTitle" xml:space="preserve">
+    <value>An Xml Feature does not specify a 'featurevalue' attribute.</value>
+  </data>
   <data name="XmlFeatureDoesNotSpecifyFeatureValueMessage" xml:space="preserve">
     <value>Failed to process '{0}'. Feature '{1}' does not specify a 'featurevalue' attribute.</value>
+  </data>
+  <data name="XmlUnsupportedNonBooleanValueForFeatureTitle" xml:space="preserve">
+    <value>Feature definition has to be a boolean.</value>
   </data>
   <data name="XmlUnsupportedNonBooleanValueForFeatureMessage" xml:space="preserve">
     <value>Failed to process '{0}'. Unsupported non-boolean feature definition '{1}'.</value>
   </data>
+  <data name="XmlExceptionTitle" xml:space="preserve">
+    <value>An exception was thrown while processing the xml file.</value>
+  </data>
   <data name="XmlExceptionMessage" xml:space="preserve">
     <value>Error processing '{0}': {1}.</value>
+  </data>
+  <data name="CouldNotFindMethodInAssemblyTitle" xml:space="preserve">
+    <value>An error ocurred while processing a method in assembly.</value>
   </data>
   <data name="CouldNotFindMethodInAssemblyMessage" xml:space="preserve">
     <value>Error processing method '{0}' in assembly '{1}'.</value>
   </data>
+  <data name="CannotStubConstructorWhenBaseTypeDoesNotHaveConstructorTitle" xml:space="preserve">
+    <value>Cannot stub constructor of a type when base type does not have default constructor. Constructors of derived types marked for substitution require to have a default constructor in its base type.</value>
+  </data>
   <data name="CannotStubConstructorWhenBaseTypeDoesNotHaveConstructorMessage" xml:space="preserve">
     <value>Cannot stub constructor on '{0}' when base type does not have default constructor.</value>
+  </data>
+  <data name="CouldNotFindTypeTitle" xml:space="preserve">
+    <value>Could not find predefined type".</value>
   </data>
   <data name="CouldNotFindTypeMessage" xml:space="preserve">
     <value>Missing predefined '{0}' type".</value>
   </data>
+<data name="CouldNotFindConstructorTitle" xml:space="preserve">
+    <value>Could not find constructor.</value>
+  </data>
   <data name="CouldNotFindConstructorMessage" xml:space="preserve">
     <value>Could not find constructor on '{0}'.</value>
+  </data>
+  <data name="CouldNotFindAssemblyReferenceTitle" xml:space="preserve">
+    <value>Assembly reference could not be resolved.</value>
   </data>
   <data name="CouldNotFindAssemblyReferenceMessage" xml:space="preserve">
     <value>Assembly reference '{0}' could not be resolved.</value>
   </data>
+  <data name="CouldNotLoadAssemblyTitle" xml:space="preserve">
+    <value>Assembly cannot be loaded due to failure in processing the reference assembly.</value>
+  </data>
   <data name="CouldNotLoadAssemblyMessage" xml:space="preserve">
     <value>Assembly '{0}' cannot be loaded due to failure in processing '{1}' reference</value>
+  </data>
+  <data name="FailedToWriteOutputTitle" xml:space="preserve">
+    <value>There was an error writing the linked assembly 'output'.</value>
   </data>
   <data name="FailedToWriteOutputMessage" xml:space="preserve">
     <value>Failed to write '{0}'.</value>
   </data>
+  <data name="LinkerUnexpectedErrorTitle" xml:space="preserve">
+    <value>There was an unexpected error while trimming. An exception with more details is printed to the MSBuild log. Please share this stack trace with the IL Linker team to further investigate the cause and possible solution.</value>
+  </data>
   <data name="LinkerUnexpectedErrorMessage" xml:space="preserve">
     <value>IL Trimmer has encountered an unexpected error. Please report the issue at https://github.com/dotnet/linker/issues</value>
+  </data>
+  <data name="ErrorProcessingXmlLocationTitle" xml:space="preserve">
+    <value>There was an error processing 'XML document location' xml file. The most likely reason for this is that the XML file has syntactical errors.</value>
   </data>
   <data name="ErrorProcessingXmlLocationMessage" xml:space="preserve">
     <value>Error processing '{0}'.</value>
   </data>
+  <data name="XmlDocumentLocationHasInvalidFeatureDefaultTitle" xml:space="preserve">
+    <value>Element in XML document contains a 'featuredefault' attribute with an invalid value.</value>
+  </data>
   <data name="XmlDocumentLocationHasInvalidFeatureDefaultMessage" xml:space="preserve">
     <value>Failed to process '{0}'. Unsupported value for featuredefault attribute.</value>
+  </data>
+  <data name="UnrecognizedCommandLineOptionTitle" xml:space="preserve">
+    <value>The string passed to the command-line does not correspond to a valid command-line option.</value>
   </data>
   <data name="UnrecognizedCommandLineOptionMessage" xml:space="preserve">
     <value>Unrecognized command-line option: '{0}'.</value>
   </data>
+  <data name="InvalidWarningVersionTitle" xml:space="preserve">
+    <value>The value given for the --warn argument was not a valid warning version.</value>
+  </data>
   <data name="InvalidWarningVersionMessage" xml:space="preserve">
     <value>Invalid warning version '{0}'.</value>
+  </data>
+  <data name="InvalidGenerateWarningSuppressionsValueTitle" xml:space="preserve">
+    <value>Invalid value 'value' was used for command-line option '--generate-warning-suppressions'; must be 'cs' or 'xml'.</value>
   </data>
   <data name="InvalidGenerateWarningSuppressionsValueMessage" xml:space="preserve">
     <value>Invalid value '{0}' for '--generate-warning-suppressions' option.</value>
   </data>
+  <data name="MissingArgumentForCommanLineOptionNameTitle" xml:space="preserve">
+    <value>The command-line option 'optionName' was specified but no argument was given.</value>
+  </data>
   <data name="MissingArgumentForCommanLineOptionNameMessage" xml:space="preserve">
     <value>Missing argument for '{0}' option.</value>
+  </data>
+  <data name="CustomDataFormatIsInvalidTitle" xml:space="preserve">
+    <value>The command-line option --custom-data receives a key-value pair using the format KEY=VALUE.</value>
   </data>
   <data name="CustomDataFormatIsInvalidMessage" xml:space="preserve">
     <value>Value used with '--custom-data' has to be in the KEY=VALUE format.</value>
   </data>
+  <data name="NoFilesToLinkSpecifiedTitle" xml:space="preserve">
+    <value>No input files were specified. Use one of the resolver options.</value>
+  </data>
   <data name="NoFilesToLinkSpecifiedMessage" xml:space="preserve">
     <value>No input files were specified. Use one of '{0}' options.</value>
+  </data>
+  <data name="NewMvidAndDeterministicCannotBeUsedAtSameTimeTitle" xml:space="preserve">
+    <value>Options '--new-mvid' and '--deterministic' cannot be used at the same time.</value>
   </data>
   <data name="NewMvidAndDeterministicCannotBeUsedAtSameTimeMessage" xml:space="preserve">
     <value>Options '--new-mvid' and '--deterministic' cannot be used at the same time.</value>
   </data>
+  <data name="AssemblyInCustomStepOptionCouldNotBeFoundTitle" xml:space="preserve">
+    <value>The assembly argument specified for '--custom-step' option could not be found.</value>
+  </data>
   <data name="AssemblyInCustomStepOptionCouldNotBeFoundMessage" xml:space="preserve">
     <value>The assembly '{0}' specified for '--custom-step' option could not be found.</value>
+  </data>
+  <data name="AssemblyPathInCustomStepMustBeFullyQualifiedTitle" xml:space="preserve">
+    <value>The path to the assembly specified for '--custom-step' must be fully qualified.</value>
   </data>
   <data name="AssemblyPathInCustomStepMustBeFullyQualifiedMessage" xml:space="preserve">
     <value>The path to the assembly '{0}' specified for '--custom-step' must be fully qualified.</value>
   </data>
+  <data name="InvalidArgForCustomStepTitle" xml:space="preserve">
+    <value>An invalid value was specified for '--custom-step' option.</value>
+  </data>
   <data name="InvalidArgForCustomStepMessage" xml:space="preserve">
     <value>Invalid value '{0}' specified for '--custom-step' option.</value>
+  </data>
+  <data name="ExpectedSignToControlNewStepInsertionTitle" xml:space="preserve">
+    <value>A custom step that is inserted relative to an existing step in the pipeline must specify whether to be added before (-) or after (+) the step it's relative to.</value>
   </data>
   <data name="ExpectedSignToControlNewStepInsertionMessage" xml:space="preserve">
     <value>Expected '+' or '-' to control new step insertion.</value>
   </data>
+  <data name="PipelineStepCouldNotBeFoundTitle" xml:space="preserve">
+    <value>A custom step was specified for insertion relative to a non existent step.</value>
+  </data>
   <data name="PipelineStepCouldNotBeFoundMessage" xml:space="preserve">
     <value>Pipeline step '{0}' could not be found.</value>
+  </data>
+  <data name="CustomStepTypeCouldNotBeFoundTitle" xml:space="preserve">
+    <value>The custom step could not be found in the given assembly.</value>
   </data>
   <data name="CustomStepTypeCouldNotBeFoundMessage" xml:space="preserve">
     <value>Custom step '{0}' could not be found.</value>
   </data>
+  <data name="CustomStepTypeIsIncompatibleWithLinkerVersionTitle" xml:space="preserve">
+    <value>Custom step is incompatible with this trimmer version.</value>
+  </data>
   <data name="CustomStepTypeIsIncompatibleWithLinkerVersionMessage" xml:space="preserve">
     <value>Custom step '{0}' is incompatible with this trimmer version.</value>
+  </data>
+  <data name="InvalidOptimizationValueTitle" xml:space="preserve">
+    <value>The optimization 'text' is invalid. Optimization values can either be 'beforefieldinit', 'overrideremoval', 'unreachablebodies', 'unusedinterfaces', 'ipconstprop', or 'sealer'.</value>
   </data>
   <data name="InvalidOptimizationValueMessage" xml:space="preserve">
     <value>Invalid optimization value '{0}'.</value>
   </data>
+  <data name="InvalidArgumentForTokenOptionTitle" xml:space="preserve">
+    <value>Invalid argument for 'token' option.</value>
+  </data>
   <data name="InvalidArgumentForTokenOptionMessage" xml:space="preserve">
     <value>Invalid argument for '{0}' option.</value>
+  </data>
+  <data name="InvalidAssemblyActionTitle" xml:space="preserve">
+    <value>Invalid assembly action.</value>
   </data>
   <data name="InvalidAssemblyActionMessage" xml:space="preserve">
     <value>Invalid assembly action '{0}'.</value>
   </data>
+  <data name="RootAssemblyCouldNotBeFoundTitle" xml:space="preserve">
+    <value>Root assembly could not be found.</value>
+  </data>
   <data name="RootAssemblyCouldNotBeFoundMessage" xml:space="preserve">
     <value>Root assembly '{0}' could not be found.</value>
+  </data>
+  <data name="XmlDescriptorCouldNotBeFoundTitle" xml:space="preserve">
+    <value>XML descriptor file could not be found'.</value>
   </data>
   <data name="XmlDescriptorCouldNotBeFoundMessage" xml:space="preserve">
     <value>XML descriptor file '{0}' could not be found'.</value>
   </data>
+  <data name="RootAssemblyDoesNotHaveEntryPointTitle" xml:space="preserve">
+    <value>Root assembly does not have entry point.</value>
+  </data>
   <data name="RootAssemblyDoesNotHaveEntryPointMessage" xml:space="preserve">
     <value>Root assembly '{0}' does not have entry point.</value>
+  </data>
+  <data name="RootAssemblyCannotUseActionTitle" xml:space="preserve">
+    <value>Referenced root assembly cannot use the specified action.</value>
   </data>
   <data name="RootAssemblyCannotUseActionMessage" xml:space="preserve">
     <value>Root assembly '{0}' cannot use action '{1}'.</value>
   </data>
+  <data name="InvalidAssemblyNameTitle" xml:space="preserve">
+    <value>Invalid assembly name.</value>
+  </data>
   <data name="InvalidAssemblyNameMessage" xml:space="preserve">
     <value>Invalid assembly name '{0}'.</value>
+  </data>
+  <data name="InvalidAssemblyRootModeTitle" xml:space="preserve">
+    <value>Invalid assembly root mode.</value>
   </data>
   <data name="InvalidAssemblyRootModeMessage" xml:space="preserve">
     <value>Invalid assembly root mode '{0}'.</value>
   </data>
+  <data name="ExportedTypeCannotBeResolvedTitle" xml:space="preserve">
+    <value>Exported type cannot be resolved.</value>
+  </data>
   <data name="ExportedTypeCannotBeResolvedMessage" xml:space="preserve">
     <value>Exported type '{0}' cannot be resolved.</value>
+  </data>
+  <data name="ReferenceAssemblyCouldNotBeLoadedTitle" xml:space="preserve">
+    <value>A reference assembly input passed via -reference could not be loaded.</value>
   </data>
   <data name="ReferenceAssemblyCouldNotBeLoadedMessage" xml:space="preserve">
     <value>Reference assembly '{0}' could not be loaded.</value>
   </data>
+  <data name="FailedToResolveMetadataElementTitle" xml:space="preserve">
+    <value>Metadata element cannot be resolved. This usually means there is a version mismatch between dependencies.</value>
+  </data>
   <data name="FailedToResolveMetadataElementMessage" xml:space="preserve">
     <value>{0}.</value>
+  </data>
+  <data name="FailedToResolveFieldElementTitle" xml:space="preserve">
+    <value>Field element cannot be resolved. This usually means there is a version mismatch between dependencies.</value>
   </data>
   <data name="FailedToResolveFieldElementMessage" xml:space="preserve">
     <value>Field '{0}' reference could not be resolved.</value>
   </data>
+  <data name="FailedToResolveMethodElementTitle" xml:space="preserve">
+    <value>Method element cannot be resolved. This usually means there is a version mismatch between dependencies.</value>
+  </data>
   <data name="FailedToResolveMethodElementMessage" xml:space="preserve">
     <value>Method '{0}' reference could not be resolved.</value>
+  </data>
+  <data name="FailedToResolveTypeElementTitle" xml:space="preserve">
+    <value>Type element cannot be resolved. This usually means there is a version mismatch between dependencies.</value>
   </data>
   <data name="FailedToResolveTypeElementMessage" xml:space="preserve">
     <value>Type '{0}' reference could not be resolved.</value>
   </data>
+  <data name="TypeUsedWithAttributeValueCouldNotBeFoundTitle" xml:space="preserve">
+    <value>The type name used to define custom attribute value could not be resolved.</value>
+  </data>
   <data name="TypeUsedWithAttributeValueCouldNotBeFoundMessage" xml:space="preserve">
     <value>The type '{0}' used with attribute value '{1}' could not be found.</value>
+  </data>
+  <data name="CannotConverValueToTypeTitle" xml:space="preserve">
+    <value>The 'value' specified for the custom attribute value cannot be converted to specified argument type 'typeName'.</value>
   </data>
   <data name="CannotConverValueToTypeMessage" xml:space="preserve">
     <value>Cannot convert value '{0}' to type '{1}'.</value>
   </data>
+  <data name="CustomAttributeArgumentForTypeRequiresNestedNodeTitle" xml:space="preserve">
+    <value>The syntax for custom attribute value for 'type' requires to also specify the underlying attribute type.</value>
+  </data>
   <data name="CustomAttributeArgumentForTypeRequiresNestedNodeMessage" xml:space="preserve">
     <value>Custom attribute argument for '{0}' requires nested '{1}' node.</value>
+  </data>
+  <data name="CouldNotResolveCustomAttributeTypeValueTitle" xml:space="preserve">
+    <value>The value specified for the custom attribute of System.Type type could not be resolved.</value>
   </data>
   <data name="CouldNotResolveCustomAttributeTypeValueMessage" xml:space="preserve">
     <value>Could not resolve custom attribute type value '{0}'.</value>
   </data>
+  <data name="UnexpectedAttributeArgumentTypeTitle" xml:space="preserve">
+    <value>The type name used with attribute type is not one of the supported types.</value>
+  </data>
   <data name="UnexpectedAttributeArgumentTypeMessage" xml:space="preserve">
     <value>Unexpected attribute argument type '{0}'.</value>
+  </data>
+  <data name="InvalidMetadataOptionTitle" xml:space="preserve">
+    <value>Invalid metadata value.</value>
   </data>
   <data name="InvalidMetadataOptionMessage" xml:space="preserve">
     <value>Invalid metadata value '{0}'.</value>
   </data>
+  <data name="TypeHasNoFieldsToPreserveTitle" xml:space="preserve">
+    <value>The XML descriptor preserves fields on type, but this type has no fields.</value>
+  </data>
   <data name="TypeHasNoFieldsToPreserveMessage" xml:space="preserve">
     <value>Type '{0}' has no fields to preserve.</value>
+  </data>
+  <data name="TypeHasNoMethodsToPreserveTitle" xml:space="preserve">
+    <value>The XML descriptor preserves methods on type, but this type has no methods.</value>
   </data>
   <data name="TypeHasNoMethodsToPreserveMessage" xml:space="preserve">
     <value>Type '{0}' has no methods to preserve.</value>
   </data>
+  <data name="CouldNotResolveDependencyAssemblyTitle" xml:space="preserve">
+    <value>The assembly in PreserveDependency attribute could not be resolved.</value>
+  </data>
   <data name="CouldNotResolveDependencyAssemblyMessage" xml:space="preserve">
     <value>Could not resolve dependency assembly '{0}' specified in a 'PreserveDependency' attribute.</value>
+  </data>
+  <data name="CouldNotResolveDependencyTypeTitle" xml:space="preserve">
+    <value>The type in PreserveDependency attribute could not be resolved.</value>
   </data>
   <data name="CouldNotResolveDependencyTypeMessage" xml:space="preserve">
     <value>Could not resolve dependency type '{0}' specified in a 'PreserveDependency' attribute.</value>
   </data>
+  <data name="CouldNotResolveDependencyMemberTitle" xml:space="preserve">
+    <value>The member in PreserveDependency attribute could not be resolved.</value>
+  </data>
   <data name="CouldNotResolveDependencyMemberMessage" xml:space="preserve">
     <value>Could not resolve dependency member '{0}' declared in type '{1}' specified in a 'PreserveDependency' attribute.</value>
+  </data>
+  <data name="XmlCouldNotResolveAssemblyTitle" xml:space="preserve">
+    <value>The assembly in the XML could not be resolved.</value>
   </data>
   <data name="XmlCouldNotResolveAssemblyMessage" xml:space="preserve">
     <value>Could not resolve assembly '{0}'.</value>
   </data>
+  <data name="XmlCouldNotResolveTypeTitle" xml:space="preserve">
+    <value>The type in the XML could not be resolved.</value>
+  </data>
   <data name="XmlCouldNotResolveTypeMessage" xml:space="preserve">
     <value>Could not resolve type '{0}'.</value>
+  </data>
+  <data name="XmlCouldNotFindMethodOnTypeTitle" xml:space="preserve">
+    <value>The XML defined a method on a type, but the method was not found.</value>
   </data>
   <data name="XmlCouldNotFindMethodOnTypeMessage" xml:space="preserve">
     <value>Could not find method '{0}' on type '{1}'.</value>
   </data>
+  <data name="XmlInvalidValueForStubTitle" xml:space="preserve">
+    <value>Invalid value for 'signature' stub in the substitution XML.</value>
+  </data>
   <data name="XmlInvalidValueForStubMessage" xml:space="preserve">
     <value>Invalid value for '{0}' stub.</value>
+  </data>
+  <data name="XmlUnkownBodyModificationTitle" xml:space="preserve">
+    <value>The value of the body attribute used in the substitution XML is invalid (the only supported options are remove and stub).</value>
   </data>
   <data name="XmlUnkownBodyModificationMessage" xml:space="preserve">
     <value>Unknown body modification '{0}' for '{1}'.</value>
   </data>
+  <data name="XmlCouldNotFindFieldOnTypeTitle" xml:space="preserve">
+    <value>The XML defined a field on a type, but the field was not found.</value>
+  </data>
   <data name="XmlCouldNotFindFieldOnTypeMessage" xml:space="preserve">
     <value>Could not find field '{0}' on type '{1}'.</value>
+  </data>
+  <data name="XmlSubstitutedFieldNeedsToBeStaticTitle" xml:space="preserve">
+    <value>The substituted field 'field' was non-static or constant. Only static non-constant fields are supported.</value>
   </data>
   <data name="XmlSubstitutedFieldNeedsToBeStaticMessage" xml:space="preserve">
     <value>Substituted field '{0}' needs to be static field.</value>
   </data>
+  <data name="XmlMissingSubstitutionValueForFieldTitle" xml:space="preserve">
+    <value>A field was specified for substitution but no value to be substituted was given.</value>
+  </data>
   <data name="XmlMissingSubstitutionValueForFieldMessage" xml:space="preserve">
     <value>Missing 'value' attribute for field '{0}'.</value>
+  </data>
+  <data name="XmlInvalidSubstitutionValueForFieldTitle" xml:space="preserve">
+    <value>The value used in the substitution XML for field is not a built-in type, or does not match the type of the field.</value>
   </data>
   <data name="XmlInvalidSubstitutionValueForFieldMessage" xml:space="preserve">
     <value>Invalid value '{0}' for '{1}'.</value>
   </data>
+  <data name="XmlCouldNotFindEventOnTypeTitle" xml:space="preserve">
+    <value>The XML defined a event on a type, but the event was not found.</value>
+  </data>
   <data name="XmlCouldNotFindEventOnTypeMessage" xml:space="preserve">
     <value>Could not find event '{0}' on type '{1}'.</value>
+  </data>
+  <data name="XmlCouldNotFindPropertyOnTypeTitle" xml:space="preserve">
+    <value>The XML defined a property on a type, but the property was not found.</value>
   </data>
   <data name="XmlCouldNotFindPropertyOnTypeMessage" xml:space="preserve">
     <value>Could not find property '{0}' on type '{1}'.</value>
   </data>
+  <data name="XmlCouldNotFindGetAccesorOfPropertyOnTypeTitle" xml:space="preserve">
+    <value>The XML defined the get accessor of property on a type, but the accessor was not found.</value>
+  </data>
   <data name="XmlCouldNotFindGetAccesorOfPropertyOnTypeMessage" xml:space="preserve">
     <value>Could not find the get accessor of property '{0}' on type '{1}'.</value>
+  </data>
+  <data name="XmlCouldNotFindSetAccesorOfPropertyOnTypeTitle" xml:space="preserve">
+    <value>The XML defined the set accessor of property on a type, but the accessor was not found.</value>
   </data>
   <data name="XmlCouldNotFindSetAccesorOfPropertyOnTypeMessage" xml:space="preserve">
     <value>Could not find the set accessor of property '{0}' in type '{1}'.</value>
   </data>
+  <data name="XmlCouldNotFindMatchingConstructorForCustomAttributeTitle" xml:space="preserve">
+    <value>The XML attribute arguments use values or types which don't match to any constructor</value>
+  </data>
   <data name="XmlCouldNotFindMatchingConstructorForCustomAttributeMessage" xml:space="preserve">
     <value>Could not find matching constructor for custom attribute '{0}' arguments.</value>
+  </data>
+  <data name="XmlMoreThanOneReturnElementForMethodTitle" xml:space="preserve">
+    <value>Method 'method' has more than one return element specified. There can only be one return element.</value>
   </data>
   <data name="XmlMoreThanOneReturnElementForMethodMessage" xml:space="preserve">
     <value>There is more than one 'return' child element specified for method '{0}'.</value>
   </data>
+  <data name="XmlMoreThanOneValyForParameterOfMethodTitle" xml:space="preserve">
+    <value>Method has more than one parameter for the XML element 'parameter'. There can only be one value specified for each parameter.</value>
+  </data>
   <data name="XmlMoreThanOneValyForParameterOfMethodMessage" xml:space="preserve">
     <value>More than one value specified for parameter '{0}' of method '{1}'.</value>
+  </data>
+  <data name="XmlDuplicatePreserveMemberTitle" xml:space="preserve">
+    <value>The XML descriptor marks for preservation the member more than once.</value>
   </data>
   <data name="XmlDuplicatePreserveMemberMessage" xml:space="preserve">
     <value>Duplicate preserve of '{0}'.</value>
@@ -333,65 +543,122 @@
   <data name="RequiresUnreferencedCodeMessage" xml:space="preserve">
     <value>Using member '{0}' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.{1}{2}</value>
   </data>
+  <data name="DynamicTypeInvocationTitle" xml:space="preserve">
+    <value>Using dynamic types might cause types or members to be removed by trimmer.</value>
+  </data>
   <data name="DynamicTypeInvocationMessage" xml:space="preserve">
     <value>Invoking members on dynamic types is not trimming-compatible. Types or members might have been removed by the trimmer.</value>
   </data>
-  <data name="DynamicTypeInvocationTitle" xml:space="preserve">
-    <value>Using dynamic types might cause types or members to be removed by trimmer.</value>
+  <data name="AttributeShouldOnlyBeUsedOnceOnMemberTitle" xml:space="preserve">
+    <value>The linker found multiple instances of attribute on a member. This attribute is only allowed to have one instance.</value>
   </data>
   <data name="AttributeShouldOnlyBeUsedOnceOnMemberMessage" xml:space="preserve">
     <value>Attribute '{0}' should only be used once on '{1}</value>
   </data>
+  <data name="AttributeDoesntHaveTheRequiredNumberOfParametersTitle" xml:space="preserve">
+    <value>Attribute doesn't have the required number of parameters specified.</value>
+  </data>
   <data name="AttributeDoesntHaveTheRequiredNumberOfParametersMessage" xml:space="preserve">
     <value>Attribute '{0}' doesn't have the required number of parameters specified.</value>
+  </data>
+  <data name="XmlElementDoesNotContainRequiredAttributeFullnameTitle" xml:space="preserve">
+    <value>'attribute' element does not contain attribute 'fullname' or it's empty.</value>
   </data>
   <data name="XmlElementDoesNotContainRequiredAttributeFullnameMessage" xml:space="preserve">
     <value>'attribute' element does not contain attribute 'fullname' or it's empty.</value>
   </data>
+  <data name="XmlCouldNotResolveAssemblyForAttributeTitle" xml:space="preserve">
+    <value>The assembly name specified for attribute could not be resolved.</value>
+  </data>
   <data name="XmlCouldNotResolveAssemblyForAttributeMessage" xml:space="preserve">
     <value>Could not resolve assembly '{0}' for attribute '{1}'.</value>
+  </data>
+  <data name="XmlAttributeTypeCouldNotBeFoundTitle" xml:space="preserve">
+    <value>The described attribute type could not be found in the assemblies.</value>
   </data>
   <data name="XmlAttributeTypeCouldNotBeFoundMessage" xml:space="preserve">
     <value>Attribute type '{0}' could not be found.</value>
   </data>
+  <data name="UnrecognizedParameterInMethodCreateInstanceTitle" xml:space="preserve">
+    <value>The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.</value>
+  </data>
   <data name="UnrecognizedParameterInMethodCreateInstanceMessage" xml:space="preserve">
     <value>Unrecognized value passed to the parameter '{0}' of method '{1}'. It's not possible to guarantee the availability of the target type.</value>
+  </data>
+  <data name="DeprecatedPreserveDependencyAttributeTitle" xml:space="preserve">
+    <value>'PreserveDependencyAttribute' is deprecated. Use 'DynamicDependencyAttribute' instead.</value>
   </data>
   <data name="DeprecatedPreserveDependencyAttributeMessage" xml:space="preserve">
     <value>'PreserveDependencyAttribute' is deprecated. Use 'DynamicDependencyAttribute' instead.</value>
   </data>
+  <data name="DynamicDependencyAttributeCouldNotBeAnalyzedTitle" xml:space="preserve">
+    <value>The input contains an invalid use of DynamicDependencyAttribute.</value>
+  </data>
   <data name="DynamicDependencyAttributeCouldNotBeAnalyzedMessage" xml:space="preserve">
     <value>The 'DynamicDependencyAttribute' could not be analyzed.</value>
+  </data>
+  <data name="UnresolvedAssemblyInDynamicDependencyAttributeTitle" xml:space="preserve">
+    <value>The assembly string given in a DynamicDependencyAttribute constructor could not be resolved.</value>
   </data>
   <data name="UnresolvedAssemblyInDynamicDependencyAttributeMessage" xml:space="preserve">
     <value>Unresolved assembly '{0}' in 'DynamicDependencyAttribute'.</value>
   </data>
+  <data name="UnresolvedTypeInDynamicDependencyAttributeTitle" xml:space="preserve">
+    <value>The type in a DynamicDependencyAttribute constructor could not be resolved.</value>
+  </data>
   <data name="UnresolvedTypeInDynamicDependencyAttributeMessage" xml:space="preserve">
     <value>Unresolved type '{0}' in 'DynamicDependencyAttribute'.</value>
+  </data>
+  <data name="NoMembersResolvedForMemberSignatureOrTypeTitle" xml:space="preserve">
+    <value>The member signature or DynamicallyAccessedMemberTypes in a DynamicDependencyAttribute constructor did not resolve to any members on the type.</value>
   </data>
   <data name="NoMembersResolvedForMemberSignatureOrTypeMessage" xml:space="preserve">
     <value>No members were resolved for '{0}'.</value>
   </data>
+  <data name="XmlMissingNameAttributeInResourceTitle" xml:space="preserve">
+    <value>The resource element in a substitution file did not have a 'name' attribute.</value>
+  </data>
   <data name="XmlMissingNameAttributeInResourceMessage" xml:space="preserve">
     <value>Missing 'name' attribute for resource.</value>
+  </data>
+  <data name="XmlInvalidValueForAttributeActionForResourceTitle" xml:space="preserve">
+    <value>The resource element in a substitution file did not have a valid 'action' attribute.</value>
   </data>
   <data name="XmlInvalidValueForAttributeActionForResourceMessage" xml:space="preserve">
     <value>Invalid value '{0}' for attribute 'action' for resource '{1}'.</value>
   </data>
+  <data name="XmlCouldNotFindResourceToRemoveInAssemblyTitle" xml:space="preserve">
+    <value>The resource name in a substitution file could not be found in the specified assembly.</value>
+  </data>
   <data name="XmlCouldNotFindResourceToRemoveInAssemblyMessage" xml:space="preserve">
     <value>Could not find embedded resource '{0}' to remove in assembly '{1}'.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersIsNotAllowedOnMethodsTitle" xml:space="preserve">
+    <value>The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.</value>
   </data>
   <data name="DynamicallyAccessedMembersIsNotAllowedOnMethodsMessage" xml:space="preserve">
     <value>The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters though.</value>
   </data>
+  <data name="DynamicallyAccessedMembersCouldNotFindBackingFieldTitle" xml:space="preserve">
+    <value>Could not find a unique backing field for property to propagate 'DynamicallyAccessedMembersAttribute'.</value>
+  </data>
   <data name="DynamicallyAccessedMembersCouldNotFindBackingFieldMessage" xml:space="preserve">
     <value>Could not find a unique backing field for property '{0}' to propagate 'DynamicallyAccessedMembersAttribute'.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersConflictsBetweenPropertyAndAccessorTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.</value>
   </data>
   <data name="DynamicallyAccessedMembersConflictsBetweenPropertyAndAccessorMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMembersAttribute' on property '{0}' conflicts with the same attribute on its accessor '{1}'.</value>
   </data>
+  <data name="XmlCouldNotFindAnyTypeInNamespaceTitle" xml:space="preserve">
+    <value>The XML descriptor specifies a namespace but there are no types found in such namespace.</value>
+  </data>
   <data name="XmlCouldNotFindAnyTypeInNamespaceMessage" xml:space="preserve">
     <value>Could not find any type in namespace '{0}'.</value>
+  </data>
+  <data name="AttributeIsReferencedButTrimmerRemoveAllInstancesTitle" xml:space="preserve">
+    <value>An attribute is being referenced in the code but the attribute instances have been removed using the 'RemoveAttributeInstances' internal attribute.</value>
   </data>
   <data name="AttributeIsReferencedButTrimmerRemoveAllInstancesMessage" xml:space="preserve">
     <value>Attribute '{0}' is being referenced in code but the trimmer was instructed to remove all instances of this attribute. If the attribute instances are necessary make sure to either remove the trimmer attribute XML portion which removes the attribute instances, or override the removal by using the trimmer XML descriptor to keep the attribute type (which in turn keeps all of its instances).</value>
@@ -402,209 +669,401 @@
   <data name="RequiresUnreferencedCodeAttributeMismatchMessage" xml:space="preserve">
     <value>{0}. 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.</value>
   </data>
+  <data name="XmlRemoveAttributeInstancesCanOnlyBeUsedOnTypeTitle" xml:space="preserve">
+    <value>Internal attribute 'RemoveAttributeInstances' can only be used on attribute types.</value>
+  </data>
   <data name="XmlRemoveAttributeInstancesCanOnlyBeUsedOnTypeMessage" xml:space="preserve">
     <value>Internal attribute '{0}' can only be used on attribute types.</value>
+  </data>
+  <data name="CorrectnessOfCOMCannotBeGuaranteedTitle" xml:space="preserve">
+    <value>Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.</value>
   </data>
   <data name="CorrectnessOfCOMCannotBeGuaranteedMessage" xml:space="preserve">
     <value>P/invoke method '{0}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.</value>
   </data>
+  <data name="XmlPropertyDoesNotContainAttributeNameTitle" xml:space="preserve">
+    <value>An attribute element has property but this could not be found.</value>
+  </data>
   <data name="XmlPropertyDoesNotContainAttributeNameMessage" xml:space="preserve">
     <value>Property element does not contain attribute 'name'.</value>
+  </data>
+  <data name="XmlCouldNotFindPropertyTitle" xml:space="preserve">
+    <value>An attribute element has property but this could not be found.</value>
   </data>
   <data name="XmlCouldNotFindPropertyMessage" xml:space="preserve">
     <value>Property '{0}' could not be found.</value>
   </data>
+  <data name="MakeGenericTypeTitle" xml:space="preserve">
+    <value>Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.</value>
+  </data>
   <data name="MakeGenericTypeMessage" xml:space="preserve">
     <value>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersOnPropertyConflictsWithBackingFieldTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMemberAttribute' on property conflicts with the same attribute on its backing field.</value>
   </data>
   <data name="DynamicallyAccessedMembersOnPropertyConflictsWithBackingFieldMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMemberAttribute' on property '{0}' conflicts with the same attribute on its backing field '{1}'.</value>
   </data>
+  <data name="UnrecognizedTypeNameInTypeGetTypeTitle" xml:space="preserve">
+    <value>Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.</value>
+  </data>
   <data name="UnrecognizedTypeNameInTypeGetTypeMessage" xml:space="preserve">
     <value>Unrecognized value passed to the parameter 'typeName' of method '{0}'. It's not possible to guarantee the availability of the target type.</value>
+  </data>
+  <data name="ParametersOfAssemblyCreateInstanceCannotBeAnalyzedTitle" xml:space="preserve">
+    <value>Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.</value>
   </data>
   <data name="ParametersOfAssemblyCreateInstanceCannotBeAnalyzedMessage" xml:space="preserve">
     <value>Parameters passed to method '{0}' cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.</value>
   </data>
+  <data name="UnrecognizedTypeInRuntimeHelpersRunClassConstructorTitle" xml:space="preserve">
+    <value>The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.</value>
+  </data>
   <data name="UnrecognizedTypeInRuntimeHelpersRunClassConstructorMessage" xml:space="preserve">
     <value>Unrecognized value passed to the parameter 'type' of method '{0}'. It's not possible to guarantee the availability of the target static constructor.</value>
+  </data>
+  <data name="MakeGenericMethodTitle" xml:space="preserve">
+    <value>Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</value>
   </data>
   <data name="MakeGenericMethodMessage" xml:space="preserve">
     <value>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</value>
   </data>
+  <data name="UnresolvedAssemblyInCreateInstanceTitle" xml:space="preserve">
+    <value>Calling CreateInstance with assembly name which can't be resolved.</value>
+  </data>
   <data name="UnresolvedAssemblyInCreateInstanceMessage" xml:space="preserve">
     <value>The assembly name '{0}' passed to method '{1}' references assembly which is not available.</value>
+  </data>
+  <data name="MethodParameterCannotBeStaticallyDeterminedTitle" xml:space="preserve">
+    <value>The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.</value>
   </data>
   <data name="MethodParameterCannotBeStaticallyDeterminedMessage" xml:space="preserve">
     <value>Value passed to parameter '{0}' of method '{1}' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.</value>
   </data>
+  <data name="MethodReturnValueCannotBeStaticallyDeterminedTitle" xml:space="preserve">
+    <value>The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.</value>
+  </data>
   <data name="MethodReturnValueCannotBeStaticallyDeterminedMessage" xml:space="preserve">
     <value>Value returned from method '{0}' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.</value>
+  </data>
+  <data name="FieldValueCannotBeStaticallyDeterminedTitle" xml:space="preserve">
+    <value>The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.</value>
   </data>
   <data name="FieldValueCannotBeStaticallyDeterminedMessage" xml:space="preserve">
     <value>Value assigned to {0} can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.</value>
   </data>
+  <data name="ImplicitThisCannotBeStaticallyDeterminedTitle" xml:space="preserve">
+    <value>The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.</value>
+  </data>
   <data name="ImplicitThisCannotBeStaticallyDeterminedMessage" xml:space="preserve">
     <value>Value passed to implicit 'this' parameter of method '{0}' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.</value>
+  </data>
+  <data name="TypePassedToGenericParameterCannotBeStaticallyDeterminedTitle" xml:space="preserve">
+    <value>The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.</value>
   </data>
   <data name="TypePassedToGenericParameterCannotBeStaticallyDeterminedMessage" xml:space="preserve">
     <value>Type passed to generic parameter '{0}' of '{1}' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchParameterTargetsParameterTitle" xml:space="preserve">
+    <value>Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchParameterTargetsParameterMessage" xml:space="preserve">
     <value>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchParameterTargetsMethodReturnTypeTitle" xml:space="preserve">
+    <value>Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchParameterTargetsMethodReturnTypeMessage" xml:space="preserve">
     <value>'{0}' method return value does not satisfy {3} requirements. The parameter '{1}' of method '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchParameterTargetsFieldTitle" xml:space="preserve">
+    <value>Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchParameterTargetsFieldMessage" xml:space="preserve">
     <value>value stored in field '{0}' does not satisfy {3} requirements. The parameter '{1}' of method '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchParameterTargetsThisParameterTitle" xml:space="preserve">
+    <value>'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchParameterTargetsThisParameterMessage" xml:space="preserve">
     <value>'this' argument does not satisfy {3} in call to '{0}'. The parameter '{1}' of method '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchParameterTargetsGenericParameterTitle" xml:space="preserve">
+    <value>Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchParameterTargetsGenericParameterMessage" xml:space="preserve">
     <value>'{0}' generic argument does not satisfy {4} in '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsParameterTitle" xml:space="preserve">
+    <value>Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsParameterMessage" xml:space="preserve">
     <value>'{0}' argument does not satisfy {3} in call to '{1}'. The return value of method '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsMethodReturnTypeTitle" xml:space="preserve">
+    <value>Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsMethodReturnTypeMessage" xml:space="preserve">
     <value>'{0}' method return value does not satisfy {2} requirements. The return value of method '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsFieldTitle" xml:space="preserve">
+    <value>Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsFieldMessage" xml:space="preserve">
     <value>value stored in field '{0}' does not satisfy {2} requirements. The return value of method '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsThisParameterTitle" xml:space="preserve">
+    <value>'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsThisParameterMessage" xml:space="preserve">
     <value>'this' argument does not satisfy {2} in call to '{0}'. The return value of method '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsGenericParameterTitle" xml:space="preserve">
+    <value>Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsGenericParameterMessage" xml:space="preserve">
     <value>'{0}' generic argument does not satisfy {3} in '{1}'. The return value of method '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchFieldTargetsParameterTitle" xml:space="preserve">
+    <value>Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchFieldTargetsParameterMessage" xml:space="preserve">
     <value>'{0}' argument does not satisfy {3} in call to '{1}'. The field '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchFieldTargetsMethodReturnTypeTitle" xml:space="preserve">
+    <value>Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchFieldTargetsMethodReturnTypeMessage" xml:space="preserve">
     <value>'{0}' method return value does not satisfy {2} requirements. The field '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchFieldTargetsFieldTitle" xml:space="preserve">
+    <value>Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchFieldTargetsFieldMessage" xml:space="preserve">
     <value>value stored in field '{0}' does not satisfy {2} requirements. The field '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchFieldTargetsThisParameterTitle" xml:space="preserve">
+    <value>'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchFieldTargetsThisParameterMessage" xml:space="preserve">
     <value>'this' argument does not satisfy {2} in call to '{0}'. The field '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchFieldTargetsGenericParameterTitle" xml:space="preserve">
+    <value>Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchFieldTargetsGenericParameterMessage" xml:space="preserve">
     <value>'{0}' generic argument does not satisfy {3} in '{1}'. The field '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsParameterTitle" xml:space="preserve">
+    <value>Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsParameterMessage" xml:space="preserve">
     <value>'{0}' argument does not satisfy {3} in call to '{1}'. The implicit 'this' argument of method '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsMethodReturnTypeTitle" xml:space="preserve">
+    <value>Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsMethodReturnTypeMessage" xml:space="preserve">
     <value>'{0}' method return value does not satisfy {2} requirements. The implicit 'this' argument of method '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsFieldTitle" xml:space="preserve">
+    <value>Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsFieldMessage" xml:space="preserve">
     <value>value stored in field '{0}' does not satisfy {2} requirements. The implicit 'this' argument of method '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsThisParameterTitle" xml:space="preserve">
+    <value>'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsThisParameterMessage" xml:space="preserve">
     <value>'this' argument does not satisfy {2} in call to '{0}'. The implicit 'this' argument of method '{1}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsGenericParameterTitle" xml:space="preserve">
+    <value>Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchThisParameterTargetsGenericParameterMessage" xml:space="preserve">
     <value>'{0}' generic argument does not satisfy {3} in '{1}'. The implicit 'this' argument of method '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsParameterTitle" xml:space="preserve">
+    <value>Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsParameterMessage" xml:space="preserve">
     <value>'{0}' argument does not satisfy {4} in call to '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsMethodReturnTypeTitle" xml:space="preserve">
+    <value>Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsMethodReturnTypeMessage" xml:space="preserve">
     <value>'{0}' method return value does not satisfy {3} requirements. The generic parameter '{1}' of '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsFieldTitle" xml:space="preserve">
+    <value>Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsFieldMessage" xml:space="preserve">
     <value>value stored in field '{0}' does not satisfy {3} requirements. The generic parameter '{1}' of '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsThisParameterTitle" xml:space="preserve">
+    <value>'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsThisParameterMessage" xml:space="preserve">
     <value>'this' argument does not satisfy {3} in call to '{0}'. The generic parameter '{1}' of '{2}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsGenericParameterTitle" xml:space="preserve">
+    <value>Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchTypeArgumentTargetsGenericParameterMessage" xml:space="preserve">
     <value>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchOnMethodParameterBetweenOverridesTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchOnMethodParameterBetweenOverridesMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the parameter '{0}' of method '{1}' don't match overridden parameter '{2}' of method '{3}'. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchOnMethodReturnValueBetweenOverridesTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchOnMethodReturnValueBetweenOverridesMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the return value of method '{0}' don't match overridden return value of method '{1}'. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersMismatchOnImplicitThisBetweenOverridesTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.</value>
   </data>
   <data name="DynamicallyAccessedMembersMismatchOnImplicitThisBetweenOverridesMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the implicit 'this' parameter of method '{0}' don't match overridden implicit 'this' parameter of method '{1}'. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMismatchOnGenericParameterBetweenOverridesTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMismatchOnGenericParameterBetweenOverridesMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the generic parameter '{0}' of '{1}' don't match overridden generic parameter '{2}' of '{3}'. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.</value>
+  </data>
+  <data name="CaseInsensitiveTypeGetTypeCallIsNotSupportedTitle" xml:space="preserve">
+    <value>Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.</value>
   </data>
   <data name="CaseInsensitiveTypeGetTypeCallIsNotSupportedMessage" xml:space="preserve">
     <value>Call to '{0}' can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.</value>
   </data>
+  <data name="DynamicallyAccessedMembersOnFieldCanOnlyApplyToTypesOrStringsTitle" xml:space="preserve">
+    <value>Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.</value>
+  </data>
   <data name="DynamicallyAccessedMembersOnFieldCanOnlyApplyToTypesOrStringsMessage" xml:space="preserve">
     <value>Field '{0}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersOnMethodParameterCanOnlyApplyToTypesOrStringsTitle" xml:space="preserve">
+    <value>Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.</value>
   </data>
   <data name="DynamicallyAccessedMembersOnMethodParameterCanOnlyApplyToTypesOrStringsMessage" xml:space="preserve">
     <value>Parameter '{0}' of method '{1}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.</value>
   </data>
+  <data name="DynamicallyAccessedMembersOnPropertyCanOnlyApplyToTypesOrStringsTitle" xml:space="preserve">
+    <value>Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.</value>
+  </data>
   <data name="DynamicallyAccessedMembersOnPropertyCanOnlyApplyToTypesOrStringsMessage" xml:space="preserve">
     <value>Property '{0}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.</value>
+  </data>
+  <data name="XmlUnsuportedWildcardTitle" xml:space="preserve">
+    <value>XML contains unsupported wildcard for assembly 'fullname' attribute.</value>
   </data>
   <data name="XmlUnsuportedWildcardMessage" xml:space="preserve">
     <value>XML contains unsupported wildcard for assembly 'fullname' attribute.</value>
   </data>
+  <data name="AssemblyWithEmbeddedXmlApplyToAnotherAssemblyTitle" xml:space="preserve">
+    <value>Embedded XML in assembly contains assembly "fullname" attribute for another assembly</value>
+  </data>
   <data name="AssemblyWithEmbeddedXmlApplyToAnotherAssemblyMessage" xml:space="preserve">
     <value>Embedded XML in assembly '{0}' contains assembly "fullname" attribute for another assembly '{1}'</value>
+  </data>
+  <data name="InvalidIsTrimmableValueTitle" xml:space="preserve">
+    <value>Invalid AssemblyMetadata 'IsTrimmable' attribute in assembly. Value must be "True".</value>
   </data>
   <data name="InvalidIsTrimmableValueMessage" xml:space="preserve">
     <value>Invalid AssemblyMetadata("IsTrimmable", "{0}") attribute in assembly '{1}'. Value must be "True".</value>
   </data>
+  <data name="PropertyAccessorParameterInLinqExpressionsCannotBeStaticallyDeterminedTitle" xml:space="preserve">
+    <value>Value passed to the parameter of method cannot be statically determined as a property accessor.</value>
+  </data>
   <data name="PropertyAccessorParameterInLinqExpressionsCannotBeStaticallyDeterminedMessage" xml:space="preserve">
     <value>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</value>
+  </data>
+  <data name="AssemblyProducedTrimWarningsTitle" xml:space="preserve">
+    <value>Assembly produced trim warnings.</value>
   </data>
   <data name="AssemblyProducedTrimWarningsMessage" xml:space="preserve">
     <value>Assembly '{0}' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries</value>
   </data>
+  <data name="TypeWasNotFoundInAssemblyNorBaseLibraryTitle" xml:space="preserve">
+    <value>Type was not found in the caller assembly nor in the base library. Type name strings used for dynamically accessing a type should be assembly qualified.</value>
+  </data>
   <data name="TypeWasNotFoundInAssemblyNorBaseLibraryMessage" xml:space="preserve">
     <value>Type '{0}' was not found in the caller assembly nor in the base library. Type name strings used for dynamically accessing a type should be assembly qualified.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersOnMethodReturnValueCanOnlyApplyToTypesOrStringsTitle" xml:space="preserve">
+    <value>Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.</value>
   </data>
   <data name="DynamicallyAccessedMembersOnMethodReturnValueCanOnlyApplyToTypesOrStringsMessage" xml:space="preserve">
     <value>Return type of method '{0}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.</value>
   </data>
+  <data name="MethodsAreAssociatedWithStateMachineTitle" xml:space="preserve">
+    <value>Trimmer currently can't correctly handle if the same compiler generated state machine type is associated (via the state machine attributes) with two different methods.</value>
+  </data>
   <data name="MethodsAreAssociatedWithStateMachineMessage" xml:space="preserve">
     <value>Methods '{0}' and '{1}' are both associated with state machine type '{2}'. This is currently unsupported and may lead to incorrectly reported warnings.</value>
+  </data>
+  <data name="InvalidScopeInUnconditionalSuppressMessageTitle" xml:space="preserve">
+    <value>Invalid scope used in 'UnconditionalSuppressMessageAttribute'. The only scopes supported on global unconditional suppressions are 'module', 'type' and 'member'.</value>
   </data>
   <data name="InvalidScopeInUnconditionalSuppressMessageMessage" xml:space="preserve">
     <value>Invalid scope '{0}' used in 'UnconditionalSuppressMessageAttribute' on module '{1}' with target '{2}'.</value>
   </data>
+  <data name="RequiresUnreferencedCodeOnBaseClassTitle" xml:space="preserve">
+    <value>Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning</value>
+  </data>
   <data name="RequiresUnreferencedCodeOnBaseClassMessage" xml:space="preserve">
     <value>Type '{0}' derives from '{1}' which has 'RequiresUnreferencedCodeAttribute'. {2}{3}</value>
   </data>
-  <data name="RequiresUnreferencedCodeOnBaseClassTitle" xml:space="preserve">
-    <value>Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning</value>
+  <data name="DynamicallyAccessedMembersFieldAccessedViaReflectionTitle" xml:space="preserve">
+    <value>Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.</value>
   </data>
   <data name="DynamicallyAccessedMembersFieldAccessedViaReflectionMessage" xml:space="preserve">
     <value>Field '{0}' with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.</value>
   </data>
+  <data name="DynamicallyAccessedMembersMethodAccessedViaReflectionTitle" xml:space="preserve">
+    <value>Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.</value>
+  </data>
   <data name="DynamicallyAccessedMembersMethodAccessedViaReflectionMessage" xml:space="preserve">
     <value>Method '{0}' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.</value>
+  </data>
+  <data name="DynamicallyAccessedMembersOnTypeReferencesMemberWithRequiresUnreferencedCodeTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMembersAttribute' on a type or one of its base types references a member which requires unreferenced code.</value>
   </data>
   <data name="DynamicallyAccessedMembersOnTypeReferencesMemberWithRequiresUnreferencedCodeMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMembersAttribute' on '{0}' or one of its base types references '{1}' which requires unreferenced code.{2}{3}</value>
   </data>
+  <data name="DynamicallyAccessedMembersOnTypeReferencesMemberOnBaseWithRequiresUnreferencedCodeTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMembersAttribute' on a type or one of its base types references a member which requires unreferenced code.</value>
+  </data>
   <data name="DynamicallyAccessedMembersOnTypeReferencesMemberOnBaseWithRequiresUnreferencedCodeMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMembersAttribute' on '{0}' or one of its base types references '{1}' which requires unreferenced code.{2}{3}</value>
+  </data>
+  <data name="DynamicallyAccessedMembersOnTypeReferencesMemberWithDynamicallyAccessedMembersTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMembersAttribute' on a type or one of its base types references a member which has 'DynamicallyAccessedMembersAttribute' requirements.</value>
   </data>
   <data name="DynamicallyAccessedMembersOnTypeReferencesMemberWithDynamicallyAccessedMembersMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMembersAttribute' on '{0}' or one of its base types references '{1}' which has 'DynamicallyAccessedMembersAttribute' requirements.</value>
   </data>
+  <data name="DynamicallyAccessedMembersOnTypeReferencesMemberOnBaseWithDynamicallyAccessedMembersTitle" xml:space="preserve">
+    <value>'DynamicallyAccessedMembersAttribute' on a type or one of its base types references a member which has 'DynamicallyAccessedMembersAttribute' requirements.</value>
+  </data>
   <data name="DynamicallyAccessedMembersOnTypeReferencesMemberOnBaseWithDynamicallyAccessedMembersMessage" xml:space="preserve">
     <value>'DynamicallyAccessedMembersAttribute' on '{0}' or one of its base types references '{1}' which has 'DynamicallyAccessedMembersAttribute' requirements.</value>
   </data>
-  <data name="RequiresUnreferencedCodeOnStaticConstructorMessage" xml:space="preserve">
-    <value>'RequiresUnreferencedCodeAttribute' cannot be placed directly on static constructor '{0}', consider placing 'RequiresUnreferencedCodeAttribute' on the type declaration instead.</value>
-  </data>
   <data name="RequiresUnreferencedCodeOnStaticConstructorTitle" xml:space="preserve">
     <value>The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.</value>
+  </data>
+  <data name="RequiresUnreferencedCodeOnStaticConstructorMessage" xml:space="preserve">
+    <value>'RequiresUnreferencedCodeAttribute' cannot be placed directly on static constructor '{0}', consider placing 'RequiresUnreferencedCodeAttribute' on the type declaration instead.</value>
   </data>
   <data name="AvoidAssemblyLocationInSingleFileTitle" xml:space="preserve">
     <value>Avoid accessing Assembly file path when publishing as a single file</value>
@@ -624,11 +1083,11 @@
   <data name="RequiresAssemblyFilesMessage" xml:space="preserve">
     <value>Using member '{0}' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app.{1}{2}</value>
   </data>
-  <data name="RequiresAssemblyFilesAttributeMismatchMessage" xml:space="preserve">
-    <value>{0}. 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.</value>
-  </data>
   <data name="RequiresAssemblyFilesAttributeMismatchTitle" xml:space="preserve">
     <value>'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.</value>
+  </data>
+  <data name="RequiresAssemblyFilesAttributeMismatchMessage" xml:space="preserve">
+    <value>{0}. 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.</value>
   </data>
   <data name="RequiresDynamicCodeTitle" xml:space="preserve">
     <value>Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.</value>
@@ -636,11 +1095,11 @@
   <data name="RequiresDynamicCodeMessage" xml:space="preserve">
     <value>Using member '{0}' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.{1}{2}</value>
   </data>
-  <data name="RequiresDynamicCodeAttributeMismatchMessage" xml:space="preserve">
-    <value>{0}. 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.</value>
-  </data>
   <data name="RequiresDynamicCodeAttributeMismatchTitle" xml:space="preserve">
     <value>'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.</value>
+  </data>
+  <data name="RequiresDynamicCodeAttributeMismatchMessage" xml:space="preserve">
+    <value>{0}. 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.</value>
   </data>
   <data name="BaseRequiresMismatchMessage" xml:space="preserve">
     <value>Base member '{2}' with '{0}' has a derived member '{1}' without '{0}'</value>


### PR DESCRIPTION
Currently, missing resources will default to an empty string printing an empty message for the diagnostics. Code should not try to gracefully handle errors. 

Included in this PR:
DiagnosticString should be able to locate a title and message resource strings otherwise it throws
Add title resource strings for all missing diagnostic Ids