### PR TITLE
[DAM analyzer] Analyze exception filters

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/ControlFlowGraphProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/ControlFlowGraphProxy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using ILLink.Shared.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 
@@ -30,6 +31,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		public RegionKind Kind => Region.Kind switch {
 			ControlFlowRegionKind.Try => RegionKind.Try,
 			ControlFlowRegionKind.Catch => RegionKind.Catch,
+			ControlFlowRegionKind.Filter => RegionKind.Filter,
 			ControlFlowRegionKind.Finally => RegionKind.Finally,
 			_ => throw new InvalidOperationException ()
 		};
@@ -65,22 +67,22 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			}
 		}
 
-		public bool TryGetEnclosingTryOrCatch (BlockProxy block, out RegionProxy tryOrCatchRegion)
+		public bool TryGetEnclosingTryOrCatchOrFilter (BlockProxy block, out RegionProxy tryOrCatchOrFilterRegion)
 		{
-			return TryGetTryOrCatch (block.Block.EnclosingRegion, out tryOrCatchRegion);
+			return TryGetTryOrCatchOrFilter (block.Block.EnclosingRegion, out tryOrCatchOrFilterRegion);
 		}
 
-		public bool TryGetEnclosingTryOrCatch (RegionProxy regionProxy, out RegionProxy tryOrCatchRegion)
+		public bool TryGetEnclosingTryOrCatchOrFilter (RegionProxy regionProxy, out RegionProxy tryOrCatchOrFilterRegion)
 		{
-			return TryGetTryOrCatch (regionProxy.Region.EnclosingRegion, out tryOrCatchRegion);
+			return TryGetTryOrCatchOrFilter (regionProxy.Region.EnclosingRegion, out tryOrCatchOrFilterRegion);
 		}
 
