### PR TITLE
Suppressing analyzer for compiler generated methods

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace ILLink.RoslynAnalyzer
 {
@@ -64,6 +65,32 @@ namespace ILLink.RoslynAnalyzer
 				context.RegisterOperationBlockAction (context => {
 					if (context.OwningSymbol.IsInRequiresUnreferencedCodeAttributeScope ())
 						return;
+
+					// See https://github.com/dotnet/linker/issues/2587
+					// Need to punt on handling compiler generated methods until the linker is fixed
+					// async is handled here and the rest are handled just below
+					// iterators could be handled here once https://github.com/dotnet/roslyn/issues/20179 is fixed
+					if (context.OwningSymbol is IMethodSymbol methodSymbol && methodSymbol.IsAsync) {
+						return;
+					}
+
+					// Sub optimal way to handle analyzer not to generate warnings until the linker is fixed
+					// Iterators, local functions and lambdas are handled 
+					bool doNotHandleThisMethod = false;
+					foreach (IOperation blockOperation in context.OperationBlocks) {
+						if (blockOperation is IBlockOperation blocks) {
+							foreach (IOperation operation in blocks.Operations) {
+								if (operation.Kind == OperationKind.AnonymousFunction ||
+								operation.Kind == OperationKind.LocalFunction ||
+								operation.Kind == OperationKind.YieldBreak ||
+								operation.Kind == OperationKind.YieldReturn)
+									doNotHandleThisMethod = true;
+							}
+						}
+					}
+					if (doNotHandleThisMethod)
+						return;
+
 
 					foreach (var operationBlock in context.OperationBlocks) {
 						ControlFlowGraph cfg = context.GetControlFlowGraph (operationBlock);

--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -76,7 +76,6 @@ namespace ILLink.RoslynAnalyzer
 
 					// Sub optimal way to handle analyzer not to generate warnings until the linker is fixed
 					// Iterators, local functions and lambdas are handled 
-					bool doNotHandleThisMethod = false;
 					foreach (IOperation blockOperation in context.OperationBlocks) {
 						if (blockOperation is IBlockOperation blocks) {
 							foreach (IOperation operation in blocks.Operations) {
@@ -84,13 +83,10 @@ namespace ILLink.RoslynAnalyzer
 								operation.Kind == OperationKind.LocalFunction ||
 								operation.Kind == OperationKind.YieldBreak ||
 								operation.Kind == OperationKind.YieldReturn)
-									doNotHandleThisMethod = true;
+									return;
 							}
 						}
 					}
-					if (doNotHandleThisMethod)
-						return;
-
 
 					foreach (var operationBlock in context.OperationBlocks) {
 						ControlFlowGraph cfg = context.GetControlFlowGraph (operationBlock);

--- a/test/ILLink.RoslynAnalyzer.Tests/Warnings.WarningSuppressionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/Warnings.WarningSuppressionTests.cs
@@ -10,7 +10,7 @@ namespace ILLink.RoslynAnalyzer.Tests.Warnings
 		[Fact]
 		public Task SuppressWarningsInCompilerGeneratedCode ()
 		{
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -135,7 +135,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TypeStore._staticTypeWithPublicParameterlessConstructor = GetUnknownType ();
 		}
 
-		[ExpectedWarning ("IL2064", nameof (TypeStore) + "." + nameof (TypeStore._staticTypeWithPublicParameterlessConstructor))]
+		[ExpectedWarning ("IL2064", nameof (TypeStore) + "." + nameof (TypeStore._staticTypeWithPublicParameterlessConstructor), ProducedBy = ProducedBy.Trimmer)]
 		private void WriteUnknownValue ()
 		{
 			var array = new object[1];

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -165,7 +165,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		// Validate error message when untracable value is passed to an annotated parameter.
 		[ExpectedWarning ("IL2062",
 			nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicParameterlessConstructor) + "(Type)",
-			"'type'")]
+			"'type'", ProducedBy = ProducedBy.Trimmer)]
 		private void UnknownValue ()
 		{
 			var array = new object[1];

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -117,7 +117,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[ExpectedWarning ("IL2063",
-			nameof (MethodReturnParameterDataFlow) + "." + nameof (ReturnUnknownValue) + "()")]
+			nameof (MethodReturnParameterDataFlow) + "." + nameof (ReturnUnknownValue) + "()", ProducedBy = ProducedBy.Trimmer)]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		Type ReturnUnknownValue ()
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -90,7 +90,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			NonTypeType.StaticMethod ();
 		}
 
