### PR TITLE
Add tests for out and ref parameter data flow

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
@@ -119,11 +119,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			typeWithMethods.RequiresPublicMethods ();
 		}
 
-		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
-		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValueFromValue))]
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValueFromValue))]
 		// https://github.com/dotnet/linker/issues/2632
-		// This second warning should not be generated, the value of typeWithMethods should have PublicMethods
-		// after the call with out parameter.
+		// This third warning should not be generated, the value of typeWithMethods should have PublicMethods
+		// after the call with ref parameter.
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
 		static void TestReadFromRefParameter_MismatchOnInput_PassedTwice ()
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
@@ -19,6 +19,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			TestAssignStaticToAnnotatedRefParameter (ref typeWithMethods);
 			TestAssignParameterToAnnotatedRefParameter (ref typeWithMethods, typeof (TestType));
+
+			TestReadFromRefParameter ();
+			TestReadFromOutParameter_PassedTwice ();
+			TestReadFromRefParameter_MismatchOnOutput ();
+			TestReadFromRefParameter_MismatchOnOutput_PassedTwice ();
+			TestReadFromRefParameter_MismatchOnInput ();
+			TestReadFromRefParameter_MismatchOnInput_PassedTwice ();
+			Type nullType1 = null;
+			TestPassingRefParameter (ref nullType1);
+			Type nullType2 = null;
+			TestPassingRefParameter_Mismatch (ref nullType2);
+			Type nullType3 = null;
+			TestAssigningToRefParameter (nullType3, ref nullType3);
+			Type nullType4 = null;
+			TestAssigningToRefParameter_Mismatch (nullType4, ref nullType4);
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
@@ -57,6 +72,108 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[RequiresUnreferencedCode ("Message for --TestType.Requires--")]
 			public static void Requires () { }
 		}
+
+		static void TestReadFromRefParameter ()
+		{
+			Type typeWithMethods = null;
+			TryGetAnnotatedValue (ref typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		static void TestReadFromOutParameter_PassedTwice ()
+		{
+			Type typeWithMethods = null;
+			TryGetAnnotatedValueFromValue (typeWithMethods, ref typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		// https://github.com/dotnet/linker/issues/2632
+		// This test should generate a warning since there's mismatch on annotations
+		// [ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicFields))]
+		static void TestReadFromRefParameter_MismatchOnOutput ()
+		{
+			Type typeWithMethods = null;
+			TryGetAnnotatedValue (ref typeWithMethods);
+			typeWithMethods.RequiresPublicFields ();
+		}
+
+		// https://github.com/dotnet/linker/issues/2632
+		// This test should generate a warning since there's mismatch on annotations
+		// [ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicFields))]
+		static void TestReadFromRefParameter_MismatchOnOutput_PassedTwice ()
+		{
+			Type typeWithMethods = null;
+			TryGetAnnotatedValueFromValue (typeWithMethods, ref typeWithMethods);
+			typeWithMethods.RequiresPublicFields ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
+		// https://github.com/dotnet/linker/issues/2632
+		// This second warning should not be generated, the value of typeWithMethods should have PublicMethods
+		// after the call with out parameter.
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
+		static void TestReadFromRefParameter_MismatchOnInput ()
+		{
+			Type typeWithMethods = GetTypeWithFields ();
+			TryGetAnnotatedValue (ref typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
+		// https://github.com/dotnet/linker/issues/2632
+		// This second warning should not be generated, the value of typeWithMethods should have PublicMethods
+		// after the call with out parameter.
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
+		static void TestReadFromRefParameter_MismatchOnInput_PassedTwice ()
+		{
+			Type typeWithMethods = GetTypeWithFields ();
+			TryGetAnnotatedValueFromValue (typeWithMethods, ref typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		static void TestPassingRefParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] ref Type typeWithMethods)
+		{
+			TryGetAnnotatedValue (ref typeWithMethods);
+		}
+
+		[ExpectedWarning ("IL2067", "typeWithMethods", nameof (TryGetAnnotatedValue))]
+		static void TestPassingRefParameter_Mismatch ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] ref Type typeWithMethods)
+		{
+			TryGetAnnotatedValue (ref typeWithMethods);
+		}
+
+		static void TestAssigningToRefParameter (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type inputTypeWithMethods,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] ref Type outputTypeWithMethods)
+		{
+			outputTypeWithMethods = inputTypeWithMethods;
+		}
+
+		[ExpectedWarning ("IL2067", "inputTypeWithFields", "outputTypeWithMethods")]
+		static void TestAssigningToRefParameter_Mismatch (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type inputTypeWithFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] ref Type outputTypeWithMethods)
+		{
+			outputTypeWithMethods = inputTypeWithFields;
+		}
+
+		static bool TryGetAnnotatedValue ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] ref Type typeWithMethods)
+		{
+			typeWithMethods = null;
+			return false;
+		}
+
+		static bool TryGetAnnotatedValueFromValue (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type inValue,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] ref Type typeWithMethods)
+		{
+			typeWithMethods = inValue;
+			return false;
+		}
+
+		[return: DynamicallyAccessedMembersAttribute (DynamicallyAccessedMemberTypes.PublicFields)]
+		static Type GetTypeWithFields () => null;
 
 		class TestType
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodOutParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodOutParameterDataFlow.cs
@@ -86,10 +86,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			typeWithMethods.RequiresPublicMethods ();
 		}
 