-		static bool TryGetTryOrCatch (ControlFlowRegion? region, out RegionProxy tryOrCatchRegion)
+		static bool TryGetTryOrCatchOrFilter (ControlFlowRegion? region, out RegionProxy tryOrCatchOrFilterRegion)
 		{
-			tryOrCatchRegion = default;
+			tryOrCatchOrFilterRegion = default;
 			while (region != null) {
-				if (region.Kind is ControlFlowRegionKind.Try or ControlFlowRegionKind.Catch) {
-					tryOrCatchRegion = new RegionProxy (region);
+				if (region.Kind is ControlFlowRegionKind.Try or ControlFlowRegionKind.Catch or ControlFlowRegionKind.Filter) {
+					tryOrCatchOrFilterRegion = new RegionProxy (region);
 					return true;
 				}
 				region = region.EnclosingRegion;
@@ -102,12 +104,23 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			return false;
 		}
 
-		public RegionProxy GetCorrespondingTry (RegionProxy catchOrFinallyRegion)
+		public RegionProxy GetCorrespondingTry (RegionProxy catchOrFilterOrFinallyRegion)
 		{
-			if (catchOrFinallyRegion.Region.Kind is not (ControlFlowRegionKind.Finally or ControlFlowRegionKind.Catch))
-				throw new ArgumentOutOfRangeException (nameof (catchOrFinallyRegion));
+			if (catchOrFilterOrFinallyRegion.Region.Kind is not (ControlFlowRegionKind.Catch or ControlFlowRegionKind.Filter or ControlFlowRegionKind.Finally))
+				throw new ArgumentException ("Must be a catch, filter, or finally region: {}", nameof (catchOrFilterOrFinallyRegion));
 
-			foreach (var nested in catchOrFinallyRegion.Region.EnclosingRegion!.NestedRegions) {
+			// Finally -> TryAndFinally
+			// Catch -> TryAndCatch or FilterAndHandler
+			// Filter -> FilterAndHandler
+			var enclosingRegion = catchOrFilterOrFinallyRegion.Region.EnclosingRegion!;
+			// FilterAndHandler -> TryAndCatch
+			if (enclosingRegion.Kind == ControlFlowRegionKind.FilterAndHandler) {
+				enclosingRegion = enclosingRegion.EnclosingRegion!;
+				Debug.Assert (enclosingRegion.Kind == ControlFlowRegionKind.TryAndCatch);
+			}
+
+			// For TryAndFinally or TryAndCatch, get the Try region.
+			foreach (var nested in enclosingRegion.NestedRegions) {
 				// Note that for try+catch+finally, the try corresponding to the finally will not be the same as
 				// the try corresponding to the catch, because Roslyn represents this region hierarchy the same as
 				// a try+catch nested inside the try block of a try+finally.
@@ -115,6 +128,67 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 					return new (nested);
 			}
 			throw new InvalidOperationException ();
+		}
+
+		public bool TryGetPreviousFilter (RegionProxy catchOrFilterRegion, out RegionProxy filterRegion)
+		{
+			filterRegion = default;
+
+			var region = catchOrFilterRegion.Region;
+			if (region.Kind is not (ControlFlowRegionKind.Catch or ControlFlowRegionKind.Filter))
+				throw new ArgumentException ("Must be a catch or filter region: {}", nameof (catchOrFilterRegion));
+
+			// Should not be called for a catch block that already has a filter.
+			if (region.Kind is ControlFlowRegionKind.Catch && region.EnclosingRegion!.Kind is ControlFlowRegionKind.FilterAndHandler)
+				throw new ArgumentException ("Must not be a catch block with filter: {}", nameof (catchOrFilterRegion));
+
+			var tryRegion = GetCorrespondingTry (catchOrFilterRegion);
+			// The enclosing region is part of a TryAndCatch region, which has
+			// a Try and multiple Catch or FilterAndHandler regions.
+			ControlFlowRegion? previousFilter = null;
+			foreach (var nested in tryRegion.Region.EnclosingRegion!.NestedRegions) {
+				ControlFlowRegion? catchOrFilter = null;
+				switch (nested.Kind) {
+				case ControlFlowRegionKind.Catch:
+					catchOrFilter = nested;
+					break;
+				case ControlFlowRegionKind.FilterAndHandler:
+					// Get Filter region from the FilterAndHandler
+					foreach (var filter in nested.NestedRegions) {
+						if (filter.Kind == ControlFlowRegionKind.Filter) {
+							catchOrFilter = filter;
+							break;
+						}
+					}
+					// In case there is no filter region, just skip this one.
+					if (catchOrFilter == null)
+						continue;
+					break;
+				default:
+					continue;
+				}
+
+				// When we reach this one, we are done searching.
+				if (catchOrFilter.Equals (region)) {
+					if (previousFilter == null)
+						return false;
+					filterRegion = new (previousFilter);
+					return true;
+				}
+
+				// If the previous region is a filter region, track this.
+				if (catchOrFilter.Kind == ControlFlowRegionKind.Filter)
+					previousFilter = catchOrFilter;
+			}
+			throw new InvalidOperationException ();
+		}
+
+		public bool HasFilter (RegionProxy catchRegion)
+		{
+			if (catchRegion.Region.Kind is not ControlFlowRegionKind.Catch)
+				throw new ArgumentException ("Must be a catch region: {}", nameof (catchRegion));
+
+			return catchRegion.Region.EnclosingRegion!.Kind == ControlFlowRegionKind.FilterAndHandler;
 		}
 
 		public BlockProxy FirstBlock (RegionProxy region) =>

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
@@ -83,6 +83,8 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			Console.Write ("block " + block.Block.Ordinal + ": ");
 			if (block.Block.Operations.FirstOrDefault () is IOperation firstBlockOp) {
 				Console.WriteLine (firstBlockOp.Syntax.ToString ());
+			} else if (block.Block.BranchValue is IOperation branchOp) {
+				Console.WriteLine (branchOp.Syntax.ToString ());
 			} else {
 				Console.WriteLine ();
 			}

--- a/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
+++ b/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
@@ -197,7 +197,7 @@ namespace ILLink.Shared.DataFlow
 					bool isTryBlock = isTryOrCatchOrFilterBlock && tryOrCatchOrFilterRegion!.Kind == RegionKind.Try;
 					bool isTryStart = isTryBlock && block.Equals (cfg.FirstBlock (tryOrCatchOrFilterRegion!));
 					bool isCatchBlock = isTryOrCatchOrFilterBlock && tryOrCatchOrFilterRegion!.Kind == RegionKind.Catch;
-					bool isCatchStartWithoutFilter = isCatchBlock && block.Equals (cfg.FirstBlock (tryOrCatchOrFilterRegion!)) && !cfg.HasFilter (tryOrCatchOrFilterRegion);
+					bool isCatchStartWithoutFilter = isCatchBlock && block.Equals (cfg.FirstBlock (tryOrCatchOrFilterRegion!)) && !cfg.HasFilter (tryOrCatchOrFilterRegion!);
 					bool isFilterBlock = isTryOrCatchOrFilterBlock && tryOrCatchOrFilterRegion!.Kind == RegionKind.Filter;
 					bool isFilterStart = isFilterBlock && block.Equals (cfg.FirstBlock (tryOrCatchOrFilterRegion!));
 
@@ -243,8 +243,8 @@ namespace ILLink.Shared.DataFlow
 						currentState = lattice.Meet (currentState, tryExceptionState.Value);
 
 						// A catch or filter can also be reached from a previous filter.
-						if (cfg.TryGetPreviousFilter (tryOrCatchOrFilterRegion!, out TRegion? previousFilter)) {
-							// For now, assume that control always leaves the previous filter from its last block.
+						foreach (TRegion previousFilter in cfg.GetPreviousFilters (tryOrCatchOrFilterRegion!)) {
+							// For now, assume that control always leaves a filter from its last block.
 							TBlock lastFilterBlock = cfg.LastBlock (previousFilter);
 							TValue previousFilterState = cfgState.Get (lastFilterBlock).Current;
 							currentState = lattice.Meet (currentState, previousFilterState);

--- a/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
+++ b/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
@@ -63,14 +63,14 @@ namespace ILLink.Shared.DataFlow
 				this.lattice = lattice;
 			}
 
-			public Box<TValue> GetExceptionState (TRegion tryOrCatchRegion)
+			public Box<TValue> GetExceptionState (TRegion tryOrCatchOrFilterRegion)
 			{
-				if (tryOrCatchRegion.Kind is not (RegionKind.Try or RegionKind.Catch))
-					throw new ArgumentException (null, nameof (tryOrCatchRegion));
+				if (tryOrCatchOrFilterRegion.Kind is not (RegionKind.Try or RegionKind.Catch or RegionKind.Filter))
+					throw new ArgumentException (null, nameof (tryOrCatchOrFilterRegion));
 
-				if (!exceptionState.TryGetValue (tryOrCatchRegion, out Box<TValue>? state)) {
+				if (!exceptionState.TryGetValue (tryOrCatchOrFilterRegion, out Box<TValue>? state)) {
 					state = new Box<TValue> (lattice.Top);
-					exceptionState.Add (tryOrCatchRegion, state);
+					exceptionState.Add (tryOrCatchOrFilterRegion, state);
 				}
 				return state;
 			}
@@ -78,10 +78,10 @@ namespace ILLink.Shared.DataFlow
 			public bool TryGetExceptionState (TBlock block, out Box<TValue>? state)
 			{
 				state = null;
-				if (!cfg.TryGetEnclosingTryOrCatch (block, out TRegion? tryOrCatchRegion))
+				if (!cfg.TryGetEnclosingTryOrCatchOrFilter (block, out TRegion? tryOrCatchOrFilterRegion))
 					return false;
 
-				state = GetExceptionState (tryOrCatchRegion);
+				state = GetExceptionState (tryOrCatchOrFilterRegion);
 				return true;
 			}
 
@@ -192,11 +192,16 @@ namespace ILLink.Shared.DataFlow
 					if (block.Equals (cfg.Entry))
 						continue;
 
-					bool isTryOrCatchBlock = cfg.TryGetEnclosingTryOrCatch (block, out TRegion? tryOrCatchRegion);
-					bool isTryBlock = isTryOrCatchBlock && tryOrCatchRegion!.Kind == RegionKind.Try;
-					bool isCatchBlock = isTryOrCatchBlock && !isTryBlock;
-					bool isTryStart = isTryBlock && block.Equals (cfg.FirstBlock (tryOrCatchRegion!));
-					bool isCatchStart = isCatchBlock && block.Equals (cfg.FirstBlock (tryOrCatchRegion!));
+					bool isTryOrCatchOrFilterBlock = cfg.TryGetEnclosingTryOrCatchOrFilter (block, out TRegion? tryOrCatchOrFilterRegion);
+
+					bool isTryBlock = isTryOrCatchOrFilterBlock && tryOrCatchOrFilterRegion!.Kind == RegionKind.Try;
+					bool isTryStart = isTryBlock && block.Equals (cfg.FirstBlock (tryOrCatchOrFilterRegion!));
+					bool isCatchBlock = isTryOrCatchOrFilterBlock && tryOrCatchOrFilterRegion!.Kind == RegionKind.Catch;
+					bool isCatchStartWithoutFilter = isCatchBlock && block.Equals (cfg.FirstBlock (tryOrCatchOrFilterRegion!)) && !cfg.HasFilter (tryOrCatchOrFilterRegion);
+					bool isFilterBlock = isTryOrCatchOrFilterBlock && tryOrCatchOrFilterRegion!.Kind == RegionKind.Filter;
+					bool isFilterStart = isFilterBlock && block.Equals (cfg.FirstBlock (tryOrCatchOrFilterRegion!));
+
+					bool isCatchOrFilterStart = isCatchStartWithoutFilter || isFilterStart;
 
 					bool isFinallyBlock = cfg.TryGetEnclosingFinally (block, out TRegion? finallyRegion);
 					bool isFinallyStart = isFinallyBlock && block.Equals (cfg.FirstBlock (finallyRegion!));
@@ -232,10 +237,18 @@ namespace ILLink.Shared.DataFlow
 					}
 					// State at start of a catch also includes the exceptional state from
 					// try -> catch exceptional control flow.
-					if (isCatchStart) {
-						TRegion correspondingTry = cfg.GetCorrespondingTry (tryOrCatchRegion!);
+					if (isCatchOrFilterStart) {
+						TRegion correspondingTry = cfg.GetCorrespondingTry (tryOrCatchOrFilterRegion!);
 						Box<TValue> tryExceptionState = cfgState.GetExceptionState (correspondingTry);
 						currentState = lattice.Meet (currentState, tryExceptionState.Value);
+
+						// A catch or filter can also be reached from a previous filter.
+						if (cfg.TryGetPreviousFilter (tryOrCatchOrFilterRegion!, out TRegion? previousFilter)) {
+							// For now, assume that control always leaves the previous filter from its last block.
+							TBlock lastFilterBlock = cfg.LastBlock (previousFilter);
+							TValue previousFilterState = cfgState.Get (lastFilterBlock).Current;
+							currentState = lattice.Meet (currentState, previousFilterState);
+						}
 					}
 					if (isFinallyStart) {
 						TValue finallyInputState = cfgState.GetFinallyInputState (finallyRegion!);
@@ -272,8 +285,8 @@ namespace ILLink.Shared.DataFlow
 					TState currentBlockState = cfgState.Get (block);
 					Box<TValue>? exceptionState = currentBlockState.Exception;
 					TValue? oldExceptionState = exceptionState?.Value;
-					if (isTryStart || isCatchStart) {
-						// Catch regions get the initial state from the exception state of the corresponding try region.
+					if (isTryStart || isCatchOrFilterStart) {
+						// Catch/filter regions get the initial state from the exception state of the corresponding try region.
 						// This is already accounted for in the non-exceptional control flow state of the catch block above,
 						// so we can just use the state we already computed, for both try and catch regions.
 						exceptionState!.Value = lattice.Meet (exceptionState!.Value, currentState);
@@ -322,10 +335,12 @@ namespace ILLink.Shared.DataFlow
 						changed = true;
 
 						// Bubble up the changed exception state to the next enclosing try or catch exception state.
-						while (cfg.TryGetEnclosingTryOrCatch (tryOrCatchRegion!, out TRegion? enclosingTryOrCatch)) {
+						while (cfg.TryGetEnclosingTryOrCatchOrFilter (tryOrCatchOrFilterRegion!, out TRegion? enclosingTryOrCatch)) {
+							// Filters can't contain try/catch/filters.
+							Debug.Assert (enclosingTryOrCatch.Kind != RegionKind.Filter);
 							Box<TValue> tryOrCatchExceptionState = cfgState.GetExceptionState (enclosingTryOrCatch);
 							tryOrCatchExceptionState.Value = lattice.Meet (tryOrCatchExceptionState!.Value, exceptionState!.Value);
-							tryOrCatchRegion = enclosingTryOrCatch;
+							tryOrCatchOrFilterRegion = enclosingTryOrCatch;
 						}
 					}
 

--- a/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
+++ b/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
@@ -244,10 +244,11 @@ namespace ILLink.Shared.DataFlow
 
 						// A catch or filter can also be reached from a previous filter.
 						foreach (TRegion previousFilter in cfg.GetPreviousFilters (tryOrCatchOrFilterRegion!)) {
-							// For now, assume that control always leaves a filter from its last block.
-							TBlock lastFilterBlock = cfg.LastBlock (previousFilter);
-							TValue previousFilterState = cfgState.Get (lastFilterBlock).Current;
-							currentState = lattice.Meet (currentState, previousFilterState);
+							// Control may flow from the last block of a previous filter region to this catch or filter region.
+							// Exceptions may also propagate from anywhere in a filter region to this catch or filter region.
+							// This covers both cases since the exceptional state is a superset of the normal state.
+							Box<TValue> previousFilterExceptionState = cfgState.GetExceptionState (previousFilter);
+							currentState = lattice.Meet (currentState, previousFilterExceptionState.Value);
 						}
 					}
 					if (isFinallyStart) {

--- a/src/ILLink.Shared/DataFlow/IControlFlowGraph.cs
+++ b/src/ILLink.Shared/DataFlow/IControlFlowGraph.cs
@@ -53,7 +53,7 @@ namespace ILLink.Shared.DataFlow
 
 		TRegion GetCorrespondingTry (TRegion cathOrFilterOrFinallyRegion);
 
-		bool TryGetPreviousFilter (TRegion catchOrFilterRegion, [NotNullWhen (true)] out TRegion? filterRegion);
+		IEnumerable<TRegion> GetPreviousFilters (TRegion catchOrFilterRegion);
 
 		bool HasFilter (TRegion catchRegion);
 

--- a/src/ILLink.Shared/DataFlow/IControlFlowGraph.cs
+++ b/src/ILLink.Shared/DataFlow/IControlFlowGraph.cs
@@ -12,6 +12,7 @@ namespace ILLink.Shared.DataFlow
 	{
 		Try,
 		Catch,
+		Filter,
 		Finally
 	}
 
@@ -44,13 +45,17 @@ namespace ILLink.Shared.DataFlow
 		// control flow from try -> finally or from catch -> finally.
 		IEnumerable<Predecessor> GetPredecessors (TBlock block);
 
-		bool TryGetEnclosingTryOrCatch (TBlock block, [NotNullWhen (true)] out TRegion? tryOrCatchRegion);
+		bool TryGetEnclosingTryOrCatchOrFilter (TBlock block, [NotNullWhen (true)] out TRegion? tryOrCatchOrFilterRegion);
 
-		bool TryGetEnclosingTryOrCatch (TRegion region, [NotNullWhen (true)] out TRegion? tryOrCatchRegion);
+		bool TryGetEnclosingTryOrCatchOrFilter (TRegion region, [NotNullWhen (true)] out TRegion? tryOrCatchOrFilterRegion);
 
 		bool TryGetEnclosingFinally (TBlock block, [NotNullWhen (true)] out TRegion? region);
 
-		TRegion GetCorrespondingTry (TRegion cathOrFinallyRegion);
+		TRegion GetCorrespondingTry (TRegion cathOrFilterOrFinallyRegion);
+
+		bool TryGetPreviousFilter (TRegion catchOrFilterRegion, [NotNullWhen (true)] out TRegion? filterRegion);
+
+		bool HasFilter (TRegion catchRegion);
 
 		TBlock FirstBlock (TRegion region);
 

--- a/test/ILLink.RoslynAnalyzer.Tests/AdvancedTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/AdvancedTests.cs
@@ -7,7 +7,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 	{
 		protected override string TestSuiteName => "Advanced";
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2415")]
+		[Fact]
 		public Task TypeCheckRemoval ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/ILLink.RoslynAnalyzer.Tests/UnreachableBlockTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/UnreachableBlockTests.cs
@@ -7,7 +7,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 	{
 		protected override string TestSuiteName => "UnreachableBlock";
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2415")]
+		[Fact]
 		public Task TryFilterBlocks ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
 	public class ExceptionalDataFlow
 	{
 		public static void Main ()
@@ -117,6 +118,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicEvents) + "()")]
 
 		[ExpectedWarning ("IL2073", nameof (MultipleFinallyPaths) + "()", nameof (GetWithPublicEvents) + "()")]
+
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2073", nameof (MultipleFinallyPaths) + "()", nameof (GetWithPublicMethods) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2073", nameof (MultipleFinallyPaths) + "()", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2073", nameof (MultipleFinallyPaths) + "()", nameof (GetWithPublicProperties) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 		public static Type MultipleFinallyPaths ()
 		{
@@ -298,23 +307,41 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicMethods) + "()",
 			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicFields) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicFields) + "()")]
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll5) + "(Type)", nameof (GetWithPublicEvents) + "()")]
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicMethods) + "()",
 			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicFields) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicProperties) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicEvents) + "()")]
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll7) + "(Type)", nameof (GetWithPublicConstructors) + "()")]
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicConstructors) + "()")]
 
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicProperties) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll5) + "(Type)", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll5) + "(Type)", nameof (GetWithPublicProperties) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll7) + "(Type)", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll7) + "(Type)", nameof (GetWithPublicProperties) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll7) + "(Type)", nameof (GetWithPublicEvents) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicProperties) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicEvents) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 
 		public static void TryFlowsToMultipleCatchAndFinally ()
 		{
@@ -353,8 +380,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			ProducedBy = ProducedBy.Analyzer)]
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicEvents) + "()",
 			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicConstructors) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicConstructors) + "()")]
 
 		public static void NestedWithFinally ()
 		{
@@ -384,16 +410,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicMethods) + "()",
 			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicMethods) + "()",
 			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicFields) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicProperties) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicEvents) + "()")]
 		public static void ControlFlowsOutOfMultipleFinally ()
 		{
@@ -460,6 +483,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 		public static void CatchInTry ()
 		{
 			try {
@@ -481,6 +507,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		// The bug was producing this warning:
 		// [ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicConstructors) + "()")]
+
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll1) + "(Type)", nameof (GetWithPublicMethods) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 		public static void CatchInTryWithFinally ()
 		{
 			Type t = GetWithPublicConstructors ();
@@ -508,6 +538,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods) + "()")]
 
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 		public static void TestCatchesHaveSeparateState ()
 		{
 			Type t = GetWithPublicMethods ();
@@ -671,11 +704,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicMethods) + "()",
 			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicProperties) + "()")]
