### PR TITLE
[DAM analyzer] Fix property set expression value

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -101,11 +101,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// A property assignment is really a call to the property setter.
 				var setMethod = propertyRef.Property.SetMethod!;
 				TValue instanceValue = Visit (propertyRef.Instance, state);
-				return HandleMethodCall (
+				// The return value of a property set expression is the value,
+				// even though a property setter has no return value.
+				HandleMethodCall (
 					setMethod,
 					instanceValue,
 					ImmutableArray.Create (value),
 					operation);
+				break;
 			// TODO: when setting a property in an attribute, target is an IPropertyReference.
 			case IArrayElementReferenceOperation:
 				// TODO

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -24,6 +24,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			instance.ReadFromStaticProperty ();
 			instance.WriteToStaticProperty ();
+			instance.WriteToStaticPropertyExpressionValue ();
 
 			_ = instance.PropertyPublicParameterlessConstructorWithExplicitAccessors;
 			_ = instance.PropertyPublicConstructorsWithExplicitAccessors;
@@ -87,6 +88,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			StaticPropertyWithPublicConstructor = GetTypeWithPublicConstructors ();
 			StaticPropertyWithPublicConstructor = GetTypeWithNonPublicConstructors ();
 			StaticPropertyWithPublicConstructor = GetUnkownType ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (StaticPropertyWithPublicConstructor) + ".set", nameof (GetTypeWithNonPublicConstructors))]
+		[ExpectedWarning ("IL2072", nameof (GetTypeWithNonPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
+		private void WriteToStaticPropertyExpressionValue ()
+		{
+			(StaticPropertyWithPublicConstructor = GetTypeWithNonPublicConstructors ()).RequiresAll ();
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]


### PR DESCRIPTION
The value of a property set expression is the value, not the return value of the set method (void).