### PR TITLE
Produce warnings for annotations on invalid types

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -170,6 +170,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public override TValue VisitPropertyReference (IPropertyReferenceOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 		{
+			if (!operation.Property.Type.IsTypeInterestingForDataflow ())
+				return TopValue;
+
 			if (operation.GetValueUsageInfo (operation.Property).HasFlag (ValueUsageInfo.Read)) {
 				// Accessing property for reading is really a call to the getter
 				// The setter case is handled in assignment operation since here we don't have access to the value to pass to the setter

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -170,9 +170,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public override TValue VisitPropertyReference (IPropertyReferenceOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 		{
-			if (!operation.Property.Type.IsTypeInterestingForDataflow ())
-				return TopValue;
-
 			if (operation.GetValueUsageInfo (operation.Property).HasFlag (ValueUsageInfo.Read)) {
 				// Accessing property for reading is really a call to the getter
 				// The setter case is handled in assignment operation since here we don't have access to the value to pass to the setter

--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -29,8 +29,10 @@ namespace ILLink.RoslynAnalyzer
 		{
 			var diagDescriptorsArrayBuilder = ImmutableArray.CreateBuilder<DiagnosticDescriptor> (26);
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode));
+			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersIsNotAllowedOnMethods));
 			AddRange (DiagnosticId.MethodParameterCannotBeStaticallyDetermined, DiagnosticId.DynamicallyAccessedMembersMismatchTypeArgumentTargetsGenericParameter);
 			AddRange (DiagnosticId.DynamicallyAccessedMembersOnFieldCanOnlyApplyToTypesOrStrings, DiagnosticId.DynamicallyAccessedMembersOnPropertyCanOnlyApplyToTypesOrStrings);
+			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnMethodReturnValueCanOnlyApplyToTypesOrStrings));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersFieldAccessedViaReflection));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersMethodAccessedViaReflection));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.UnrecognizedTypeInRuntimeHelpersRunClassConstructor));
@@ -166,6 +168,10 @@ namespace ILLink.RoslynAnalyzer
 			if (member is IFieldSymbol field && field.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None && !field.Type.IsTypeInterestingForDataflow ())
 				context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnFieldCanOnlyApplyToTypesOrStrings), member.Locations[0], member.GetDisplayName ()));
 			else if (member is IMethodSymbol method) {
+				if (method.GetDynamicallyAccessedMemberTypesOnReturnType () != DynamicallyAccessedMemberTypes.None && !method.ReturnType.IsTypeInterestingForDataflow ())
+					context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnMethodReturnValueCanOnlyApplyToTypesOrStrings), member.Locations[0], member.GetDisplayName ()));
+				if (method.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None && !method.ContainingType.IsTypeInterestingForDataflow ())
+					context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersIsNotAllowedOnMethods), member.Locations[0]));
 				foreach (var parameter in method.Parameters) {
 					if (parameter.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None && !parameter.Type.IsTypeInterestingForDataflow ())
 						context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnMethodParameterCanOnlyApplyToTypesOrStrings), member.Locations[0], parameter.GetDisplayName (), member.GetDisplayName ()));

--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -161,17 +161,16 @@ namespace ILLink.RoslynAnalyzer
 			return diagnosticContext.Diagnostics;
 		}
 
-		static void VerifyMemberOnlyApplyToTypesOrStrings(SymbolAnalysisContext context, ISymbol member)
+		static void VerifyMemberOnlyApplyToTypesOrStrings (SymbolAnalysisContext context, ISymbol member)
 		{
-			if (member is IFieldSymbol field && field.GetDynamicallyAccessedMemberTypes() != DynamicallyAccessedMemberTypes.None && !field.Type.IsTypeInterestingForDataflow ())
+			if (member is IFieldSymbol field && field.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None && !field.Type.IsTypeInterestingForDataflow ())
 				context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnFieldCanOnlyApplyToTypesOrStrings), member.Locations[0], member.GetDisplayName ()));
 			else if (member is IMethodSymbol method) {
 				foreach (var parameter in method.Parameters) {
-					if(parameter.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None && !parameter.Type.IsTypeInterestingForDataflow())
-						context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnMethodParameterCanOnlyApplyToTypesOrStrings), member.Locations[0], parameter.GetDisplayName(), member.GetDisplayName ()));
+					if (parameter.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None && !parameter.Type.IsTypeInterestingForDataflow ())
+						context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnMethodParameterCanOnlyApplyToTypesOrStrings), member.Locations[0], parameter.GetDisplayName (), member.GetDisplayName ()));
 				}
-			}
-			else if (member is IPropertySymbol property && property.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None &&!property.Type.IsTypeInterestingForDataflow ()) {
+			} else if (member is IPropertySymbol property && property.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None && !property.Type.IsTypeInterestingForDataflow ()) {
 				context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnPropertyCanOnlyApplyToTypesOrStrings), member.Locations[0], member.GetDisplayName ()));
 			}
 		}

