### PR TITLE
Fix lint job in CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -135,6 +135,9 @@ dotnet_diagnostic.RS2008.severity = none
 # Exception type is not sufficiently specific
 dotnet_diagnostic.CA2201.severity = none
 
+# xUnit1004: Test methods should not be skipped
+dotnet_diagnostic.xUnit1004.severity = none
+
 [src/linker/ref/**/*.cs]
 
 # CA1822: Mark members as static

--- a/.editorconfig
+++ b/.editorconfig
@@ -146,6 +146,10 @@ dotnet_diagnostic.CA1822.severity = none
 # IDE0060: Remove unused parameter
 dotnet_diagnostic.IDE0060.severity = none
 
+[test/**/*.cs]
+
+dotnet_diagnostic.IDE0060.severity = none
+
 [external**]
 dotnet_analyzer_diagnostic.severity = none
 generated_code = true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -145,7 +145,7 @@ stages:
       steps:
       - checkout: self
         submodules: true
-      - script: ./lint.sh --check --verbosity diagnostic
+      - script: ./lint.sh --verify-no-changes --verbosity diagnostic
 
 # Post-Build Arcade logic
 - ${{ if eq(variables.officialBuild, 'true') }}:

--- a/lint.cmd
+++ b/lint.cmd
@@ -1,2 +1,3 @@
 @echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "Set-Location %~dp0; & """%~dp0eng\dotnet.ps1""" ""format illink.sln --exclude external %*"""
+powershell -ExecutionPolicy ByPass -NoProfile -command "Set-Location %~dp0; & """%~dp0eng\dotnet.ps1""" ""format illink.sln --exclude external --verify-no-changes %*"""

--- a/lint.sh
+++ b/lint.sh
@@ -14,3 +14,4 @@ done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 "$scriptroot/eng/dotnet.sh" format illink.sln --exclude external $@
+"$scriptroot/eng/dotnet.sh" format illink.sln --exclude external --verify-no-changes $@

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using ILLink.Shared;
 using Microsoft.CodeAnalysis;

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkAttributesTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkAttributesTests.cs
@@ -8,25 +8,25 @@ namespace ILLink.RoslynAnalyzer.Tests
 	{
 		protected override string TestSuiteName => "LinkAttributes";
 
-		[Fact(Skip = "XML Analyzer not implemented")]
+		[Fact (Skip = "XML Analyzer not implemented")]
 		public Task EmbeddedLinkAttributes ()
 		{
 			return RunTest (nameof (EmbeddedLinkAttributes));
 		}
 
-		[Fact(Skip = "XML Analyzer not implemented")]
+		[Fact (Skip = "XML Analyzer not implemented")]
 		public Task LinkerAttributeRemoval ()
 		{
 			return RunTest (nameof (LinkerAttributeRemoval));
 		}
 
-		[Fact(Skip = "XML Analyzer not implemented")]
+		[Fact (Skip = "XML Analyzer not implemented")]
 		public Task TypedArguments ()
 		{
 			return RunTest (nameof (TypedArguments));
 		}
 
-		[Fact(Skip = "XML Analyzer not implemented")]
+		[Fact (Skip = "XML Analyzer not implemented")]
 		public Task LinkerAttributeRemovalConditional ()
 		{
 			return RunTest (nameof (LinkerAttributeRemovalConditional));

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresDynamicCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresDynamicCodeAnalyzerTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using ILLink.Shared;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -16,8 +15,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 {
 	public class RequiresDynamicCodeAnalyzerTests
 	{
-		static readonly DiagnosticDescriptor dynamicInvocationDiagnosticDescriptor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode, new DiagnosticString ("DynamicTypeInvocation"));
-
 		static readonly string dynamicCodeAttribute = @"
 #nullable enable
 

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseCompilation.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseCompilation.cs
@@ -5,14 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
-using Mono.Linker.Tests.Cases.LinkXml;
 
 namespace ILLink.RoslynAnalyzer.Tests
 {

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -82,13 +81,13 @@ namespace ILLink.RoslynAnalyzer.Tests
 			}
 		}
 
-		private static IEnumerable<AdditionalText> GetAdditionalFiles(string rootSourceDir, SyntaxTree tree)
+		private static IEnumerable<AdditionalText> GetAdditionalFiles (string rootSourceDir, SyntaxTree tree)
 		{
 			var resolver = new XmlFileResolver (rootSourceDir);
 			foreach (var attribute in tree.GetRoot ().DescendantNodes ().OfType<AttributeSyntax> ()) {
 				if (attribute.Name.ToString () == nameof (SetupLinkAttributesFile)
 					|| (attribute.Name.ToString ().Contains ("SetupCompileResource")
-						&& (string?) attribute.ArgumentList?.Arguments[1].ToString () == "\"ILLink.LinkAttributes.xml\"")) {
+						&& (attribute.ArgumentList?.Arguments[1].ToString ()) == "\"ILLink.LinkAttributes.xml\"")) {
 					var xmlFileName = attribute.ArgumentList?.Arguments[0].ToString ().Trim ('"') ?? "";
 					var resolvedPath = resolver.ResolveReference (xmlFileName, rootSourceDir);
 					if (resolvedPath != null) {

--- a/test/ILLink.RoslynAnalyzer.Tests/XmlText.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/XmlText.cs
@@ -1,13 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -16,14 +11,15 @@ namespace ILLink.RoslynAnalyzer.Tests
 	class XmlText : AdditionalText
 	{
 		public override string Path { get; }
-		Stream Doc;
+
+		readonly Stream Doc;
 		public XmlText (string path, Stream data)
 		{
 			Path = path;
 			Doc = data;
 		}
 
-		public override SourceText? GetText(CancellationToken token = default)
+		public override SourceText? GetText (CancellationToken token = default)
 		{
 			return SourceText.From (Doc);
 		}


### PR DESCRIPTION
It did run linter, but didn't fail if any changes were to be applied, instead it actually applied them (and then dropped). So the job would actually never fail.