### PR TITLE
Update tests to match analyzer behavior around intrinsics

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -52,7 +52,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task ComplexTypeHandling ()
 		{
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -16,7 +16,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task ApplyTypeAnnotations ()
 		{
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -51,9 +51,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		// Analyzer doesn't track known types: https://github.com/dotnet/linker/issues/2273
-		[ExpectedWarning ("IL2072", "'type'", nameof (ApplyTypeAnnotations) + "." + nameof (RequireCombination) + "(Type)", "System.Type.GetType(String)",
-			ProducedBy = ProducedBy.Analyzer)]
 		static void TestFromTypeGetTypeOverConstant ()
 		{
 			RequireCombination (Type.GetType ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromTypeGetTypeOverConstantTestType"));

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -99,9 +99,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		// Analyzer doesn't support intrinsics: https://github.com/dotnet/linker/issues/2374
-		[ExpectedWarning ("IL2072", "'type'", nameof (ComplexTypeHandling) + "." + nameof (RequirePublicMethods) + "(Type)", "System.Object.GetType()",
-			ProducedBy = ProducedBy.Analyzer)]
 		static void TestArrayGetTypeFromMethodParamHelper (ArrayGetTypeFromMethodParamElement[] p)
 		{
 			RequirePublicMethods (p.GetType ());
@@ -124,9 +121,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static ArrayGetTypeFromFieldElement[] _arrayGetTypeFromField;
 
 		[Kept]
-		// Analyzer doesn't support intrinsics: https://github.com/dotnet/linker/issues/2374
-		[ExpectedWarning ("IL2072", "'type'", nameof (ComplexTypeHandling) + "." + nameof (RequirePublicMethods) + "(Type)", "System.Object.GetType()",
-			ProducedBy = ProducedBy.Analyzer)]
 		static void TestArrayGetTypeFromField ()
 		{
 			RequirePublicMethods (_arrayGetTypeFromField.GetType ());
@@ -140,9 +134,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		// Analyzer doesn't track known types: https://github.com/dotnet/linker/issues/2273
-		[ExpectedWarning ("IL2072", "'type'", nameof (ComplexTypeHandling) + "." + nameof (RequirePublicMethods) + "(Type)", "System.Type.GetType(String)",
-			ProducedBy = ProducedBy.Analyzer)]
 		static void TestArrayTypeGetType ()
 		{
 			RequirePublicMethods (Type.GetType ("Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayTypeGetTypeElement[]"));


### PR DESCRIPTION
Analyzer intentionally "ignores" intrinsics which linker recognizes, but analyzer doesn't yet. Meaning it will not produce any warnings due to them.

Some tests didn't reflect this change correctly.