--- a/src/ILLink.RoslynAnalyzer/ITypeSymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ITypeSymbolExtensions.cs
@@ -20,19 +20,9 @@ namespace ILLink.RoslynAnalyzer
 			if (type.SpecialType == SpecialType.System_String)
 				return true;
 
-			return IsSystemType (type) || IsSystemReflectionIReflect (type);
+			var flags = GetFlags (type);
+			return IsSystemType (flags) || IsSystemReflectionIReflect (flags);
 		}
-
-		private static bool IsSystemType (ITypeSymbol type)
-		{
-			return (GetFlags (type) & HierarchyFlags.IsSystemType) != 0;
-		}
-
-		private static bool IsSystemReflectionIReflect (this ITypeSymbol type)
-		{
-			return (GetFlags (type) & HierarchyFlags.IsSystemReflectionIReflect) != 0;
-		}
-
 
 		private static HierarchyFlags GetFlags (ITypeSymbol type)
 		{
@@ -43,9 +33,8 @@ namespace ILLink.RoslynAnalyzer
 
 			ITypeSymbol? baseType = type;
 			while (baseType != null) {
-				if (baseType.Name == "Type" && baseType.ContainingNamespace.GetDisplayName () == "System") {
+				if (baseType.Name == "Type" && baseType.ContainingNamespace.GetDisplayName () == "System")
 					flags |= HierarchyFlags.IsSystemType;
-				}
 
 				foreach (var iface in baseType.Interfaces) {
 					if (iface.Name == "IReflect" && iface.ContainingNamespace.GetDisplayName () == "System.Reflection") {
@@ -57,5 +46,9 @@ namespace ILLink.RoslynAnalyzer
 			}
 			return flags;
 		}
+
+		private static bool IsSystemType (HierarchyFlags flags) => (flags & HierarchyFlags.IsSystemType) != 0;
+
+		private static bool IsSystemReflectionIReflect (HierarchyFlags flags) => (flags & HierarchyFlags.IsSystemReflectionIReflect) != 0;
 	}
 }

--- a/src/ILLink.RoslynAnalyzer/ITypeSymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ITypeSymbolExtensions.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace ILLink.RoslynAnalyzer
+{
+	static class ITypeSymbolExtensions
+	{
+		[Flags]
+		private enum HierarchyFlags
+		{
+			IsSystemType = 0x01,
+			IsSystemReflectionIReflect = 0x02,
+		}
+
+		public static bool IsTypeInterestingForDataflow (this ITypeSymbol type)
+		{
+			if (type.SpecialType == SpecialType.System_String)
+				return true;
+
+			return IsSystemType (type) || IsSystemReflectionIReflect (type);
+		}
+
+		private static bool IsSystemType (ITypeSymbol type)
+		{
+			return (GetFlags (type) & HierarchyFlags.IsSystemType) != 0;
+		}
+
+		private static bool IsSystemReflectionIReflect (this ITypeSymbol type)
+		{
+			return (GetFlags (type) & HierarchyFlags.IsSystemReflectionIReflect) != 0;
+		}
+
+		
+		private static HierarchyFlags GetFlags (ITypeSymbol type)
+		{
+			HierarchyFlags flags = 0;
+			if (type.Name == "IReflect" && type.ContainingNamespace.GetDisplayName () == "System.Reflection") {
+				flags |= HierarchyFlags.IsSystemReflectionIReflect;
+			}
+
+			ITypeSymbol? baseType = type;
+			while (baseType != null) {
+				if (baseType.Name == "Type" && baseType.ContainingNamespace.GetDisplayName () == "System") {
+					flags |= HierarchyFlags.IsSystemType;
+				}
+
+				foreach (var iface in baseType.Interfaces) {
+					if (iface.Name == "IReflect" && iface.ContainingNamespace.GetDisplayName () == "System.Reflection") {
+						flags |= HierarchyFlags.IsSystemReflectionIReflect;
+					}
+				}
+
+				baseType = baseType.BaseType;
+			}
+			return flags;
+		}
+	}
+}

--- a/src/ILLink.RoslynAnalyzer/ITypeSymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ITypeSymbolExtensions.cs
@@ -33,7 +33,7 @@ namespace ILLink.RoslynAnalyzer
 			return (GetFlags (type) & HierarchyFlags.IsSystemReflectionIReflect) != 0;
 		}
 
