### PR TITLE
Run dotnet format only once

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,9 @@
 {
+  "sdk": {
+    "version": "6.0.100",
+    "allowPrerelease": true,
+    "rollForward": "major"
+  },
   "tools": {
     "dotnet": "6.0.100"
   },

--- a/lint.sh
+++ b/lint.sh
@@ -14,4 +14,3 @@ done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 "$scriptroot/eng/dotnet.sh" format illink.sln --exclude external $@
-"$scriptroot/eng/dotnet.sh" format illink.sln --exclude external --verify-no-changes $@


### PR DESCRIPTION
@vitek-karas I saw some strange behavior in the lint script again in https://github.com/dotnet/linker/pull/2585. It was failing in PR but not locally. I tracked this down to the fact that our `global.json` doesn't specify an SDK version, so it was running locally with a version of `dotnet format` from the 7.0 SDK I have installed.

The pipeline is already passing `--verify-no-changes` so I don't think we need to run it twice.

I took the `allowPrerelease` and `rollForward` settings from dotnet/runtime to make it possible to build the repo locally even with a later SDK (even though it becomes possible then to run into this issue). I don't have a strong preference on it and would be fine with requiring the exact SDK if you prefer.
