### PR TITLE
[release/6.0.2xx] Fix invalid cast of type parameter

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -172,10 +172,10 @@ namespace ILLink.RoslynAnalyzer
 					for (int i = 0; i < typeParams.Length; i++) {
 						var typeParam = typeParams[i];
 						var typeArg = typeArgs[i];
-						if (!typeParam.HasConstructorConstraint)
+						if (!typeParam.HasConstructorConstraint ||
+							typeArg is not INamedTypeSymbol { InstanceConstructors: { } typeArgCtors })
 							continue;
 
-						var typeArgCtors = ((INamedTypeSymbol) typeArg).InstanceConstructors;
 						foreach (var instanceCtor in typeArgCtors) {
 							if (instanceCtor.Arity > 0)
 								continue;

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapability.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -748,9 +748,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				var _ = new Action (GenericWithStaticMethod<TestType>.GenericTypeWithStaticMethodWhichRequires);
 			}
 
+			static T MakeNew<T> () where T : new() => new T ();
+			static T MakeNew2<T> () where T : new() => MakeNew<T> ();
+
 			public static void Test ()
 			{
 				GenericTypeWithStaticMethodViaLdftn ();
+				MakeNew2<TestType> ();
 			}
 		}
 


### PR DESCRIPTION
Brings the fix @agocke made as part of https://github.com/dotnet/linker/pull/2540 to 6.0.2. Fixes https://github.com/dotnet/linker/issues/2642.

## Customer Impact

Updating VS from 17 to 17.1 brings in a 6.0.2 SDK which causes the analyzer to crash on a project that previously worked, producing a warning. The warning also shows up in CI when using the 6.0.2 SDK, and fails the build with warnaserror. See details in https://github.com/dotnet/linker/issues/2642.

## Testing

Unit tests confirmed the issue and the fix. This was originally discovered as part of running the analyzer over itself and the linker in https://github.com/dotnet/linker/pull/2523.

## Risk

Very low risk - this turns a cast to a type check, and skips the case which used to throw an InvalidCastException.