### PR TITLE
Handle object creation as a call to .ctor

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using ILLink.Shared.DataFlow;
+using ILLink.Shared.TrimAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;
@@ -142,27 +143,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		}
 
 		public override TValue VisitInvocation (IInvocationOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
-		{
-			TValue instanceValue = Visit (operation.Instance, state);
-
-			var argumentsBuilder = ImmutableArray.CreateBuilder<TValue> ();
-			foreach (var argument in operation.Arguments) {
-				// For __arglist argument there might not be any parameter
-				// __arglist is only legal as the last argument to a method and there's also no supported
-				// way for it to carry annotations or participate in data flow in any way, so it's OK to ignore it.
-				// Since it's always last, it's also OK to simply pass a shorter arguments array to the call.
-				if (argument?.Parameter == null)
-					break;
-
-				argumentsBuilder.Add (VisitArgument (argument, state));
-			}
-
-			return HandleMethodCall (
-				operation.TargetMethod,
-				instanceValue,
-				argumentsBuilder.ToImmutableArray (),
-				operation);
-		}
+			=> ProcessMethodCall (operation, operation.TargetMethod, operation.Instance, operation.Arguments, state);
 
 		public static IMethodSymbol GetPropertyMethod (IPropertyReferenceOperation operation)
 		{
@@ -220,6 +201,42 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		{
 			var operandValue = Visit (operation.Operand, state);
 			return operation.OperatorMethod == null ? operandValue : TopValue;
+		}
+
+		public override TValue VisitObjectCreation (IObjectCreationOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
+		{
+			if (operation.Constructor == null)
+				return TopValue;
+
+			return ProcessMethodCall (operation, operation.Constructor, null, operation.Arguments, state);
+		}
+
+		TValue ProcessMethodCall (
+			IOperation operation,
+			IMethodSymbol method,
+			IOperation? instance,
+			ImmutableArray<IArgumentOperation> arguments,
+			LocalDataFlowState<TValue, TValueLattice> state)
+		{
+			TValue instanceValue = Visit (instance, state);
+
+			var argumentsBuilder = ImmutableArray.CreateBuilder<TValue> ();
+			foreach (var argument in arguments) {
+				// For __arglist argument there might not be any parameter
+				// __arglist is only legal as the last argument to a method and there's also no supported
+				// way for it to carry annotations or participate in data flow in any way, so it's OK to ignore it.
+				// Since it's always last, it's also OK to simply pass a shorter arguments array to the call.
+				if (argument?.Parameter == null)
+					break;
+
+				argumentsBuilder.Add (VisitArgument (argument, state));
+			}
+
+			return HandleMethodCall (
+				method,
+				instanceValue,
+				argumentsBuilder.ToImmutableArray (),
+				operation);
 		}
 	}
 }

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using ILLink.Shared.DataFlow;
-using ILLink.Shared.TrimAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;
@@ -208,6 +207,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			if (operation.Constructor == null)
 				return TopValue;
 
+			// Passing null for instance value is a bit wrong - below we will translate it to TopValue right now.
+			// Technically this is an instance call and the instance is some valid value, we just don't know which
+			// but for example it does have a static type. For now this is OK since we don't need the information
+			// for anything yet.
+
+			// The return here is also technically problematic, the return value is an instance of a known type.
+			// Especially with DAM on type, this can lead to incorrectly analyzed code (as in unknown type which leads
+			// to noise). Linker has the same problem currently: https://github.com/dotnet/linker/issues/1952
 			return ProcessMethodCall (operation, operation.Constructor, null, operation.Arguments, state);
 		}
 

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -207,14 +207,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			if (operation.Constructor == null)
 				return TopValue;
 
-			// Passing null for instance value is a bit wrong - below we will translate it to TopValue right now.
-			// Technically this is an instance call and the instance is some valid value, we just don't know which
-			// but for example it does have a static type. For now this is OK since we don't need the information
-			// for anything yet.
-
-			// The return here is also technically problematic, the return value is an instance of a known type.
-			// Especially with DAM on type, this can lead to incorrectly analyzed code (as in unknown type which leads
-			// to noise). Linker has the same problem currently: https://github.com/dotnet/linker/issues/1952
 			return ProcessMethodCall (operation, operation.Constructor, null, operation.Arguments, state);
 		}
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -103,6 +103,16 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public override MultiValue HandleMethodCall (IMethodSymbol calledMethod, MultiValue instance, ImmutableArray<MultiValue> arguments, IOperation operation)
 		{
+			// For .ctors:
+			// - The instance value is empty (TopValue) and that's a bit wrong.
+			//   Technically this is an instance call and the instance is some valid value, we just don't know which
+			//   but for example it does have a static type. For now this is OK since we don't need the information
+			//   for anything yet.
+			// - The return here is also technically problematic, the return value is an instance of a known type,
+			//   but currently we return empty (since the .ctor is declared as returning void).
+			//   Especially with DAM on type, this can lead to incorrectly analyzed code (as in unknown type which leads
+			//   to noise). Linker has the same problem currently: https://github.com/dotnet/linker/issues/1952
+
 			var handleCallAction = new HandleCallAction (Context.OwningSymbol, operation);
 			if (!handleCallAction.Invoke (new MethodProxy (calledMethod), instance, arguments, out MultiValue methodReturnValue)) {
 				methodReturnValue = calledMethod.ReturnsVoid ? TopValue : new MethodReturnValue (calledMethod);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
@@ -76,6 +76,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				type.GetInterface ("ITestInterface").RequiresInterfaces ();
 			}
 
+			class GetInterfaceInCtor
+			{
+				public GetInterfaceInCtor ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] Type type)
+				{
+					type.GetInterface ("ITestInterface").RequiresInterfaces ();
+				}
+			}
+
 			public static void Test ()
 			{
 				TestNoAnnotation (typeof (TestType));
@@ -85,6 +93,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestKnownType ();
 				TestMultipleValues (0, typeof (TestType));
 				TestMergedValues (0, typeof (TestType));
+				var _ = new GetInterfaceInCtor (typeof (TestType));
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -39,6 +39,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.LongWriteToParameterOnInstanceMethod (0, 0, 0, 0, null);
 			instance.UnsupportedParameterType (null);
 
+			ParametersPassedToInstanceCtor (typeof (TestType), typeof (TestType));
+
 			TestParameterOverwrite (typeof (TestType));
 		}
 
@@ -198,6 +200,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[ExpectedWarning ("IL2098", "p1", nameof (UnsupportedParameterType), ProducedBy = ProducedBy.Trimmer)]
 		private void UnsupportedParameterType ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] object p1)
 		{
+		}
+
+		private class InstanceCtor
+		{
+			[ExpectedWarning ("IL2067", nameof (DataFlowTypeExtensions.RequiresPublicConstructors))]
+			public InstanceCtor ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type)
+			{
+				type.RequiresNonPublicConstructors ();
+				type.RequiresPublicConstructors ();
+			}
+		}
+
+		[ExpectedWarning ("IL2067", "'type'")]
+		static void ParametersPassedToInstanceCtor ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type typeWithCtors, Type typeWithNothing)
+		{
+			var a1 = new InstanceCtor (typeWithCtors); // no warn
+			var a2 = new InstanceCtor (typeof (TestType)); // no warn
+			var a3 = new InstanceCtor (typeWithNothing); // warn
 		}
 
 		private static void RequirePublicParameterlessConstructorAndNothing (


### PR DESCRIPTION
This is necessary for correct data flow processing since we need to check the arguments to ctor the same way we do any other method.
Added couple of simple tests.