### PR TITLE
nameof calls should not warn on analyzer

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -225,6 +225,10 @@ namespace ILLink.RoslynAnalyzer
 					ISymbol member,
 					ImmutableArray<ISymbol> incompatibleMembers)
 				{
+					// Do not emit diagnostics if the operation is nameof()
+					if (operationContext.Operation.Parent is IOperation operation && operation.Kind == OperationKind.NameOf)
+						return;
+
 					ISymbol containingSymbol = FindContainingSymbol (operationContext, AnalyzerDiagnosticTargets);
 
 					// Do not emit any diagnostic if caller is annotated with the attribute too.

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/BasicRequires.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/BasicRequires.cs
@@ -30,6 +30,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestRequiresOnPropertyGetterAndSetter ();
 			TestThatTrailingPeriodIsAddedToMessage ();
 			TestThatTrailingPeriodIsNotDuplicatedInWarningMessage ();
+			TestRequiresFromNameOf ();
 			OnEventMethod.Test ();
 			RequiresOnGenerics.Test ();
 		}
@@ -135,6 +136,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		static void TestThatTrailingPeriodIsNotDuplicatedInWarningMessage ()
 		{
 			WarningMessageEndsWithPeriod ();
+		}
+
+		static void TestRequiresFromNameOf ()
+		{
+			_ = nameof (BasicRequires.RequiresWithMessageOnly);
 		}
 
 		class OnEventMethod

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -29,6 +29,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestStaticMethodOnRequiresTypeSuppressedByRequiresOnMethod ();
 			TestStaticConstructorCalls ();
 			TestOtherMemberTypesWithRequires ();
+			TestNameOfDoesntWarn ();
 			ReflectionAccessOnMethod.Test ();
 			ReflectionAccessOnCtor.Test ();
 			ReflectionAccessOnField.Test ();
@@ -426,6 +427,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			MemberTypesWithRequires.Event -= null;
 		}
 
+		static void TestNameOfDoesntWarn ()
+		{
+			_ = nameof (ClassWithRequires.StaticMethod);
+			_ = nameof (MemberTypesWithRequires.field);
+			_ = nameof (MemberTypesWithRequires.Property);
+			_ = nameof (MemberTypesWithRequires.Event);
+		}
+
 		class ReflectionAccessOnMethod
 		{
 			// Analyzer still dont understand RUC on type
@@ -591,11 +600,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				typeof (DerivedWithRequires).RequiresPublicFields ();
 			}
 
-			[ExpectedWarning ("IL2026", "WithRequires.StaticField")]
-			// Analyzer does not recognize the binding flags
+			[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
 			[ExpectedWarning ("IL2026", "WithRequires.PrivateStaticField", ProducedBy = ProducedBy.Trimmer)]
-			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField")]
-			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField", ProducedBy = ProducedBy.Analyzer)]
+			[ExpectedWarning ("IL2026", "DerivedWithRequires.DerivedStaticField", ProducedBy = ProducedBy.Trimmer)]
 			static void TestDirectReflectionAccess ()
 			{
 				typeof (WithRequires).GetField (nameof (WithRequires.StaticField));
@@ -606,7 +613,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				typeof (DerivedWithRequires).GetField (nameof (DerivedWithRequires.DerivedStaticField));
 			}
 
-			[ExpectedWarning ("IL2026", "WithRequires.StaticField")]
+			[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
 			[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
 			[ExpectedWarning ("IL2026", "WithRequires.StaticField", ProducedBy = ProducedBy.Trimmer)]
 			[DynamicDependency (nameof (WithRequires.StaticField), typeof (WithRequires))]


### PR DESCRIPTION
Add a condition to bypass `nameof` usage since it will not invoke the member and instead will be translated to load a string
Add tests
Fix ExpectedWarnings from disabled intrinsics that were producing warnings from accessing fields in a `nameof` call

Fixes #2647 