-		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
-		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValueFromValue))]
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValueFromValue))]
 		// https://github.com/dotnet/linker/issues/2632
-		// This second warning should not be generated, the value of typeWithMethods should have PublicMethods
+		// This third warning should not be generated, the value of typeWithMethods should have PublicMethods
 		// after the call with out parameter.
 		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
 		static void TestInitializedReadFromOutParameter_MismatchOnInput_PassedTwice ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodOutParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodOutParameterDataFlow.cs
@@ -1,0 +1,149 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	class MethodOutParameterDataFlow
+	{
+		public static void Main ()
+		{
+			Type t = null;
+			TestInitializedReadFromOutParameter ();
+			TestInitializedReadFromOutParameter_PassedTwice ();
+			TestUninitializedReadFromOutParameter ();
+			TestInitializedReadFromOutParameter_MismatchOnOutput ();
+			TestInitializedReadFromOutParameter_MismatchOnOutput_PassedTwice ();
+			TestInitializedReadFromOutParameter_MismatchOnInput ();
+			TestInitializedReadFromOutParameter_MismatchOnInput_PassedTwice ();
+			TestPassingOutParameter (out t);
+			TestPassingOutParameter_Mismatch (out t);
+			TestAssigningToOutParameter (t, out t);
+			TestAssigningToOutParameter_Mismatch (t, out t);
+		}
+
+		static void TestInitializedReadFromOutParameter ()
+		{
+			Type typeWithMethods = null;
+			TryGetAnnotatedValue (out typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		static void TestInitializedReadFromOutParameter_PassedTwice ()
+		{
+			Type typeWithMethods = null;
+			TryGetAnnotatedValueFromValue (typeWithMethods, out typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		// https://github.com/dotnet/linker/issues/2632
+		// These two warnings should not be generated, the annotations are all correct
+		[ExpectedWarning ("IL2062", nameof (TryGetAnnotatedValue))]
+		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
+		static void TestUninitializedReadFromOutParameter ()
+		{
+			Type typeWithMethods;
+			TryGetAnnotatedValue (out typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		// https://github.com/dotnet/linker/issues/2632
+		// This test should generate a warning since there's mismatch on annotations
+		// [ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicFields))]
+		static void TestInitializedReadFromOutParameter_MismatchOnOutput ()
+		{
+			Type typeWithMethods = null;
+			TryGetAnnotatedValue (out typeWithMethods);
+			typeWithMethods.RequiresPublicFields ();
+		}
+
+		// https://github.com/dotnet/linker/issues/2632
+		// This test should generate a warning since there's mismatch on annotations
+		// [ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicFields))]
+		static void TestInitializedReadFromOutParameter_MismatchOnOutput_PassedTwice ()
+		{
+			Type typeWithMethods = null;
+			TryGetAnnotatedValueFromValue (typeWithMethods, out typeWithMethods);
+			typeWithMethods.RequiresPublicFields ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
+		// https://github.com/dotnet/linker/issues/2632
+		// This second warning should not be generated, the value of typeWithMethods should have PublicMethods
+		// after the call with out parameter.
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
+		static void TestInitializedReadFromOutParameter_MismatchOnInput ()
+		{
+			Type typeWithMethods = GetTypeWithFields ();
+			TryGetAnnotatedValue (out typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
+		[ExpectedWarning ("IL2072", nameof (TryGetAnnotatedValue))]
+		// https://github.com/dotnet/linker/issues/2632
+		// This second warning should not be generated, the value of typeWithMethods should have PublicMethods
+		// after the call with out parameter.
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
+		static void TestInitializedReadFromOutParameter_MismatchOnInput_PassedTwice ()
+		{
+			Type typeWithMethods = GetTypeWithFields ();
+			TryGetAnnotatedValueFromValue (typeWithMethods, out typeWithMethods);
+			typeWithMethods.RequiresPublicMethods ();
+		}
+
+		static void TestPassingOutParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] out Type typeWithMethods)
+		{
+			TryGetAnnotatedValue (out typeWithMethods);
+		}
+
+		[ExpectedWarning ("IL2067", "typeWithFields", nameof (TryGetAnnotatedValue))]
+		static void TestPassingOutParameter_Mismatch ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] out Type typeWithFields)
+		{
+			TryGetAnnotatedValue (out typeWithFields);
+		}
+
+		static void TestAssigningToOutParameter (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type inputTypeWithMethods,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] out Type outputTypeWithMethods)
+		{
+			outputTypeWithMethods = inputTypeWithMethods;
+		}
+
+		[ExpectedWarning ("IL2067", "inputTypeWithFields", "outputTypeWithMethods")]
+		static void TestAssigningToOutParameter_Mismatch (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type inputTypeWithFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] out Type outputTypeWithMethods)
+		{
+			outputTypeWithMethods = inputTypeWithFields;
+		}
+
+		static bool TryGetAnnotatedValue ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] out Type typeWithMethods)
+		{
+			typeWithMethods = null;
+			return false;
+		}
+
+		static bool TryGetAnnotatedValueFromValue (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type inValue,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] out Type typeWithMethods)
+		{
+			typeWithMethods = inValue;
+			return false;
+		}
+
+		[return: DynamicallyAccessedMembersAttribute (DynamicallyAccessedMemberTypes.PublicFields)]
+		static Type GetTypeWithFields () => null;
+
+		class TestType
+		{
+		}
+	}
+}


### PR DESCRIPTION
This adds tests for https://github.com/dotnet/linker/issues/2632