### PR TITLE
Fix inconsistencies in Requires attribute checks

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -183,7 +183,8 @@ namespace ILLink.RoslynAnalyzer
 							if (instanceCtor.Arity > 0)
 								continue;
 
-							if (instanceCtor.TargetHasRequiresAttribute (RequiresAttributeName, out var requiresAttribute)) {
+							if (instanceCtor.TargetHasRequiresAttribute (RequiresAttributeName, out var requiresAttribute) &&
+								VerifyAttributeArguments (requiresAttribute)) {
 								syntaxNodeAnalysisContext.ReportDiagnostic (Diagnostic.Create (RequiresDiagnosticRule,
 									syntaxNodeAnalysisContext.Node.GetLocation (),
 									containingSymbol.GetDisplayName (),
@@ -365,30 +366,6 @@ namespace ILLink.RoslynAnalyzer
 		{
 			var url = requiresAttribute?.NamedArguments.FirstOrDefault (na => na.Key == "Url").Value.Value?.ToString ();
 			return MessageFormat.FormatRequiresAttributeUrlArg (url);
-		}
-
-		/// <summary>
-		/// This method determines if the member has a Requires attribute and returns it in the variable requiresAttribute.
-		/// </summary>
-		/// <param name="member">Symbol of the member to search attribute.</param>
-		/// <param name="requiresAttribute">Output variable in case of matching Requires attribute.</param>
-		/// <returns>True if the member contains a Requires attribute; otherwise, returns false.</returns>
-		private bool TryGetRequiresAttribute (ISymbol? member, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttribute)
-		{
-			requiresAttribute = null;
-			if (member == null)
-				return false;
-
-			foreach (var _attribute in member.GetAttributes ()) {
-				if (_attribute.AttributeClass is { } attrClass &&
-					attrClass.HasName (RequiresAttributeFullyQualifiedName) &&
-					VerifyAttributeArguments (_attribute)) {
-					requiresAttribute = _attribute;
-					return true;
-				}
-			}
-
-			return false;
 		}
 
 		/// <summary>

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -151,7 +151,7 @@ namespace ILLink.RoslynAnalyzer
 
 				context.RegisterSyntaxNodeAction (syntaxNodeAnalysisContext => {
 					var model = syntaxNodeAnalysisContext.SemanticModel;
-					if (syntaxNodeAnalysisContext.ContainingSymbol is not ISymbol containingSymbol || containingSymbol.HasAttribute (RequiresAttributeName))
+					if (syntaxNodeAnalysisContext.ContainingSymbol is not ISymbol containingSymbol || containingSymbol.IsInRequiresScope (RequiresAttributeName))
 						return;
 
 					GenericNameSyntax genericNameSyntaxNode = (GenericNameSyntax) syntaxNodeAnalysisContext.Node;
@@ -183,12 +183,12 @@ namespace ILLink.RoslynAnalyzer
 							if (instanceCtor.Arity > 0)
 								continue;
 
-							if (instanceCtor.TryGetAttribute (RequiresAttributeName, out var requiresUnreferencedCodeAttribute)) {
+							if (instanceCtor.TargetHasRequiresAttribute (RequiresAttributeName, out var requiresAttribute)) {
 								syntaxNodeAnalysisContext.ReportDiagnostic (Diagnostic.Create (RequiresDiagnosticRule,
 									syntaxNodeAnalysisContext.Node.GetLocation (),
 									containingSymbol.GetDisplayName (),
-									(string) requiresUnreferencedCodeAttribute.ConstructorArguments[0].Value!,
-									GetUrlFromAttribute (requiresUnreferencedCodeAttribute)));
+									(string) requiresAttribute.ConstructorArguments[0].Value!,
+									GetUrlFromAttribute (requiresAttribute)));
 							}
 						}
 					}
@@ -208,13 +208,13 @@ namespace ILLink.RoslynAnalyzer
 					SymbolAnalysisContext symbolAnalysisContext,
 					ISymbol symbol)
 				{
-					if (symbol.HasAttribute (RequiresAttributeName))
+					if (symbol.IsInRequiresScope (RequiresAttributeName))
 						return;
 
 					foreach (var attr in symbol.GetAttributes ()) {
-						if (TryGetRequiresAttribute (attr.AttributeConstructor, out var requiresAttribute)) {
+						if (attr.AttributeConstructor?.TargetHasRequiresAttribute (RequiresAttributeName, out var requiresAttribute) == true) {
 							symbolAnalysisContext.ReportDiagnostic (Diagnostic.Create (RequiresDiagnosticRule,
-								symbol.Locations[0], attr.AttributeConstructor!.Name, GetMessageFromAttribute (requiresAttribute), GetUrlFromAttribute (requiresAttribute)));
+								symbol.Locations[0], attr.AttributeConstructor.GetDisplayName (), GetMessageFromAttribute (requiresAttribute), GetUrlFromAttribute (requiresAttribute)));
 						}
 					}
 				}

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -51,6 +51,11 @@ namespace ILLink.RoslynAnalyzer
 
 		private static bool IsInRequiresScope (this ISymbol member, string requiresAttribute, bool checkAssociatedSymbol)
 		{
+			// Requires attribute on a type does not silence warnings that originate
+			// from the type directly.
+			if (member is ITypeSymbol typeSymbol)
+				return false;
+
 			if (member is ISymbol containingSymbol) {
 				if (containingSymbol.HasAttribute (requiresAttribute)
 					|| (containingSymbol is not ITypeSymbol &&

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -53,7 +53,7 @@ namespace ILLink.RoslynAnalyzer
 		{
 			// Requires attribute on a type does not silence warnings that originate
 			// from the type directly.
-			if (member is ITypeSymbol typeSymbol)
+			if (member is ITypeSymbol)
 				return false;
 
 			if (member is ISymbol containingSymbol) {

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -49,21 +49,21 @@ namespace ILLink.RoslynAnalyzer
 			return member.IsInRequiresScope (requiresAttribute, false);
 		}
 
-		private static bool IsInRequiresScope (this ISymbol containingSymbol, string requiresAttribute, bool checkAssociatedSymbol)
+		private static bool IsInRequiresScope (this ISymbol symbol, string requiresAttribute, bool checkAssociatedSymbol)
 		{
 			// Requires attribute on a type does not silence warnings that originate
 			// from the type directly. We also only check the containing type for members
 			// below, not of nested types.
-			if (containingSymbol is null or ITypeSymbol)
+			if (symbol is ITypeSymbol)
 				return false;
 
-			if (containingSymbol.HasAttribute (requiresAttribute)
-				|| (containingSymbol.ContainingType is ITypeSymbol containingType &&
+			if (symbol.HasAttribute (requiresAttribute)
+				|| (symbol.ContainingType is ITypeSymbol containingType &&
 					containingType.HasAttribute (requiresAttribute))) {
 				return true;
 			}
 			// Only check associated symbol if not override or virtual method
-			if (checkAssociatedSymbol && containingSymbol is IMethodSymbol { AssociatedSymbol: { } associated } && associated.HasAttribute (requiresAttribute))
+			if (checkAssociatedSymbol && symbol is IMethodSymbol { AssociatedSymbol: { } associated } && associated.HasAttribute (requiresAttribute))
 				return true;
 
 			return false;

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -49,21 +49,21 @@ namespace ILLink.RoslynAnalyzer
 			return member.IsInRequiresScope (requiresAttribute, false);
 		}
 
-		private static bool IsInRequiresScope (this ISymbol symbol, string requiresAttribute, bool checkAssociatedSymbol)
+		private static bool IsInRequiresScope (this ISymbol member, string requiresAttribute, bool checkAssociatedSymbol)
 		{
 			// Requires attribute on a type does not silence warnings that originate
 			// from the type directly. We also only check the containing type for members
 			// below, not of nested types.
-			if (symbol is ITypeSymbol)
+			if (member is ITypeSymbol)
 				return false;
 
-			if (symbol.HasAttribute (requiresAttribute)
-				|| (symbol.ContainingType is ITypeSymbol containingType &&
+			if (member.HasAttribute (requiresAttribute)
+				|| (member.ContainingType is ITypeSymbol containingType &&
 					containingType.HasAttribute (requiresAttribute))) {
 				return true;
 			}
 			// Only check associated symbol if not override or virtual method
-			if (checkAssociatedSymbol && symbol is IMethodSymbol { AssociatedSymbol: { } associated } && associated.HasAttribute (requiresAttribute))
+			if (checkAssociatedSymbol && member is IMethodSymbol { AssociatedSymbol: { } associated } && associated.HasAttribute (requiresAttribute))
 				return true;
 
 			return false;

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -28,7 +28,7 @@ namespace ILLink.RoslynAnalyzer
 
 		static readonly Action<OperationAnalysisContext> s_dynamicTypeInvocation = operationContext => {
 			if (FindContainingSymbol (operationContext, DiagnosticTargets.All) is ISymbol containingSymbol &&
-				containingSymbol.HasAttribute (RequiresUnreferencedCodeAttribute))
+				containingSymbol.IsInRequiresScope (RequiresUnreferencedCodeAttribute))
 				return;
 
 			operationContext.ReportDiagnostic (Diagnostic.Create (s_dynamicTypeInvocationRule,

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -343,6 +343,25 @@ class C
 		}
 
 		[Fact]
+		public Task DynamicInRequiresUnreferencedCodeClass ()
+		{
+			var source = @"
+using System.Diagnostics.CodeAnalysis;
+
+[RequiresUnreferencedCode(""message"")]
+class ClassWithRequires
+{
+	public static void MethodWithDynamicArg (dynamic arg)
+	{
+		arg.DynamicInvocation ();
+	}
+}
+";
+
+			return VerifyRequiresUnreferencedCodeAnalyzer (source);
+		}
+
+		[Fact]
 		public Task InvocationOnDynamicTypeInMethodWithRUCDoesNotWarnTwoTimes ()
 		{
 			var source = @"

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttributeCtor.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttributeCtor.cs
@@ -42,18 +42,23 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
+		[ExpectedWarning ("IL2026", "Message from attribute's type.")]
 		[RequiresOnAttributeCtor]
+		[RequiresOnAttributeType]
 		[KeptMember (".ctor()")]
 		public class Type
 		{
 			[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
+			[ExpectedWarning ("IL2026", "Message from attribute's type.")]
 			[RequiresOnAttributeCtor]
+			[RequiresOnAttributeType]
 			public void Method ()
 			{
 			}
 
 			[RequiresUnreferencedCode ("RUC on MethodAnnotatedWithRequires")]
 			[RequiresOnAttributeCtor]
+			[RequiresOnAttributeType]
 			public void MethodAnnotatedWithRequires ()
 			{
 			}
@@ -101,21 +106,16 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 		}
 
-		// https://github.com/dotnet/linker/issues/2529
-		[ExpectedWarning ("IL2026", "Message from attribute's ctor.", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2026", "Message from attribute's ctor.")]
 		[RequiresUnreferencedCode ("RUC on TypeWithRequires")]
 		[RequiresOnAttributeCtor]
 		public class TypeWithRequires
 		{
-			// https://github.com/dotnet/linker/issues/2529
-			[ExpectedWarning ("IL2026", "Message from attribute's ctor.", ProducedBy = ProducedBy.Analyzer)]
 			[RequiresOnAttributeCtor]
 			public void Method ()
 			{
 			}
 
-			// https://github.com/dotnet/linker/issues/2529
-			[ExpectedWarning ("IL2026", "Message from attribute's ctor.", ProducedBy = ProducedBy.Analyzer)]
 			[RequiresOnAttributeCtor]
 			public static void StaticMethod ()
 			{
@@ -133,5 +133,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 			}
 		}
+	}
+
+	[RequiresUnreferencedCode ("Message from attribute's type.")]
+	public class RequiresOnAttributeTypeAttribute : Attribute
+	{
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -816,7 +816,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[AttributeWithRequires (PropertyOnAttribute = 42)]
-		[ExpectedWarning ("IL2026", "AttributeWithRequires.AttributeWithRequires()", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2026", "AttributeWithRequires.AttributeWithRequires()")]
 		static void KeepFieldOnAttribute () { }
 	}
 }


### PR DESCRIPTION
While investigating failures in https://github.com/dotnet/linker/pull/2536 I came across a bunch of places where we check for RequiresAttribute without considering RUC on type.

- DAM analyzer:
  - checking for dataflow warnings. @tlakollo fixed these in https://github.com/dotnet/linker/pull/2536/commits/8121647f09929ed49f072ff878fe2681361c1c80. This change contains a few more tests.
  - checking for generic method warnings. These tests aren't turned on yet but I added a few testcases that should be enabled as part of https://github.com/dotnet/linker/issues/2364.
- Requires analyzer:
  - checking for attributes on ctors of types substituted for generic parameters with new constraint
  - the above should be silenced if the declaring type of the caller has RequiresAttribute
  - checking for RequiresAttribute on attribute ctors should check the attribute type for RequiresAttribute
  - the above should be silenced if the declaring type of the attribute provider has RequiresAttribute (but not when the provider is itself a type) (https://github.com/dotnet/linker/issues/2529)
- RUC analyzer:
  - warnings for use of `dynamic` should be silenced in a method whose declaring type has RequiresAttribute

I added tests for all of the above. Also fixes https://github.com/dotnet/linker/issues/2529.

I noticed another inconsistency in the attribute checks that I'm not addressing here: https://github.com/dotnet/linker/issues/2554