-		[ExpectedWarning ("IL2065", nameof (MethodThisDataFlowTypeTest) + "." + nameof (MethodThisDataFlowTypeTest.RequireThisNonPublicMethods), "'this'")]
+		[ExpectedWarning ("IL2065", nameof (MethodThisDataFlowTypeTest) + "." + nameof (MethodThisDataFlowTypeTest.RequireThisNonPublicMethods), "'this'", ProducedBy = ProducedBy.Trimmer)]
 		static void TestUnknownThis ()
 		{
 			var array = new object[1];

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -94,7 +94,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				_ = _default.Value;
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static IEnumerable<int> TestDynamicallyAccessedMethod ()
 			{
 				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
@@ -264,7 +264,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				_ = _default.Value;
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static async void TestDynamicallyAccessedMethod ()
 			{
 				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
@@ -436,7 +436,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				_ = _default.Value;
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static async IAsyncEnumerable<int> TestDynamicallyAccessedMethod ()
 			{
 				typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -45,8 +45,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static IEnumerable<int> TestLdftnOnRUCMethod ()
 			{
 				yield return 0;
-				var a = new Action (RequiresUnreferencedCodeMethod);
-				a ();
+				var _ = new Action (RequiresUnreferencedCodeMethod);
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
@@ -57,7 +56,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			}
 
 			// See https://github.com/dotnet/linker/issues/2587
-			//[UnconditionalSuppressMessage ("Analyzer only sees the method parameter from the source file", "IL2067")]
 			[UnconditionalSuppressMessage ("Linker sees the compiler generated property", "IL2077")]
 			static IEnumerable<int> TestMethodParameterWithRequirements (Type unknownType = null)
 			{
@@ -125,7 +123,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			}
 
 			// See https://github.com/dotnet/linker/issues/2587
-			//[UnconditionalSuppressMessage ("Analyzer only sees the method parameter from the source file", "IL2067")]
 			[UnconditionalSuppressMessage ("Linker sees the compiler generated property", "IL2077")]
 			static async void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
@@ -280,8 +277,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethodInLtftnLocalFunction ()
 			{
-				var a = new Action (LocalFunction);
-				a ();
+				var _ = new Action (LocalFunction);
 
 				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
@@ -304,7 +300,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				LocalFunction ();
 
 				[UnconditionalSuppressMessage ("Test", "IL2026")] // This supresses the RequiresUnreferencedCodeMethod
-				void LocalFunction (/**Type unknownType = null**/)
+				void LocalFunction (Type unknownType = null)
 				{
 					RequiresUnreferencedCodeMethod ();
 				}
@@ -352,58 +348,51 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
-				Action a = () => RequiresUnreferencedCodeMethod ();
-				a ();
+				Action _ = () => RequiresUnreferencedCodeMethod ();
 			}
 
 			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestReflectionAccessRUCMethod ()
 			{
-				Action a = () => typeof (SuppressWarningsInCompilerGeneratedCode)
+				Action _ = () => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
-				a ();
 			}
 
 			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestLdftnOnRUCMethod ()
 			{
-				Action a = () => { var _ = new Action (RequiresUnreferencedCodeMethod); };
-				a ();
+				Action _ = () => { var _ = new Action (RequiresUnreferencedCodeMethod); };
 			}
 
 			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestDynamicallyAccessedMethod ()
 			{
-				Action a = () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
-				a ();
+				Action _ = () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
 			[ExpectedWarning ("IL2077", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2077")]
 			static void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
-				Action a = () => unknownType.RequiresNonPublicMethods ();
-				a ();
+				Action _ = () => unknownType.RequiresNonPublicMethods ();
 			}
 
 			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericMethodParameterRequirement<TUnknown> ()
 			{
-				Action a = () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
-				a ();
+				Action _ = () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
 			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericTypeParameterRequirement<TUnknown> ()
 			{
-				Action a = () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
-				a ();
+				Action _ = () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
 			public static void Test ()

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -45,7 +45,8 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static IEnumerable<int> TestLdftnOnRUCMethod ()
 			{
 				yield return 0;
-				var _ = new Action (RequiresUnreferencedCodeMethod);
+				var a = new Action (RequiresUnreferencedCodeMethod);
+				a ();
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
@@ -56,7 +57,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			}
 
 			// See https://github.com/dotnet/linker/issues/2587
-			[UnconditionalSuppressMessage ("Analyzer only sees the method parameter from the source file", "IL2067")]
+			//[UnconditionalSuppressMessage ("Analyzer only sees the method parameter from the source file", "IL2067")]
 			[UnconditionalSuppressMessage ("Linker sees the compiler generated property", "IL2077")]
 			static IEnumerable<int> TestMethodParameterWithRequirements (Type unknownType = null)
 			{
@@ -124,7 +125,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			}
 
 			// See https://github.com/dotnet/linker/issues/2587
-			[UnconditionalSuppressMessage ("Analyzer only sees the method parameter from the source file", "IL2067")]
+			//[UnconditionalSuppressMessage ("Analyzer only sees the method parameter from the source file", "IL2067")]
 			[UnconditionalSuppressMessage ("Linker sees the compiler generated property", "IL2077")]
 			static async void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
@@ -167,7 +168,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -176,7 +177,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
@@ -187,7 +188,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction ()
 				{ var _ = new Action (RequiresUnreferencedCodeMethod); }
 			}
@@ -197,7 +198,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
@@ -206,7 +207,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2077")]
+				[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => unknownType.RequiresNonPublicMethods ();
 			}
 
@@ -215,7 +216,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2091")]
+				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
@@ -224,7 +225,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2091")]
+				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
@@ -244,8 +245,8 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction<TUnknown> ();
 
-				[ExpectedWarning ("IL2087")]
-				[ExpectedWarning ("IL2087")]
+				[ExpectedWarning ("IL2087", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2087", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction<TSecond> ()
 				{
 					typeof (TUnknown).RequiresPublicMethods ();
@@ -279,9 +280,10 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethodInLtftnLocalFunction ()
 			{
-				var _ = new Action (LocalFunction);
+				var a = new Action (LocalFunction);
+				a ();
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -292,7 +294,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				{
 					typeof (DynamicallyAccessedLocalFunction).RequiresNonPublicMethods ();
 
-					[ExpectedWarning ("IL2026")]
+					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 					void LocalFunction () => RequiresUnreferencedCodeMethod ();
 				}
 			}
@@ -302,7 +304,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				LocalFunction ();
 
 				[UnconditionalSuppressMessage ("Test", "IL2026")] // This supresses the RequiresUnreferencedCodeMethod
-				void LocalFunction (Type unknownType = null)
+				void LocalFunction (/**Type unknownType = null**/)
 				{
 					RequiresUnreferencedCodeMethod ();
 				}
@@ -313,7 +315,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2067")]
+				[ExpectedWarning ("IL2067", ProducedBy = ProducedBy.Trimmer)]
 				[UnconditionalSuppressMessage ("Test", "IL2026")] // This supresses the RequiresUnreferencedCodeMethod
 				void LocalFunction (Type unknownType = null)
 				{
@@ -333,6 +335,8 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				TestGenericTypeParameterRequirement<TestType> ();
 				TestGenericLocalFunction<TestType> ();
 				TestGenericLocalFunctionInner<TestType> ();
+				TestGenericLocalFunctionWithAnnotations<TestType> ();
+				TestGenericLocalFunctionWithAnnotationsAndClosure<TestType> ();
 				TestCallRUCMethodInLtftnLocalFunction ();
 				DynamicallyAccessedLocalFunction.TestCallRUCMethodInDynamicallyAccessedLocalFunction ();
 				TestSuppressionOnLocalFunction ();
@@ -344,55 +348,62 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 		{
 			// Suppression currently doesn't propagate to local functions
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
-				Action _ = () => RequiresUnreferencedCodeMethod ();
+				Action a = () => RequiresUnreferencedCodeMethod ();
+				a ();
 			}
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestReflectionAccessRUCMethod ()
 			{
-				Action _ = () => typeof (SuppressWarningsInCompilerGeneratedCode)
+				Action a = () => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
+				a ();
 			}
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestLdftnOnRUCMethod ()
 			{
-				Action _ = () => { var _ = new Action (RequiresUnreferencedCodeMethod); };
+				Action a = () => { var _ = new Action (RequiresUnreferencedCodeMethod); };
+				a ();
 			}
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestDynamicallyAccessedMethod ()
 			{
-				Action _ = () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				Action a = () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				a ();
 			}
 
-			[ExpectedWarning ("IL2077", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2077", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2077")]
 			static void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
-				Action _ = () => unknownType.RequiresNonPublicMethods ();
+				Action a = () => unknownType.RequiresNonPublicMethods ();
+				a ();
 			}
 
-			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericMethodParameterRequirement<TUnknown> ()
 			{
-				Action _ = () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				Action a = () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				a ();
 			}
 
-			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true)]
+			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericTypeParameterRequirement<TUnknown> ()
 			{
-				Action _ = () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				Action a = () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				a ();
 			}
 
 			public static void Test ()
@@ -432,7 +443,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				LocalFunction ();
 				await MethodAsync ();
 
-				[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
+				[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;


### PR DESCRIPTION
Fixes #2587. This fix is temporary until we fix the linker.

- #2561 impacts the local functions and lambda data flow analysis
- The fix is sub-optimal in going through all the `IOperations `in a method to detect candidates for compiler generated code (other than async)
- Roslyn should expose `IsIterator `as a public API, which is a feature [request ](https://github.com/dotnet/roslyn/issues/20179)currently.