### PR TITLE
Share intrinsic handling of GetMember and similar APIs

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodParameterValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodParameterValue.cs
@@ -11,11 +11,15 @@ namespace ILLink.Shared.TrimAnalysis
 {
 	partial record MethodParameterValue
 	{
-		public MethodParameterValue (IParameterSymbol parameterSymbol) => ParameterSymbol = parameterSymbol;
+		public MethodParameterValue (IParameterSymbol parameterSymbol)
+			: this (parameterSymbol, FlowAnnotations.GetMethodParameterAnnotation (parameterSymbol)) { }
+
+		public MethodParameterValue (IParameterSymbol parameterSymbol, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+			=> (ParameterSymbol, DynamicallyAccessedMemberTypes) = (parameterSymbol, dynamicallyAccessedMemberTypes);
 
 		public readonly IParameterSymbol ParameterSymbol;
 
-		public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes => FlowAnnotations.GetMethodParameterAnnotation (ParameterSymbol);
+		public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes { get; }
 
 		public override IEnumerable<string> GetDiagnosticArgumentsForAnnotationMismatch ()
 			=> new string[] { ParameterSymbol.GetDisplayName (), ParameterSymbol.ContainingSymbol.GetDisplayName () };

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -93,13 +93,12 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public override MultiValue VisitFieldReference (IFieldReferenceOperation fieldRef, StateValue state)
 		{
-			if (fieldRef.Field.Type.IsTypeInterestingForDataflow())
-			{
+			if (fieldRef.Field.Type.IsTypeInterestingForDataflow ()) {
 				var field = fieldRef.Field;
-				if (field.Name is "Empty" && field.ContainingType.HasName("System.String"))
-					return new KnownStringValue(string.Empty);
+				if (field.Name is "Empty" && field.ContainingType.HasName ("System.String"))
+					return new KnownStringValue (string.Empty);
 
-				return new FieldValue(fieldRef.Field);
+				return new FieldValue (fieldRef.Field);
 			}
 
 			return TopValue;

--- a/src/ILLink.Shared/TrimAnalysis/SystemReflectionMethodBaseValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/SystemReflectionMethodBaseValue.cs
@@ -2,11 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using ILLink.Shared.DataFlow;
+using ILLink.Shared.TypeSystemProxy;
 
 namespace ILLink.Shared.TrimAnalysis
 {
 	/// <summary>
 	/// This is a known System.Reflection.MethodBase value.  MethodRepresented is the 'value' of the MethodBase.
 	/// </summary>
-	sealed partial record SystemReflectionMethodBaseValue : SingleValue;
+	sealed partial record SystemReflectionMethodBaseValue : SingleValue
+	{
+		public SystemReflectionMethodBaseValue (MethodProxy methodRepresented) => MethodRepresented = methodRepresented;
+
+		public readonly MethodProxy MethodRepresented;
+
+		public override string ToString () => this.ValueToString (MethodRepresented);
+	}
 }

--- a/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using ILLink.Shared.TypeSystemProxy;
 using Mono.Cecil;
 using Mono.Linker;
@@ -47,8 +49,42 @@ namespace ILLink.Shared.TrimAnalysis
 		private partial MethodThisParameterValue GetMethodThisParameterValue (MethodProxy method, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 			=> new (method.Method, dynamicallyAccessedMemberTypes);
 
+		private partial MethodParameterValue GetMethodParameterValue (MethodProxy method, int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+			=> new (
+				ReflectionMethodBodyScanner.ResolveToTypeDefinition (_context, method.Method.Parameters[parameterIndex].ParameterType),
+				method.Method,
+				parameterIndex,
+				dynamicallyAccessedMemberTypes);
+
+		private partial IEnumerable<SystemReflectionMethodBaseValue> GetMethodsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
+		{
+			foreach (var method in type.Type.GetMethodsOnTypeHierarchy (_context, m => m.Name == name, bindingFlags))
+				yield return new SystemReflectionMethodBaseValue (new MethodProxy (method));
+		}
+
+		private partial IEnumerable<SystemTypeValue> GetNestedTypesOnType (TypeProxy type, string name, BindingFlags? bindingFlags)
+		{
+			foreach (var nestedType in type.Type.GetNestedTypesOnType (t => t.Name == name, bindingFlags))
+				yield return new SystemTypeValue (new TypeProxy (nestedType));
+		}
+
 		private partial void MarkStaticConstructor (TypeProxy type)
 			=> _reflectionMethodBodyScanner.MarkStaticConstructor (_analysisContext, type.Type);
+
+		private partial void MarkEventsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
+			=> _reflectionMethodBodyScanner.MarkEventsOnTypeHierarchy (_analysisContext, type.Type, e => e.Name == name, bindingFlags);
+
+		private partial void MarkFieldsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
+			=> _reflectionMethodBodyScanner.MarkFieldsOnTypeHierarchy (_analysisContext, type.Type, f => f.Name == name, bindingFlags);
+
+		private partial void MarkPropertiesOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
+			=> _reflectionMethodBodyScanner.MarkPropertiesOnTypeHierarchy (_analysisContext, type.Type, p => p.Name == name, bindingFlags);
+
+		private partial void MarkMethod (MethodProxy method)
+			=> _reflectionMethodBodyScanner.MarkMethod (_analysisContext, method.Method);
+
+		private partial void MarkType (TypeProxy type)
+			=> _reflectionMethodBodyScanner.MarkType (_analysisContext, type.Type);
 
 		private partial string GetContainingSymbolDisplayName () => _callingMethodDefinition.GetDisplayName ();
 	}

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -120,18 +120,6 @@ namespace ILLink.Shared.TrimAnalysis
 	}
 
 	/// <summary>
-	/// This is a known System.Reflection.MethodBase value.  MethodRepresented is the 'value' of the MethodBase.
-	/// </summary>
-	partial record SystemReflectionMethodBaseValue
-	{
-		public SystemReflectionMethodBaseValue (MethodDefinition methodRepresented) => MethodRepresented = methodRepresented;
-
-		public readonly MethodDefinition MethodRepresented;
-
-		public override string ToString () => this.ValueToString (MethodRepresented);
-	}
-
-	/// <summary>
 	/// A value that came from a method parameter - such as the result of a ldarg.
 	/// </summary>
 	partial record MethodParameterValue : IValueWithStaticType

--- a/test/ILLink.RoslynAnalyzer.Tests/DynamicallyAccessedMembersAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DynamicallyAccessedMembersAnalyzerTests.cs
@@ -196,14 +196,13 @@ class C
 			// (17,9): warning IL2070: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'.
 			// The parameter 'type' of method 'C.M(Type)' does not have matching annotations.
 			// The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-			return VerifyDynamicallyAccessedMembersAnalyzer (TargetMethodWithAnnotations);
-			/*,
-			VerifyCS.Diagnostic (DiagnosticId.DynamicallyAccessedMembersMismatchParameterTargetsThisParameter)
-			.WithSpan (17, 9, 17, 30)
-			.WithArguments ("System.Type.GetMethod(String)",
-				"type",
-				"C.M(Type)",
-				"'DynamicallyAccessedMemberTypes.PublicMethods'")*/
+			return VerifyDynamicallyAccessedMembersAnalyzer (TargetMethodWithAnnotations,
+				VerifyCS.Diagnostic (DiagnosticId.DynamicallyAccessedMembersMismatchParameterTargetsThisParameter)
+				.WithSpan (17, 9, 17, 30)
+				.WithArguments ("System.Type.GetMethod(String)",
+					"type",
+					"C.M(Type)",
+					"'DynamicallyAccessedMemberTypes.PublicMethods'"));
 		}
 		#endregion
 
@@ -351,11 +350,10 @@ class C
 			// (12,9): warning IL2075: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'.
 			// The return value of method 'C.GetT()' does not have matching annotations.
 			// The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-			return VerifyDynamicallyAccessedMembersAnalyzer (TargetMethodWithAnnotations
-				/*,
+			return VerifyDynamicallyAccessedMembersAnalyzer (TargetMethodWithAnnotations,
 				VerifyCS.Diagnostic (DiagnosticId.DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsThisParameter)
 				.WithSpan (12, 9, 12, 34)
-				.WithArguments ("System.Type.GetMethod(String)", "C.GetFoo()", "'DynamicallyAccessedMemberTypes.PublicMethods'")*/);
+				.WithArguments ("System.Type.GetMethod(String)", "C.GetFoo()", "'DynamicallyAccessedMemberTypes.PublicMethods'"));
 		}
 		#endregion
 
@@ -493,13 +491,12 @@ class C
 			// (14,9): warning IL2080: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'.
 			// The field 'C.f' does not have matching annotations.
 			// The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-			return VerifyDynamicallyAccessedMembersAnalyzer (TargetMethodWithAnnotations);
-			/*,
-			VerifyCS.Diagnostic (DiagnosticId.DynamicallyAccessedMembersMismatchFieldTargetsThisParameter)
-			.WithSpan (14, 9, 14, 27)
-			.WithArguments ("System.Type.GetMethod(String)",
-				"C.f",
-				"'DynamicallyAccessedMemberTypes.PublicMethods'")*/
+			return VerifyDynamicallyAccessedMembersAnalyzer (TargetMethodWithAnnotations,
+				VerifyCS.Diagnostic (DiagnosticId.DynamicallyAccessedMembersMismatchFieldTargetsThisParameter)
+				.WithSpan (14, 9, 14, 27)
+				.WithArguments ("System.Type.GetMethod(String)",
+					"C.f",
+					"'DynamicallyAccessedMemberTypes.PublicMethods'"));
 		}
 		#endregion
 

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -25,8 +25,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task ConstructorsUsedViaReflection ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]
@@ -37,10 +36,15 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task EventUsedViaReflection ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task EventsUsedViaReflection ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]
@@ -63,38 +67,63 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task FieldUsedViaReflection ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task FieldsUsedViaReflection ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]
 		public Task MembersUsedViaReflection ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]
 		public Task MemberUsedViaReflection ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task MethodUsedViaReflection ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task MethodUsedViaReflectionAndLocal ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task MethodUsedViaReflectionWithDefaultBindingFlags ()
