### PR TITLE
[DAM analyzer] Disable dataflow warnings for unimplemented intrinsics

### DIFF
--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -144,34 +144,16 @@ namespace ILLink.Shared.TrimAnalysis
 				}
 				break;
 
-
-			// Disable Type_GetMethod, Type_GetProperty, Type_GetField, Type_GetConstructor, Type_GetEvent, Activator_CreateInstance_Type
-			// These calls have annotations on the runtime by default, trying to analyze the annotations without intrinsic handling
-			// might end up generating unnecessary warnings. So we disable handling these calls until a proper intrinsic handling is made
-			case IntrinsicId.Type_GetMethod:
-			case IntrinsicId.Type_GetProperty:
-			case IntrinsicId.Type_GetField:
-			case IntrinsicId.Type_GetConstructor:
-			case IntrinsicId.Type_GetEvent:
-			case IntrinsicId.Activator_CreateInstance_Type:
-			case IntrinsicId.Type_GetNestedType:
-			case IntrinsicId.Type_GetType:
-			case IntrinsicId.Type_get_BaseType:
-			case IntrinsicId.Type_GetConstructors:
-			case IntrinsicId.Type_GetEvents:
-			case IntrinsicId.Type_GetFields:
-			case IntrinsicId.Type_GetMember:
-			case IntrinsicId.Type_GetMembers:
-			case IntrinsicId.Type_GetMethods:
-			case IntrinsicId.Type_GetNestedTypes:
-			case IntrinsicId.Object_GetType:
-			case IntrinsicId.Type_GetProperties:
-				methodReturnValue = MultiValueLattice.Top;
-				return true;
-
-			default:
+			case IntrinsicId.None:
 				methodReturnValue = MultiValueLattice.Top;
 				return false;
+
+			// Disable warnings for all unimplemented intrinsics. Some intrinsic methods have annotations, but analyzing them
+			// would produce unnecessary warnings even for cases that are intrinsically handled. So we disable handling these calls
+			// until a proper intrinsic handling is made
+			default:
+				methodReturnValue = MultiValueLattice.Top;
+				return true;
 			}
 
 			if (returnValue.IsEmpty () && !calledMethod.ReturnsVoid ()) {

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -154,6 +154,18 @@ namespace ILLink.Shared.TrimAnalysis
 			case IntrinsicId.Type_GetConstructor:
 			case IntrinsicId.Type_GetEvent:
 			case IntrinsicId.Activator_CreateInstance_Type:
+			case IntrinsicId.Type_GetNestedType:
+			case IntrinsicId.Type_GetType:
+			case IntrinsicId.Type_get_BaseType:
+			case IntrinsicId.Type_GetConstructors:
+			case IntrinsicId.Type_GetEvents:
+			case IntrinsicId.Type_GetFields:
+			case IntrinsicId.Type_GetMember:
+			case IntrinsicId.Type_GetMembers:
+			case IntrinsicId.Type_GetMethods:
+			case IntrinsicId.Type_GetNestedTypes:
+			case IntrinsicId.Object_GetType:
+			case IntrinsicId.Type_GetProperties:
 				methodReturnValue = MultiValueLattice.Top;
 				return true;
 

--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -16,7 +16,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task ApplyTypeAnnotations ()
 		{
-			return RunTest (nameof (ApplyTypeAnnotations));
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact]
@@ -52,7 +52,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task ComplexTypeHandling ()
 		{
-			return RunTest (nameof (ComplexTypeHandling));
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact]
@@ -90,7 +90,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task GetInterfaceDataFlow ()
 		{
-			return RunTest (nameof (GetInterfaceDataFlow));
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -93,10 +93,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (nameof (GetInterfaceDataFlow));
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2273")]
+		[Fact]
 		public Task GetNestedTypeOnAllAnnotatedType ()
 		{
-			return RunTest (nameof (GetNestedTypeOnAllAnnotatedType));
+			// https://github.com/dotnet/linker/issues/2273
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact (Skip = "https://github.com/dotnet/linker/issues/2273")]
@@ -196,10 +197,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (nameof (SuppressWarningWithLinkAttributes));
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2273")]
+		[Fact]
 		public Task TypeBaseTypeDataFlow ()
 		{
-			return RunTest (nameof (TypeBaseTypeDataFlow));
+			// https://github.com/dotnet/linker/issues/2273
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -61,10 +61,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (nameof (DynamicDependencyDataflow));
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2273")]
+		[Fact]
 		public Task EmptyArrayIntrinsicsDataFlow ()
 		{
-			return RunTest (nameof (EmptyArrayIntrinsicsDataFlow));
+			// https://github.com/dotnet/linker/issues/2273
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact]
@@ -79,10 +80,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (nameof (GenericParameterDataFlow));
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2273")]
+		[Fact]
 		public Task MakeGenericDataFlow ()
 		{
-			return RunTest (nameof (MakeGenericDataFlow));
+			// https://github.com/dotnet/linker/issues/2273
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact]
@@ -200,10 +202,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (nameof (TypeBaseTypeDataFlow));
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2273")]
+		[Fact]
 		public Task UnresolvedMembers ()
 		{
-			return RunTest (nameof (UnresolvedMembers));
+			// https://github.com/dotnet/linker/issues/2273
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact (Skip = "https://github.com/dotnet/linker/issues/2273")]

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -28,9 +28,10 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ConstructorUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
@@ -40,9 +41,10 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ExpressionCallString ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -22,9 +22,10 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ConstructorsUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
@@ -35,9 +36,10 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task EventsUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
@@ -60,57 +62,66 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task FieldsUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task MembersUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task MemberUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task MethodsUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task NestedTypesUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ObjectGetType ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task PropertiesUsedViaReflection ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task TypeHierarchyReflectionWarnings ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task TypeHierarchySuppressions ()
 		{
+			// https://github.com/dotnet/linker/issues/2578
 			return RunTest (allowMissingWarnings: true);
 		}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -404,7 +404,7 @@ class C
 			return VerifyRequiresUnreferencedCodeAnalyzer (source);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2557")]
+		[Fact]
 		public Task TestMakeGenericTypeUsage ()
 		{
 			var source = @"


### PR DESCRIPTION
This skips unimplemented intrinsics in the dataflow analyzer and enables more tests. Addresses part of https://github.com/dotnet/linker/issues/2578. Now the remaining warnings in skipped tests are all about RUC which @LakshanF is working on.