### PR TITLE
Add a link to an issue for existing test case

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
@@ -71,8 +71,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				Type type = new TestType ().GetType ();
 				if (p == 0) {
 					type = typeWithAll;
-					type.GetInterface ("ITestInterface").RequiresInterfaces ();
 				}
+
+				type.GetInterface ("ITestInterface").RequiresInterfaces ();
 			}
 
 			public static void Test ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/LocalDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/LocalDataFlow.cs
@@ -24,6 +24,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// that we might be able to lift in the future.
 
 			// These are overly conservative (extraneous warnings)
+			// 	 https://github.com/dotnet/linker/issues/2550
 			TestBranchGoto ();
 			TestBranchIf ();
 			TestBranchIfElse ();
@@ -221,7 +222,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			return;
 		}
 
-		// https://github.com/dotnet/linker/issues/2550
 		[UnrecognizedReflectionAccessPattern (typeof (LocalDataFlow), nameof (RequirePublicFields), new Type[] { typeof (string) }, messageCode: "IL2072")]
 		public static void TestBranchIf ()
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/LocalDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/LocalDataFlow.cs
@@ -221,13 +221,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			return;
 		}
 
+		// https://github.com/dotnet/linker/issues/2550
 		[UnrecognizedReflectionAccessPattern (typeof (LocalDataFlow), nameof (RequirePublicFields), new Type[] { typeof (string) }, messageCode: "IL2072")]
 		public static void TestBranchIf ()
 		{
 			string str = GetWithPublicMethods ();
 			if (String.Empty.Length == 0) {
 				str = GetWithPublicFields (); // dataflow will merge this with the value from the previous basic block
-				RequirePublicFields (str); // produces a warning
+				RequirePublicFields (str); // produces a warning (technically it should not)
 			}
 		}
 


### PR DESCRIPTION
"fixes" a test case in `GetInterface` which was not meant to run into the wrong linker behavior as per bug https://github.com/dotnet/linker/issues/2550