+
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 		public static void NestedFinally ()
 		{
 			Type t = GetWithPublicMethods ();
@@ -698,11 +734,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicMethods) + "()",
 			ProducedBy = ProducedBy.Analyzer)]
-		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()",
-			ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicProperties) + "()")]
+
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 		public static void NestedFinallyWithPredecessor ()
 		{
 			Type t = GetWithPublicMethods ();
@@ -720,9 +759,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
-		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicMethods) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicMethods) + "()",
+			ProducedBy = ProducedBy.Analyzer)]
 		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicFields) + "()")]
-		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods) + "()",
+			ProducedBy = ProducedBy.Analyzer)]
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		public static void ExceptionFilter ()
 		{
@@ -738,6 +779,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicMethods) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()")]
+
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 		public static void ExceptionFilterStateChange ()
 		{
 			Type t = GetWithPublicMethods ();
@@ -751,20 +796,36 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[ExpectedWarning ("IL2072", nameof (RequireAllFalse) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()")]
-		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicFields) + "()")]
-		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicProperties) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicProperties) + "()")]
+
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicMethods) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicProperties) + "()")]
+
+		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicMethods) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicProperties) + "()")]
+
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicMethods) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields) + "()",
+			ProducedBy = ProducedBy.Trimmer)]
 		public static void ExceptionMultipleFilters ()
 		{
 			Type t = GetWithPublicMethods ();
 			try {
 			} catch (Exception) when (RequireAllFalse (t = GetWithPublicFields ())) {
 				RequireAll (t);
-			} catch (Exception) when (RequireAllTrue (t)) {
+			} catch (Exception) when (RequireAllTrue (t = GetWithPublicProperties ())) {
 				RequireAll2 (t);
+			} catch {
+				RequireAll3 (t);
 			}
-			RequireAll3 (t);
+			RequireAll4 (t);
 		}
 
 		public static bool RequireAllTrue (

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
@@ -796,6 +796,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[ExpectedWarning ("IL2072", nameof (RequireAllFalse) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()")]
+
 		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 
@@ -803,9 +804,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll3) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 
+		[ExpectedWarning ("IL2072", nameof (RequireAllFalse2) + "(Type)", nameof (GetWithPublicMethods) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAllFalse2) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAllFalse2) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicMethods) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicFields) + "()")]
 		[ExpectedWarning ("IL2072", nameof (RequireAll4) + "(Type)", nameof (GetWithPublicProperties) + "()")]
