### PR TITLE
No analyzer warnings for intrinsics

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -73,16 +73,10 @@ namespace ILLink.RoslynAnalyzer
 		protected override bool IsAnalyzerEnabled (AnalyzerOptions options, Compilation compilation) =>
 			options.IsMSBuildPropertyValueTrue (MSBuildPropertyOptionNames.EnableTrimAnalyzer, compilation);
 
-		/// <summary>
-		/// Add methods that the Trimmer handles intrinsically to an exlusionary list
-		/// </summary>
-		/// <param name="compilation"></param>
-		/// <returns></returns>
-
 		protected override bool ReportSpecialIncompatibleMembersDiagnostic (OperationAnalysisContext operationContext, ImmutableArray<ISymbol> specialIncompatibleMembers, ISymbol member)
 		{
 			// Some RUC-annotated APIs are intrinsically handled by the trimmer
-			if (member is IMethodSymbol method && Intrinsics.GetIntrinsicIdForMethod (new MethodProxy (method)) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel) {
+			if (member is IMethodSymbol method && Intrinsics.GetIntrinsicIdForMethod (new MethodProxy (method)) != IntrinsicId.None) {
 				return true;
 			}
 

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -78,18 +78,11 @@ namespace ILLink.RoslynAnalyzer
 		/// </summary>
 		/// <param name="compilation"></param>
 		/// <returns></returns>
-		protected override ImmutableArray<ISymbol> GetSpecialIncompatibleMembers (Compilation compilation)
-		{
-			var incompatibleMembers = ImmutableArray.CreateBuilder<ISymbol> ();
-
-			return incompatibleMembers.ToImmutable ();
-		}
 
 		protected override bool ReportSpecialIncompatibleMembersDiagnostic (OperationAnalysisContext operationContext, ImmutableArray<ISymbol> specialIncompatibleMembers, ISymbol member)
 		{
-			if (member is IMethodSymbol method && (ImmutableArrayOperations.Contains (specialIncompatibleMembers, method, SymbolEqualityComparer.Default) ||
-				Intrinsics.GetIntrinsicIdForMethod (new MethodProxy (method)) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel)) {
-				// Some RUC-annotated APIs are intrinsically handled by the trimmer
+			// Some RUC-annotated APIs are intrinsically handled by the trimmer
+			if (member is IMethodSymbol method && Intrinsics.GetIntrinsicIdForMethod (new MethodProxy (method)) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel) {
 				return true;
 			}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -10,13 +10,13 @@ namespace ILLink.RoslynAnalyzer.Tests
 	{
 		protected override string TestSuiteName => "Reflection";
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ActivatorCreateInstance ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task AssemblyImportedViaReflectionWithSweptReferences ()
 		{
 			return RunTest (allowMissingWarnings: true);
@@ -28,7 +28,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ConstructorUsedViaReflection ()
 		{
 			return RunTest (allowMissingWarnings: true);
@@ -40,19 +40,19 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ExpressionCallString ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ExpressionNewType ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task ExpressionPropertyMethodInfo ()
 		{
 			return RunTest (allowMissingWarnings: true);
@@ -112,13 +112,13 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task TypeUsedViaReflection ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2578")]
+		[Fact]
 		public Task TypeUsedViaReflectionTypeDoesntExist ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -51,9 +51,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		// Analyzer doesn't support intrinsics: https://github.com/dotnet/linker/issues/2374
-		[ExpectedWarning ("IL2026", "System.Type.GetType(String)",
-			ProducedBy = ProducedBy.Analyzer)]
 		// Analyzer doesn't track known types: https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2072", "'type'", nameof (ApplyTypeAnnotations) + "." + nameof (RequireCombination) + "(Type)", "System.Type.GetType(String)",
 			ProducedBy = ProducedBy.Analyzer)]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -140,9 +140,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		// Analyzer doesn't support intrinsics: https://github.com/dotnet/linker/issues/2374
-		[ExpectedWarning ("IL2026", "System.Type.GetType(String)",
-			ProducedBy = ProducedBy.Analyzer)]
 		// Analyzer doesn't track known types: https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2072", "'type'", nameof (ComplexTypeHandling) + "." + nameof (RequirePublicMethods) + "(Type)", "System.Type.GetType(String)",
 			ProducedBy = ProducedBy.Analyzer)]
@@ -160,9 +157,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		// Analyzer doesn't support intrinsics: https://github.com/dotnet/linker/issues/2374
-		[ExpectedWarning ("IL2026", "Activator.CreateInstance(String, String)",
-			ProducedBy = ProducedBy.Analyzer)]
 		static void TestArrayCreateInstanceByName ()
 		{
 			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayCreateInstanceByNameElement[]");


### PR DESCRIPTION
Fixes #2578 - temporary fix so as for the analyzer to not generate warnings until we add intrinsic support. This PR suppresses RUC and combined with #2596 should generate no warnings.