+		{
+			return RunTest ();
 		}
 
 		[Fact]
 		public Task MethodsUsedViaReflection ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task NestedTypeUsedViaReflection ()
+		{
+			return RunTest ();
 		}
 
 		[Fact]
 		public Task NestedTypesUsedViaReflection ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]
@@ -105,10 +134,21 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task PropertyUsedViaReflection ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task PropertiesUsedViaReflection ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task RuntimeReflectionExtensionsCalls ()
+		{
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReflectionTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReflectionTests.g.cs
@@ -38,12 +38,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task EventUsedViaReflection ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
 		public Task ExpressionCallStringAndLocals ()
 		{
 			return RunTest (allowMissingWarnings: true);
@@ -62,36 +56,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task FieldUsedViaReflection ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task MethodUsedViaReflection ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task MethodUsedViaReflectionAndLocal ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task MethodUsedViaReflectionWithDefaultBindingFlags ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task NestedTypeUsedViaReflection ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
 		public Task ObjectGetTypeLibraryMode ()
 		{
 			return RunTest (allowMissingWarnings: true);
@@ -104,19 +68,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task PropertyUsedViaReflection ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
 		public Task RunClassConstructorUsedViaReflection ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task RuntimeReflectionExtensionsCalls ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -39,8 +39,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public static Type _annotatedField;
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2110", nameof (_annotatedField), ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
 			static void Reflection ()
 			{
 				typeof (AnnotatedField).GetField ("_annotatedField").SetValue (null, typeof (TestType));
@@ -52,8 +51,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedField).GetField ("_annotatedField").SetValue (null, typeof (TestType));
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2110", nameof (_annotatedField), ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
 			static void ReflectionReadOnly ()
 			{
 				typeof (AnnotatedField).GetField ("_annotatedField").GetValue (null);
@@ -160,8 +158,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				{ }
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter), ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
 			static void Reflection ()
 			{
 				typeof (AnnotatedMethodParameters).GetMethod (nameof (MethodWithSingleAnnotatedParameter)).Invoke (null, null);
@@ -294,8 +291,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedMethodReturnValue).GetMethod (nameof (InstanceMethodWithAnnotatedReturnValue)).Invoke (null, null);
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2111", nameof (VirtualMethodWithAnnotatedReturnValue), ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2111", nameof (VirtualMethodWithAnnotatedReturnValue))]
 			static void ReflectionOnVirtual ()
 			{
 				typeof (AnnotatedMethodReturnValue).GetMethod (nameof (VirtualMethodWithAnnotatedReturnValue)).Invoke (null, null);
@@ -423,8 +419,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				public Type PropertyWithAnnotation { get; set; }
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2111", nameof (Property1WithAnnotation) + ".set", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2111", nameof (Property1WithAnnotation) + ".set")]
 			static void ReflectionOnPropertyItself ()
 			{
 				typeof (AnnotatedProperty).GetProperty (nameof (Property1WithAnnotation));
@@ -441,8 +436,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedProperty).GetProperty (nameof (Property2WithAnnotationGetterOnly));
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2111", nameof (VirtualProperty3WithAnnotationGetterOnly), ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2111", nameof (VirtualProperty3WithAnnotationGetterOnly))]
 			static void ReflectionOnPropertyWithGetterOnlyOnVirtual ()
 			{
 				typeof (AnnotatedProperty).GetProperty (nameof (VirtualProperty3WithAnnotationGetterOnly));
@@ -453,15 +447,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedProperty).GetMethod ("get_" + nameof (Property1WithAnnotation));
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2111", nameof (Property1WithAnnotation) + ".set", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2111", nameof (Property1WithAnnotation) + ".set")]
 			static void ReflectionOnSetter ()
 			{
 				typeof (AnnotatedProperty).GetMethod ("set_" + nameof (Property1WithAnnotation));
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2111", nameof (VirtualProperty3WithAnnotationGetterOnly) + ".get", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2111", nameof (VirtualProperty3WithAnnotationGetterOnly) + ".get")]
 			static void ReflectionOnVirtualGetter ()
 			{
 				typeof (AnnotatedProperty).GetMethod ("get_" + nameof (VirtualProperty3WithAnnotationGetterOnly));
@@ -662,8 +654,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				var _ = new Action<Type> (GenericWithAnnotatedMethod<TestType>.AnnotatedMethod);
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
-			[ExpectedWarning ("IL2111", nameof (GenericMethodWithAnnotation), ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2111", nameof (GenericMethodWithAnnotation))]
 			public static void GenericMethodWithAnnotationReflection ()
 			{
 				typeof (AnnotationOnGenerics).GetMethod (nameof (GenericMethodWithAnnotation));

--- a/test/Mono.Linker.Tests.Cases/DataFlow/DynamicDependencyDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/DynamicDependencyDataflow.cs
@@ -18,18 +18,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 		static Type TypeWithPublicMethods;
 
-		// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
 		[Kept]
-		[ExpectedWarning ("IL2080", nameof (Type.GetField), ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2080", nameof (Type.GetField))]
 		[DynamicDependency ("DynamicDependencyTo")]
 		static void DynamicDependencyFrom ()
 		{
 			_ = TypeWithPublicMethods.GetField ("f");
 		}
 
-		// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
 		[Kept]
-		[ExpectedWarning ("IL2080", nameof (Type.GetProperty), ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2080", nameof (Type.GetProperty))]
 		static void DynamicDependencyTo ()
 		{
 			_ = TypeWithPublicMethods.GetProperty ("p");

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
@@ -358,6 +358,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static void Test ()
 			{
 				typeof (TestClassWithRUCMethods).GetMethods ((BindingFlags) 24);
+
+				// Analyzer currently can't figure this out
+				int bindingFlagsNumber = 24;
+				typeof (TestClassWithRUCMethods).GetMethods ((BindingFlags) bindingFlagsNumber);
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
@@ -24,6 +24,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestIgnoreCaseBindingFlags ();
 			TestIgnorableBindingFlags ();
 			TestUnsupportedBindingFlags ();
+
+			HandlingOfComplexExpressionForBindingFlags.Test ();
+			HandlingOfBindingFlagsAsNumbers.Test ();
+			HandlingOfBindingFlagsFromConstants.Test ();
 		}
 
 		[Kept]
@@ -305,6 +309,79 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			private bool MarkedDueToSuppressChangeType ()
 			{
 				return true;
+			}
+		}
+
+		[Kept]
+		class HandlingOfComplexExpressionForBindingFlags
+		{
+			[Kept]
+			class TestClassWithRUCMethods
+			{
+				[Kept]
+				public void Method () { }
+
+				[Kept]
+				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+				[RequiresUnreferencedCode (nameof (HandlingOfComplexExpressionForBindingFlags) + "--" + nameof (TestClassWithRUCMethods))]
+				private void PrivateMethodWithRUC () { }
+			}
+
+			[Kept]
+			// https://github.com/dotnet/linker/issues/2638
+			[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+			public static void Test ()
+			{
+				BindingFlags left = BindingFlags.Instance | BindingFlags.Static;
+				BindingFlags right = BindingFlags.Public;
+				int result = (int) left | (int) right;
+				typeof (TestClassWithRUCMethods).GetMethods ((BindingFlags) result);
+			}
+		}
+
+		[Kept]
+		class HandlingOfBindingFlagsAsNumbers
+		{
+			[Kept]
+			class TestClassWithRUCMethods
+			{
+				[Kept]
+				public static void Method () { }
+
+				[RequiresUnreferencedCode (nameof (HandlingOfBindingFlagsAsNumbers) + "--" + nameof (TestClassWithRUCMethods))]
+				private static void PrivateMethodWithRUC () { }
+			}
+
+			[Kept]
+			// https://github.com/dotnet/linker/issues/2638
+			[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
+			public static void Test ()
+			{
+				typeof (TestClassWithRUCMethods).GetMethods ((BindingFlags) 24);
+			}
+		}
+
+		[Kept]
+		class HandlingOfBindingFlagsFromConstants
+		{
+			[Kept]
+			class TestClassWithRUCMethods
+			{
+				[Kept]
+				public static void Method () { }
+
+				[RequiresUnreferencedCode (nameof (HandlingOfBindingFlagsAsNumbers) + "--" + nameof (TestClassWithRUCMethods))]
+				private static void PrivateMethodWithRUC () { }
+			}
+
+			const BindingFlags PublicStaticFlags = BindingFlags.Public | BindingFlags.Static;
+			const BindingFlags PublicOnlyFlags = BindingFlags.Public;
+
+			[Kept]
+			public static void Test ()
+			{
+				typeof (TestClassWithRUCMethods).GetMethods (PublicStaticFlags);
+				typeof (TestClassWithRUCMethods).GetMethods (PublicOnlyFlags | BindingFlags.Static);
 			}
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAccessedThrough.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAccessedThrough.cs
@@ -39,7 +39,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		{
 		}
 
-		[ExpectedWarning ("IL2026", "--RequiresOnlyThroughReflection--", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2026", "--RequiresOnlyThroughReflection--")]
 		static void TestRequiresOnlyThroughReflection ()
 		{
 			typeof (RequiresAccessedThrough)
@@ -54,7 +54,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 			}
 
-			[ExpectedWarning ("IL2026", "--GenericType.RequiresOnlyThroughReflection--", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "--GenericType.RequiresOnlyThroughReflection--")]
 			public static void Test ()
 			{
 				typeof (AccessedThroughReflectionOnGenericType<T>)

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -464,10 +464,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				typeof (DerivedWithoutRequiresOnType).RequiresPublicMethods ();
 			}
 
-			[ExpectedWarning ("IL2026", "BaseWithoutRequiresOnType.Method()", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "InterfaceWithoutRequires.Method(Int32)", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "InterfaceWithoutRequires.Method()", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "ImplementationWithRequiresOnType.Method()", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "BaseWithoutRequiresOnType.Method()")]
+			[ExpectedWarning ("IL2026", "InterfaceWithoutRequires.Method(Int32)")]
+			[ExpectedWarning ("IL2026", "InterfaceWithoutRequires.Method()")]
+			[ExpectedWarning ("IL2026", "ImplementationWithRequiresOnType.Method()")]
 			static void TestDirectReflectionAccess ()
 			{
 				// Requires on the method itself
@@ -600,16 +600,16 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				typeof (DerivedWithRequires).RequiresPublicFields ();
 			}
 
-			[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticField", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "WithRequires.StaticField")]
+			[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticField")]
+			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField")]
 			static void TestDirectReflectionAccess ()
 			{
 				typeof (WithRequires).GetField (nameof (WithRequires.StaticField));
 				typeof (WithRequires).GetField (nameof (WithRequires.InstanceField)); // Doesn't warn
 				typeof (WithRequires).GetField ("PrivateStaticField", BindingFlags.NonPublic);
 				typeof (WithRequiresOnlyInstanceFields).GetField (nameof (WithRequiresOnlyInstanceFields.InstanceField)); // Doesn't warn
-				typeof (DerivedWithoutRequires).GetField (nameof (DerivedWithRequires.DerivedStaticField)); // Doesn't warn
+				typeof (DerivedWithoutRequires).GetField (nameof (DerivedWithoutRequires.DerivedStaticField)); // Doesn't warn
 				typeof (DerivedWithRequires).GetField (nameof (DerivedWithRequires.DerivedStaticField));
 			}
 
@@ -676,7 +676,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static event EventHandler StaticEvent;
 			}
 
-			[ExpectedWarning ("IL2026", "StaticEvent.add", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "StaticEvent.add")]
+			// https://github.com/mono/linker/issues/2218
+			[ExpectedWarning ("IL2026", "StaticEvent.remove", ProducedBy = ProducedBy.Analyzer)]
 			static void TestDirectReflectionAccess ()
 			{
 				typeof (WithRequires).GetEvent (nameof (WithRequires.StaticEvent));
@@ -735,12 +737,12 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				typeof (DerivedWithRequires).RequiresPublicProperties ();
 			}
 
-			[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.get", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.set", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.get")]
+			[ExpectedWarning ("IL2026", "WithRequires.StaticProperty.set")]
+			[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticProperty.get")]
+			[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticProperty.set")]
+			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.get")]
+			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticProperty.set")]
 			static void TestDirectReflectionAccess ()
 			{
 				typeof (WithRequires).GetProperty (nameof (WithRequires.StaticProperty));

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresWithCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresWithCopyAssembly.cs
@@ -50,7 +50,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			tmp.Method ();
 		}
 
-		[ExpectedWarning ("IL2026", "--MethodCalledThroughReflection--", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2026", "--MethodCalledThroughReflection--")]
 		static void TestRequiresThroughReflectionInMethodFromCopiedAssembly ()
 		{
 			typeof (RequiresInCopyAssembly)


### PR DESCRIPTION
Other than sharing more code and adapting it so that it works on both linker and analyzer, this change brings simple analysis of constant integer values in the analyzer. This is necessary to make most reflection API calls recognize binding flags. For example `GetMethods(BindingFlags.Public | BindingFlags.Static)`. So this change adds analysis of constant values (as recognized by the Roslyn's operation tree) and the OR binary operator for integers and enums.

Added some new tests for the binding flags handling.

Reenabled some disabled tests for analyzer.
Moved the main affected tests from the generated source files to the hardcoded one and force them to exact match of warnings for both linker and analyzer.