+
+		[ExpectedWarning ("IL2072", nameof (RequireAll5) + "(Type)", nameof (GetWithPublicMethods) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll5) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll5) + "(Type)", nameof (GetWithPublicProperties) + "()")]
+
+		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicMethods) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicFields) + "()")]
+		[ExpectedWarning ("IL2072", nameof (RequireAll6) + "(Type)", nameof (GetWithPublicProperties) + "()")]
 
 		// Linker merges branches going forward.
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods) + "()",
@@ -822,10 +834,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				RequireAll (t);
 			} catch (Exception) when (RequireAllTrue (t = GetWithPublicProperties ())) {
 				RequireAll2 (t);
-			} catch {
+			} catch (Exception1) {
 				RequireAll3 (t);
+			} catch (Exception) when (RequireAllFalse2 (t)) {
+				RequireAll4 (t);
+			} catch {
+				RequireAll5 (t);
 			}
-			RequireAll4 (t);
+			RequireAll6 (t);
 		}
 
 		public static bool RequireAllTrue (
@@ -836,6 +852,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		public static bool RequireAllFalse (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+			Type type)
+		{
+			return true;
+		}
+
+		public static bool RequireAllFalse2 (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 			Type type)
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
@@ -40,6 +40,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			ExceptionFilter ();
 			ExceptionFilterStateChange ();
 			ExceptionMultipleFilters ();
+			ExceptionFilterWithBranch ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()",
@@ -842,6 +843,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				RequireAll5 (t);
 			}
 			RequireAll6 (t);