-		
+
 		private static HierarchyFlags GetFlags (ITypeSymbol type)
 		{
 			HierarchyFlags flags = 0;

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -51,7 +51,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public override MultiValue VisitParameterReference (IParameterReferenceOperation paramRef, StateValue state)
 		{
-			return paramRef.Parameter.Type.IsTypeInterestingForDataflow() ? new MethodParameterValue (paramRef.Parameter) : TopValue;
+			return paramRef.Parameter.Type.IsTypeInterestingForDataflow () ? new MethodParameterValue (paramRef.Parameter) : TopValue;
 		}
 
 		public override MultiValue VisitInstanceReference (IInstanceReferenceOperation instanceRef, StateValue state)
@@ -68,7 +68,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public override MultiValue VisitFieldReference (IFieldReferenceOperation fieldRef, StateValue state)
 		{
-			return fieldRef.Field.Type.IsTypeInterestingForDataflow() ? new FieldValue (fieldRef.Field) : TopValue;
+			return fieldRef.Field.Type.IsTypeInterestingForDataflow () ? new FieldValue (fieldRef.Field) : TopValue;
 		}
 
 		public override MultiValue VisitTypeOf (ITypeOfOperation typeOfOperation, StateValue state)

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -51,7 +51,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public override MultiValue VisitParameterReference (IParameterReferenceOperation paramRef, StateValue state)
 		{
-			return new MethodParameterValue (paramRef.Parameter);
+			return paramRef.Parameter.Type.IsTypeInterestingForDataflow() ? new MethodParameterValue (paramRef.Parameter) : TopValue;
 		}
 
 		public override MultiValue VisitInstanceReference (IInstanceReferenceOperation instanceRef, StateValue state)
@@ -68,7 +68,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public override MultiValue VisitFieldReference (IFieldReferenceOperation fieldRef, StateValue state)
 		{
-			return new FieldValue (fieldRef.Field);
+			return fieldRef.Field.Type.IsTypeInterestingForDataflow() ? new FieldValue (fieldRef.Field) : TopValue;
 		}
 
 		public override MultiValue VisitTypeOf (ITypeOfOperation typeOfOperation, StateValue state)

--- a/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -44,9 +44,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		static Type _staticTypeWithoutRequirements;
 
-		// TODO: warn about annotation on wrong type in analyzer: https://github.com/dotnet/linker/issues/2273
-		[ExpectedWarning ("IL2097", nameof (_annotationOnWrongType),
-			ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2097", nameof (_annotationOnWrongType))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
 		static object _annotationOnWrongType;
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -196,8 +196,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicParameterlessConstructorAndNothing (typeof (TestType), this.GetType ());
 		}
 
-		// TODO: https://github.com/dotnet/linker/issues/2273
-		[ExpectedWarning ("IL2098", "p1", nameof (UnsupportedParameterType), ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2098", "p1", nameof (UnsupportedParameterType))]
 		private void UnsupportedParameterType ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] object p1)
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -185,10 +185,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			throw new NotImplementedException ();
 		}
 
-		// TODO: https://github.com/dotnet/linker/issues/2273
-		[ExpectedWarning ("IL2106", nameof (UnsupportedReturnType), ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2106", nameof (UnsupportedReturnType))]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 		static object UnsupportedReturnType () => null;
+
+		[ExpectedWarning ("IL2106", nameof (UnsupportedReturnTypeAndParameter))]
+		[ExpectedWarning ("IL2098", nameof (UnsupportedReturnTypeAndParameter))]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		static object UnsupportedReturnTypeAndParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] object param) => null;
 
 		class TestType
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -138,18 +138,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class NonTypeType
 		{
-			// Analyzer doesn't warn about annotations on unsupported types:
-			// https://github.com/dotnet/linker/issues/2273
-			[ExpectedWarning ("IL2041", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2041")]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public MethodInfo GetMethod (string name)
 			{
 				return null;
 			}
 
-			// Analyzer doesn't warn about annotations on unsupported types:
-			// https://github.com/dotnet/linker/issues/2273
-			[ExpectedWarning ("IL2041", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2041")]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public static void StaticMethod ()
 			{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -18,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		public static void Main ()
 		{
 			var instance = new PropertyDataFlow ();
+
 			instance.ReadFromInstanceProperty ();
 			instance.WriteToInstanceProperty ();
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -18,7 +18,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		public static void Main ()
 		{
 			var instance = new PropertyDataFlow ();
-
 			instance.ReadFromInstanceProperty ();
 			instance.WriteToInstanceProperty ();
 
@@ -43,9 +42,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		static Type StaticPropertyWithPublicConstructor { get; set; }
 
-		// Analyzer doesn't warn about annotations on unsupported types
-		// https://github.com/dotnet/linker/issues/2273
-		[ExpectedWarning ("IL2099", nameof (PropertyWithUnsupportedType), ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2099", nameof (PropertyWithUnsupportedType))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
 		static object PropertyWithUnsupportedType { get; set; }
 


### PR DESCRIPTION
Produce warnings for annotations on invalid types using a symbol analyzer
Don't produce dataflow warnings for annotations on invalid types
Add extension file to ask if a type is interesting for dataflow

Fixes https://github.com/dotnet/linker/issues/2598