### PR TITLE
GetDisplayName uses definition's type parameter names instead of instance's

### DIFF
--- a/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
@@ -110,6 +110,8 @@ namespace ILLink.RoslynAnalyzer
 				break;
 
 			case IMethodSymbol methodSymbol:
+				// Use definition type parameter names, not instance type parameters
+				methodSymbol = methodSymbol.OriginalDefinition;
 				// Format the declaring type with namespace and containing types.
 				if (methodSymbol.ContainingSymbol.Kind == SymbolKind.NamedType) {
 					// If the containing symbol is a method (for example for local functions),

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -766,9 +766,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		// Warn about calls to the static methods and the ctor on the RUC type:
 		[ExpectedWarning ("IL2026", "RUCTypeRequiresPublicFields<T>.StaticMethod", "message")]
-		[ExpectedWarning ("IL2026", "RUCTypeRequiresPublicFields<T>.StaticMethodRequiresPublicMethods<U>", "message", ProducedBy = ProducedBy.Trimmer)]
-		// https://github.com/dotnet/linker/issues/2573
-		[ExpectedWarning ("IL2026", "RUCTypeRequiresPublicFields<T>.StaticMethodRequiresPublicMethods<T>", "message", ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL2026", "RUCTypeRequiresPublicFields<T>.StaticMethodRequiresPublicMethods<U>", "message")]
 		[ExpectedWarning ("IL2026", "RUCTypeRequiresPublicFields<T>.RUCTypeRequiresPublicFields", "message")]
 		// And about method generic parameters:
 		[ExpectedWarning ("IL2091", "RUCTypeRequiresPublicFields<T>.InstanceMethodRequiresPublicMethods<U>()")]


### PR DESCRIPTION
Addresses https://github.com/dotnet/linker/issues/2573

Uses IMethodSymbol.OriginalDefinition to get the display name for reporting warnings in the analyzer