+		}
+
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields))]
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicProperties))]
+
+		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicMethods))]
+		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicFields))]
+		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicProperties))]
+
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicMethods))]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields))]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicProperties))]
+		public static void ExceptionFilterWithBranch ()
+		{
+			Type t = GetWithPublicMethods ();
+			try {
+			} catch (Exception) when (string.Empty.Length == 0 ? (t = GetWithPublicFields ()) == null : (t = GetWithPublicProperties ()) == null) {
+				RequireAll (t);
+			} catch (Exception) when (RequireAllTrue (t)) {
+			} catch {
+				RequireAll2 (t);
+			}
 		}
 
 		public static bool RequireAllTrue (

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
@@ -855,6 +855,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicMethods))]
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields))]
 		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicProperties))]
+
+		// Linker merges branches going forward.
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods),
+			ProducedBy = ProducedBy.Trimmer)]
 		public static void ExceptionFilterWithBranch ()
 		{
 			Type t = GetWithPublicMethods ();

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ExceptionalDataFlow.cs
@@ -41,6 +41,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			ExceptionFilterStateChange ();
 			ExceptionMultipleFilters ();
 			ExceptionFilterWithBranch ();
+			ExceptionFilterWithException ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields) + "()",
@@ -867,6 +868,34 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				RequireAll (t);
 			} catch (Exception) when (RequireAllTrue (t)) {
 			} catch {
+				RequireAll2 (t);
+			}
+		}
+
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicMethods))]
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicFields))]
+		[ExpectedWarning ("IL2072", nameof (RequireAll) + "(Type)", nameof (GetWithPublicProperties))]
+
+		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicMethods))]
+		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicFields))]
+		[ExpectedWarning ("IL2072", nameof (RequireAllTrue) + "(Type)", nameof (GetWithPublicProperties))]
+
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicMethods))]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicFields))]
+		[ExpectedWarning ("IL2072", nameof (RequireAll2) + "(Type)", nameof (GetWithPublicProperties))]
+		public static void ExceptionFilterWithException ()
+		{
+			Type t = GetWithPublicMethods ();
+			try {
+			} catch (Exception) when ((t = GetWithPublicFields ()) != null
+				? (t = GetWithPublicProperties ()) == null
+				: (t = GetWithPublicProperties ()) == null) {
+			} catch (Exception1) {
+				// An exception thrown from the above filter could result in methods, fields, or properties here,
+				// even though a non-exceptional exit from the filter always leaves t with 'properties'.
+				RequireAll (t);
+			} catch (Exception2) when (RequireAllTrue (t)) {
+				// Same as above, with a filter.
 				RequireAll2 (t);
 			}
 		}


### PR DESCRIPTION
This adds support for exception filters in the analyzer. Now the exception state will flow from from try blocks to any catch blocks without filters, or to the filter regions of any catch blocks that do have filters. Additionally, the dataflow state flows from a filter region to the next filter or catch. We don't check whether the exception type of the filter regions match, but conservatively assume that control can flow out of any filter to the next filter or catch.

This also assumes that control leaves the filter region from its last block - I don't know if there are cases where a filter region can contain more than one basic block, so if this is possible the logic might need to be updated.

I added a few testcases with dataflow and side effects in filter regions. This fixes https://github.com/dotnet/linker/issues/2415 and allows enabling two more of the previously failing tests.