### PR TITLE
Fix behavior of intrinsics with empty inputs

### DIFF
--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -183,9 +183,7 @@ namespace ILLink.Shared.TrimAnalysis
 				return true;
 			}
 
-			if (returnValue == null && !calledMethod.ReturnsVoid ())
-				throw new InvalidOperationException ("No return value set for intrinsic");
-
+			Debug.Assert (returnValue != null || calledMethod.ReturnsVoid (), "Intrinsics must set a return value.");
 			returnValue ??= MultiValueLattice.Top;
 
 			// Validate that the return value has the correct annotations as per the method return value annotations

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -95,28 +95,37 @@ namespace ILLink.Shared.TrimAnalysis
 			// GetInterface (String, bool)
 			//
 			case IntrinsicId.Type_GetInterface: {
-					if (instanceValue.IsEmpty ()) {
+					if (instanceValue.IsEmpty () || argumentValues[0].IsEmpty ()) {
 						returnValue = MultiValueLattice.Top;
 						break;
 					}
 
 					var targetValue = GetMethodThisParameterValue (calledMethod, DynamicallyAccessedMemberTypesOverlay.Interfaces);
 					foreach (var value in instanceValue) {
-						// For now no support for marking a single interface by name. We would have to correctly support
-						// mangled names for generics to do that correctly. Simply mark all interfaces on the type for now.
+						foreach (var interfaceName in argumentValues[0]) {
+							if (interfaceName == NullValue.Instance) {
+								// Throws on null string, so no return value.
+								returnValue ??= MultiValueLattice.Top;
+							} else if (interfaceName is KnownStringValue stringValue && stringValue.Contents.Length == 0) {
+								AddReturnValue (NullValue.Instance);
+							} else {
+								// For now no support for marking a single interface by name. We would have to correctly support
+								// mangled names for generics to do that correctly. Simply mark all interfaces on the type for now.
 
-						// Require Interfaces annotation
-						_requireDynamicallyAccessedMembersAction.Invoke (value, targetValue);
+								// Require Interfaces annotation
+								_requireDynamicallyAccessedMembersAction.Invoke (value, targetValue);
 
-						// Interfaces is transitive, so the return values will always have at least Interfaces annotation
-						DynamicallyAccessedMemberTypes returnMemberTypes = DynamicallyAccessedMemberTypesOverlay.Interfaces;
+								// Interfaces is transitive, so the return values will always have at least Interfaces annotation
+								DynamicallyAccessedMemberTypes returnMemberTypes = DynamicallyAccessedMemberTypesOverlay.Interfaces;
 
-						// Propagate All annotation across the call - All is a superset of Interfaces
-						if (value is ValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers
-							&& valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.All)
-							returnMemberTypes = DynamicallyAccessedMemberTypes.All;
+								// Propagate All annotation across the call - All is a superset of Interfaces
+								if (value is ValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers
+									&& valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.All)
+									returnMemberTypes = DynamicallyAccessedMemberTypes.All;
 
-						AddReturnValue (GetMethodReturnValue (calledMethod, returnMemberTypes));
+								AddReturnValue (GetMethodReturnValue (calledMethod, returnMemberTypes));
+							}
+						}
 					}
 				}
 				break;
@@ -188,6 +197,8 @@ namespace ILLink.Shared.TrimAnalysis
 					} else if (uniqueValue is SystemTypeValue) {
 						// SystemTypeValue can fullfill any requirement, so it's always valid
 						// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
+					} else if (uniqueValue == NullValue.Instance) {
+						// NullValue can fulfill any requirements because reflection access to it will typically throw.
 					} else {
 						throw new InvalidOperationException ($"Internal linker error: in {GetContainingSymbolDisplayName ()} processing call to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
 					}

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -491,8 +491,9 @@ namespace ILLink.Shared.TrimAnalysis
 				return true;
 			}
 
-			Debug.Assert (returnValue != null || calledMethod.ReturnsVoid (), "Intrinsics must set a return value.");
-			returnValue ??= MultiValueLattice.Top;
+			// For now, if the intrinsic doesn't set a return value, fall back on the annotations.
+			// Note that this will be DynamicallyAccessedMembers.None for the intrinsics which don't return types.
+			returnValue ??= calledMethod.ReturnsVoid () ? MultiValueLattice.Top : GetMethodReturnValue (calledMethod, returnValueDynamicallyAccessedMemberTypes);
 
 			// Validate that the return value has the correct annotations as per the method return value annotations
 			if (returnValueDynamicallyAccessedMemberTypes != 0) {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1310,7 +1310,7 @@ namespace Mono.Linker.Dataflow
 
 				bool allIndicesKnown = true;
 				for (int i = 0; i < size.Value; i++) {
-					if (!array.TryGetValueByIndex (i, out MultiValue value) || value.IsEmpty () || value.AsSingleValue () is UnknownValue) {
+					if (!array.TryGetValueByIndex (i, out MultiValue value) || value.AsSingleValue () is UnknownValue) {
 						allIndicesKnown = false;
 						break;
 					}
@@ -1353,7 +1353,15 @@ namespace Mono.Linker.Dataflow
 
 			foreach (var assemblyNameValue in methodParams[methodParamsOffset]) {
 				if (assemblyNameValue is KnownStringValue assemblyNameStringValue) {
+					if (assemblyNameStringValue.Contents is string assemblyName && assemblyName.Length == 0) {
+						// Throws exception for zero-length assembly name.
+						continue;
+					}
 					foreach (var typeNameValue in methodParams[methodParamsOffset + 1]) {
+						if (typeNameValue is NullValue) {
+							// Throws exception for null type name.
+							continue;
+						}
 						if (typeNameValue is KnownStringValue typeNameStringValue) {
 							var resolvedAssembly = _context.TryResolve (assemblyNameStringValue.Contents);
 							if (resolvedAssembly == null) {

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
@@ -100,16 +100,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
 			// t.TypeHandle throws at runtime so don't warn here.
 			RequirePublicConstructors (noValue.AssemblyQualifiedName);
-		 }
+		}
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		class AnnotatedType
 		{
 		}
 
 		static void TestObjectGetTypeValue (AnnotatedType instance = null)
 		{
-			string type = instance.GetType().AssemblyQualifiedName;
+			string type = instance.GetType ().AssemblyQualifiedName;
 			// Currently Object.GetType is unimplemented in the analyzer, but
 			// this still shouldn't warn.
 			RequirePublicConstructors (type);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
@@ -21,6 +21,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestNull ();
 			TestMultipleValues ();
 			TestUnknownValue ();
+			TestNoValue ();
+			TestObjectGetTypeValue ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (RequirePublicConstructors))]
@@ -90,6 +92,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			string unknown = ((Type) o[0]).AssemblyQualifiedName;
 			RequirePublicConstructors (unknown);
 			RequireNothing (unknown); // shouldn't warn
+		}
+
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			// t.TypeHandle throws at runtime so don't warn here.
+			RequirePublicConstructors (noValue.AssemblyQualifiedName);
+		 }
+
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		class AnnotatedType
+		{
+		}
+
+		static void TestObjectGetTypeValue (AnnotatedType instance = null)
+		{
+			string type = instance.GetType().AssemblyQualifiedName;
+			// Currently Object.GetType is unimplemented in the analyzer, but
+			// this still shouldn't warn.
+			RequirePublicConstructors (type);
+			RequireNothing (type);
 		}
 
 		private static void RequirePublicParameterlessConstructor (

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
@@ -24,6 +24,23 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class GetInterface_Name
 		{
+			static void TestNullName (Type type)
+			{
+				type.GetInterface (null);
+			}
+
+			static void TestEmptyName (Type type)
+			{
+				type.GetInterface (string.Empty);
+			}
+
+			static void TestNoValueName (Type type)
+			{
+				Type t = null;
+				string noValue = t.AssemblyQualifiedName;
+				type.GetInterface (noValue);
+			}
+
 			[ExpectedWarning ("IL2070", nameof (Type.GetInterface), nameof (DynamicallyAccessedMemberTypes) + "." + nameof (DynamicallyAccessedMemberTypes.Interfaces))]
 			static void TestNoAnnotation (Type type)
 			{
@@ -76,12 +93,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				type.GetInterface ("ITestInterface").RequiresInterfaces ();
 			}
 
+			static void TestNullValue ()
+			{
+				Type t = null;
+				t.GetInterface ("ITestInterface").RequiresInterfaces ();
+			}
+
 			static void TestNoValue ()
 			{
 				Type t = null;
 				Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
 				// t.TypeHandle throws at runtime so don't warn here.
-				noValue.GetInterface ("ITestInterface").RequiresAll ();
+				noValue.GetInterface ("ITestInterface").RequiresInterfaces ();
 			}
 
 			class GetInterfaceInCtor
@@ -94,6 +117,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			public static void Test ()
 			{
+				TestNullName (typeof (TestType));
+				TestEmptyName (typeof (TestType));
+				TestNoValueName (typeof (TestType));
 				TestNoAnnotation (typeof (TestType));
 				TestWithAnnotation (typeof (TestType));
 				TestWithAnnotation (typeof (ITestInterface));
@@ -101,6 +127,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestKnownType ();
 				TestMultipleValues (0, typeof (TestType));
 				TestMergedValues (0, typeof (TestType));
+				TestNullValue ();
 				TestNoValue ();
 				var _ = new GetInterfaceInCtor (typeof (TestType));
 			}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
@@ -76,6 +76,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				type.GetInterface ("ITestInterface").RequiresInterfaces ();
 			}
 
+			static void TestNoValue ()
+			{
+				Type t = null;
+				Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+				// t.TypeHandle throws at runtime so don't warn here.
+				noValue.GetInterface ("ITestInterface").RequiresAll ();
+			}
+
 			class GetInterfaceInCtor
 			{
 				public GetInterfaceInCtor ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] Type type)
@@ -93,6 +101,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestKnownType ();
 				TestMultipleValues (0, typeof (TestType));
 				TestMergedValues (0, typeof (TestType));
+				TestNoValue ();
 				var _ = new GetInterfaceInCtor (typeof (TestType));
 			}
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
@@ -21,6 +21,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestPublicParameterlessConstructor ();
 			TestPublicConstructors ();
 			TestConstructors ();
+			TestNull ();
+			TestNoValue ();
 			TestUnknownType ();
 
 			TestTypeNameFromParameter (null);
@@ -67,6 +69,22 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			type.RequiresPublicConstructors ();
 			type.RequiresNonPublicConstructors ();
 			type.RequiresNone ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresAll) + "(Type)", nameof (Type.GetType) + "(String)")]
+		static void TestNull ()
+		{
+			// Warns about the return value of GetType, even though this throws at runtime.
+			Type.GetType (null).RequiresAll ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresAll) + "(Type)", nameof (Type.GetType) + "(String)")]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			// Warns about the return value of GetType, even though AssemblyQualifiedName throws at runtime.
+			Type.GetType (noValue).RequiresAll ();
 		}
 
 		[ExpectedWarning ("IL2057", nameof (GetType))]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeInfoDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeInfoDataFlow.cs
@@ -17,6 +17,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			TestNoAnnotations (typeof (TestType));
 			TestWithAnnotations (typeof (TestType));
+			TestWithNull ();
+			TestWithNoValue ();
 		}
 
 		[ExpectedWarning ("IL2067", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
@@ -32,6 +34,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			t.GetTypeInfo ().RequiresPublicMethods ();
 			t.GetTypeInfo ().RequiresPublicFields ();
 			t.GetTypeInfo ().RequiresNone ();
+		}
+
+		static void TestWithNull ()
+		{
+			Type t = null;
+			t.GetTypeInfo ().RequiresPublicMethods ();
+		}
+
+		static void TestWithNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			noValue.GetTypeInfo ().RequiresPublicMethods ();
 		}
 
 		class TestType { }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
@@ -22,7 +22,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public static void Test ()
 			{
 				TestNullType ();
+				TestNoValueInput ();
 				TestUnknownInput (null);
+				TestNullTypeArgument ();
+				TestNoValueTypeArgument ();
 				TestWithUnknownTypeArray (null);
 				TestWithArrayUnknownIndexSet (0);
 				TestWithArrayUnknownLengthSet (1);
@@ -51,6 +54,26 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				Type nullType = null;
 				nullType.MakeGenericType (typeof (TestType));
+			}
+
+			static void TestNoValueInput ()
+			{
+				Type t = null;
+				Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+				noValue.MakeGenericType (typeof (TestType));
+			}
+
+			static void TestNullTypeArgument ()
+			{
+				Type t = null;
+				typeof (GenericWithPublicFieldsArgument<>).MakeGenericType (t);
+			}
+
+			static void TestNoValueTypeArgument ()
+			{
+				Type t = null;
+				Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+				typeof (GenericWithPublicFieldsArgument<>).MakeGenericType (noValue);
 			}
 
 			[ExpectedWarning ("IL2055", nameof (Type.MakeGenericType))]
@@ -196,6 +219,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestNullMethod ();
 				TestUnknownMethod (null);
 				TestUnknownMethodButNoTypeArguments (null);
+				TestNullTypeArgument ();
+				TestNoValueTypeArgument ();
 				TestWithUnknownTypeArray (null);
 				TestWithArrayUnknownIndexSet (0);
 				TestWithArrayUnknownIndexSetByRef (0);
@@ -246,6 +271,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				// Thechnically linker could figure this out, but it's not worth the complexity - such call will always fail at runtime.
 				mi.MakeGenericMethod (Type.EmptyTypes);
+			}
+
+			static void TestNullTypeArgument ()
+			{
+				Type t = null;
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static)
+					.MakeGenericMethod (t);
+			}
+
+			static void TestNoValueTypeArgument ()
+			{
+				Type t = null;
+				Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static)
+					.MakeGenericMethod (noValue);
 			}
 
 			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
@@ -217,6 +217,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public static void Test ()
 			{
 				TestNullMethod ();
+				TestNoValueMethod ();
 				TestUnknownMethod (null);
 				TestUnknownMethodButNoTypeArguments (null);
 				TestNullTypeArgument ();
@@ -258,6 +259,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				MethodInfo mi = null;
 				mi.MakeGenericMethod (typeof (TestType));
+			}
+
+			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod) + "(Type[])")]
+			static void TestNoValueMethod ()
+			{
+				// GetMethod(null) throws at runtime.
+				MethodInfo noValue = typeof (MakeGenericMethod).GetMethod (null);
+				noValue.MakeGenericMethod (typeof (TestType));
 			}
 
 			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
@@ -44,6 +44,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestNoAnnotation (typeof (TestType));
 			TestAnnotatedAndUnannotated (typeof (TestType), typeof (TestType), 0);
 			TestNull ();
+			TestNoValue ();
 
 			Mixed_Derived.Test (typeof (TestType), 0);
 		}
@@ -209,6 +210,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			Type type = null;
 			type.BaseType.RequiresPublicMethods ();
+		}
+
+		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			// Warns about the base type even though the above throws an exception at runtime.
+			noValue.BaseType.RequiresPublicMethods ();
 		}
 
 		class Mixed_Base

--- a/test/Mono.Linker.Tests.Cases/DataFlow/TypeHandleDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/TypeHandleDataFlow.cs
@@ -21,6 +21,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestGetTypeHandleFromGeneric<TestType> ();
 			TestUnsupportedPatterns (typeof (TestType));
 			TestNull ();
+			TestNoValue ();
 		}
 
 		[ExpectedWarning ("IL2026", "--" + nameof (TestTypeWithRUCOnMembers.PublicMethodWithRUC) + "--")]
@@ -70,6 +71,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// This should not warn - we know the type is null. Null is ignored since we know it will fail at runtime
 			// and thus there are no actual requirements on the rest of the app to make it fail that way.
 			Type.GetTypeFromHandle (type.TypeHandle).RequiresPublicMethods ();
+		}
+
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			// t.TypeHandle throws at runtime so don't warn here.
+			Type.GetTypeFromHandle (noValue.TypeHandle).RequiresPublicMethods ();
 		}
 
 		class TestType { }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/TypeInfoAsTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/TypeInfoAsTypeDataFlow.cs
@@ -17,6 +17,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			TestNoAnnotations (typeof (TestType).GetTypeInfo ());
 			TestWithAnnotations (typeof (TestType).GetTypeInfo ());
+			TestWithNull ();
+			TestWithNoValue ();
 		}
 
 		[ExpectedWarning ("IL2067", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
@@ -32,6 +34,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			t.AsType ().RequiresPublicMethods ();
 			t.AsType ().RequiresPublicFields ();
 			t.AsType ().RequiresNone ();
+		}
+
+		static void TestWithNull ()
+		{
+			TypeInfo t = null;
+			t.AsType ().RequiresPublicMethods ();
+		}
+
+		static void TestWithNoValue ()
+		{
+			Type t = null;
+			Type noValueType = Type.GetTypeFromHandle (t.TypeHandle);
+			TypeInfo noValue = noValueType.GetTypeInfo ();
+			noValue.AsType ().RequiresPublicMethods ();
 		}
 
 		class TestType { }

--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -58,6 +58,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNullArgsNonPublicOnly (typeof (TestType));
 			TestNullArgsNonPublicWithNonPublicAnnotation (typeof (TestType));
 
+			TestNullType ();
+			TestNoValue ();
+
 			CreateInstanceWithGetTypeFromHierarchy.Test ();
 		}
 
@@ -314,6 +317,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyNamePrivateOnly", false, BindingFlags.NonPublic, null, new object[] { }, null, new object[] { });
 
 			WithNullAssemblyName ();
+			WithEmptyAssemblyName ();
+			WithNoValueAssemblyName ();
+			WithAssemblyAndNullTypeName ();
+			WithAssemblyAndEmptyTypeName ();
+			WithAssemblyAndNoValueTypeName ();
 			WithNonExistingAssemblyName ();
 			WithAssemblyAndUnknownTypeName ();
 			WithAssemblyAndNonExistingTypeName ();
@@ -324,6 +332,40 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		private static void WithNullAssemblyName ()
 		{
 			Activator.CreateInstance (null, "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyNameParameterless1");
+		}
+
+		[Kept]
+		private static void WithEmptyAssemblyName ()
+		{
+			Activator.CreateInstance (string.Empty, "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyNameParameterless1");
+		}
+
+		[Kept]
+		private static void WithNoValueAssemblyName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			Activator.CreateInstance (noValue, "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyNameParameterless1");
+		}
+
+		[Kept]
+		private static void WithAssemblyAndNullTypeName ()
+		{
+			Activator.CreateInstance ("test", null);
+		}
+
+		[Kept]
+		private static void WithAssemblyAndEmptyTypeName ()
+		{
+			Activator.CreateInstance ("test", string.Empty);
+		}
+
+		[Kept]
+		private static void WithAssemblyAndNoValueTypeName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			Activator.CreateInstance ("test", noValue);
 		}
 
 		[Kept]
@@ -366,6 +408,56 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		private static void WithAssemblyPath ()
 		{
 			Activator.CreateInstanceFrom ("test", "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyPathParameterless");
+
+			WithNullAssemblyPath ();
+			WithEmptyAssemblyPath ();
+			WithNoValueAssemblyPath ();
+			WithAssemblyPathAndNullTypeName ();
+			WithAssemblyPathAndEmptyTypeName ();
+			WithAssemblyPathAndNoValueTypeName ();
+		}
+
+		[Kept]
+		// Technically this shouldn't warn because CreateInstanceFrom throws if the assembly file path is null.
+		// However, our implementation is the same for CreateInstance and CreateInstanceFrom.
+		[ExpectedWarning ("IL2032", nameof (Activator) + "." + nameof (Activator.CreateInstance), "assemblyFile")]
+		private static void WithNullAssemblyPath ()
+		{
+			Activator.CreateInstanceFrom (null, "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyPathParameterless");
+		}
+
+		[Kept]
+		private static void WithEmptyAssemblyPath ()
+		{
+			Activator.CreateInstanceFrom (string.Empty, "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyPathParameterless");
+		}
+
+		[Kept]
+		private static void WithNoValueAssemblyPath ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			Activator.CreateInstanceFrom (noValue, "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyPathParameterless");
+		}
+
+		[Kept]
+		private static void WithAssemblyPathAndNullTypeName ()
+		{
+			Activator.CreateInstanceFrom ("test", null);
+		}
+
+		[Kept]
+		private static void WithAssemblyPathAndEmptyTypeName ()
+		{
+			Activator.CreateInstanceFrom ("test", string.Empty);
+		}
+
+		[Kept]
+		private static void WithAssemblyPathAndNoValueTypeName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			Activator.CreateInstanceFrom ("test", noValue);
 		}
 
 		[Kept]
@@ -530,6 +622,21 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))] Type type)
 		{
 			Activator.CreateInstance (type, nonPublic: true);
+		}
+
+		[Kept]
+		private static void TestNullType ()
+		{
+			Type t = null;
+			Activator.CreateInstance (t);
+		}
+
+		[Kept]
+		private static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			Activator.CreateInstance (noValue);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
@@ -20,6 +20,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			GetConstructor_BindingAttr_Types.Test ();
 #endif
 			TestNullType ();
+			TestNoValue ();
+			TestNullArguments ();
 			TestDataFlowType ();
 			IfElse.TestIfElse (true);
 		}
@@ -262,6 +264,20 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var constructor = type.GetConstructor (new Type[] { });
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var constructor = noValue.GetConstructor (new Type[] { });
+		}
+
+		[Kept]
+		static void TestNullArguments ()
+		{
+			var constrctor = typeof (TestType).GetConstructor (null);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ConstructorsUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ConstructorsUsedViaReflection.cs
@@ -16,6 +16,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestWithBindingFlags ();
 			TestWithUnknownBindingFlags (BindingFlags.Public);
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (true);
@@ -45,6 +46,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var constructors = type.GetConstructors ();
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var constructors = noValue.GetConstructors ();
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -21,8 +21,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNameUnknownBindingFlagsAndName (BindingFlags.Public, "DoesntMatter");
 			TestNullName ();
 			TestEmptyName ();
+			TestNoValueName ();
 			TestNonExistingName ();
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestIfElse (1);
 			TestEventInBaseType ();
@@ -90,6 +92,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		static void TestNoValueName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			var method = typeof (EventUsedViaReflection).GetEvent (noValue);
+		}
+
+		[Kept]
 		static void TestNonExistingName ()
 		{
 			var eventInfo = typeof (EventUsedViaReflection).GetEvent ("NonExisting");
@@ -100,6 +110,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var eventInfo = type.GetEvent ("Event");
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var method = noValue.GetEvent ("Event");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventsUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventsUsedViaReflection.cs
@@ -20,6 +20,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestBindingFlags ();
 			TestUnknownBindingFlags (BindingFlags.Public);
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (1);
@@ -62,6 +63,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var events = type.GetEvents ();
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var methods = noValue.GetEvents ();
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -26,6 +26,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Expression.Call (typeof (UnknownNameMethodClass), GetUnknownString (), Type.EmptyTypes);
 
 			TestUnknownType.Test ();
+			TestNullType ();
+			TestNoValue ();
+			TestNullString ();
+			TestEmptyString ();
+			TestNoValueString ();
 
 			TestGenericMethods.Test ();
 		}
@@ -140,6 +145,41 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{
 				return typeof (TestType);
 			}
+		}
+
+		[Kept]
+		static void TestNullType ()
+		{
+			Type t = null;
+			Expression.Call (t, "This string will not be reached", Type.EmptyTypes);
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			Expression.Call (noValue, "This string will not be reached", Type.EmptyTypes);
+		}
+
+		[Kept]
+		static void TestNullString ()
+		{
+			Expression.Call (typeof (TestType), null, Type.EmptyTypes);
+		}
+
+		[Kept]
+		static void TestEmptyString ()
+		{
+			Expression.Call (typeof (TestType), string.Empty, Type.EmptyTypes);
+		}
+
+		[Kept]
+		static void TestNoValueString ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			Expression.Call (typeof (TestType), noValue, Type.EmptyTypes);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
@@ -21,6 +21,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			UnknownTypeNoAnnotation.Test ();
 			UnknownString.Test ();
 			Expression.Field (null, GetType (), "This string will not be reached"); // IL2072
+			TestNullType ();
+			TestNoValue ();
+			TestNullString ();
+			TestEmptyString ();
+			TestNoValueString ();
 		}
 
 		[Kept]
@@ -102,6 +107,41 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				return "UnknownString";
 			}
 		}
+
+		[Kept]
+		static void TestNullType ()
+		{
+			Expression.Field (null, null, "This string will not be reached");
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			Expression.Field (null, noValue, "This string will not be reached");
+		}
+
+		[Kept]
+		static void TestNullString ()
+		{
+			Expression.Field (null, typeof (Base), null);
+		}
+
+		[Kept]
+		static void TestEmptyString ()
+		{
+			Expression.Field (null, typeof (Base), string.Empty);
+		}
+
+		[Kept]
+		static void TestNoValueString ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			Expression.Field (null, typeof (Base), noValue);
+		}
+
 
 		[Kept]
 		class Base

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionNewType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionNewType.cs
@@ -18,6 +18,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Branch_NullValueNode ();
 			Branch_MethodParameterValueNode (typeof (C));
 			Branch_UnrecognizedPatterns ();
+			TestNullType ();
+			TestNoValue ();
 		}
 
 		[Kept]
@@ -58,6 +60,21 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Expression.New (Type.GetType ("RemovedType"));
 			Expression.New (GetType ());
+		}
+
+		[Kept]
+		static void TestNullType ()
+		{
+			Type t = null;
+			Expression.New (t);
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			Expression.New (noValue);
 		}
 
 		#region Helpers

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
@@ -20,6 +20,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Expression.Property (null, typeof (Derived), "ProtectedPropertyOnBase");
 			Expression.Property (null, typeof (Derived), "PublicPropertyOnBase");
 			UnknownType.Test ();
+			TestNull ();
+			TestNoValue ();
+			TestNullString ();
+			TestEmptyString ();
+			TestNoValueString ();
 			UnknownString.Test ();
 			Expression.Property (null, GetType (), "This string will not be reached"); // IL2072
 		}
@@ -85,6 +90,21 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		static void TestNull ()
+		{
+			Type t = null;
+			Expression.Property (null, t, "This string will not be reached");
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			Expression.Property (null, noValue, "This string will not be reached");
+		}
+
+		[Kept]
 		class UnknownString
 		{
 			[Kept]
@@ -112,6 +132,26 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{
 				return "UnknownString";
 			}
+		}
+
+		[Kept]
+		static void TestNullString ()
+		{
+			Expression.Property (null, typeof (Base), null);
+		}
+
+		[Kept]
+		static void TestEmptyString ()
+		{
+			Expression.Property (null, typeof (Base), string.Empty);
+		}
+
+		[Kept]
+		static void TestNoValueString ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			Expression.Property (null, typeof (Base), noValue);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
@@ -18,9 +18,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNameUnknownBindingFlags (BindingFlags.Public);
 			TestNameUnknownBindingFlagsAndName (BindingFlags.Public, "DoesntMatter");
 			TestNullName ();
+			TestNoValueName ();
 			TestEmptyName ();
 			TestNonExistingName ();
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestIfElse (1);
 			TestFieldInBaseType ();
@@ -76,6 +78,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		static void TestNoValueName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			var method = typeof (FieldUsedViaReflection).GetField (noValue);
+		}
+
+		[Kept]
 		static void TestEmptyName ()
 		{
 			var field = typeof (FieldUsedViaReflection).GetField (string.Empty);
@@ -92,6 +102,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var field = type.GetField ("publicField");
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var method = noValue.GetField ("publicField");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/FieldsUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/FieldsUsedViaReflection.cs
@@ -16,6 +16,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestBindingFlags ();
 			TestUnknownBindingFlags (BindingFlags.Public);
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (1);
@@ -47,6 +48,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var fields = type.GetFields ();
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var methods = noValue.GetFields ();
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/MemberUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MemberUsedViaReflection.cs
@@ -15,11 +15,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			// Normally calls to GetMember use prefix lookup to match multiple values, we took a conservative approach
 			// and preserve not based on the string passed but on the binding flags requirements
 			TestWithName ();
+			TestWithNullName ();
+			TestWithEmptyName ();
+			TestWithNoValueName ();
 			TestWithPrefixLookup ();
 			TestWithBindingFlags ();
 			TestWithUnknownBindingFlags (BindingFlags.Public);
 			TestWithMemberTypes ();
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (true);
@@ -31,6 +35,25 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			var members = typeof (SimpleType).GetMember ("memberKept");
 		}
 
+		[Kept]
+		public static void TestWithNullName ()
+		{
+			var members = typeof (SimpleType).GetMember (null);
+		}
+
+		[Kept]
+		static void TestWithEmptyName ()
+		{
+			var members = typeof (SimpleType).GetMember (string.Empty);
+		}
+
+		[Kept]
+		static void TestWithNoValueName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			var members = typeof (SimpleType).GetMember (noValue);
+		}
 
 		[Kept]
 		static void TestWithPrefixLookup ()
@@ -64,6 +87,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var constructor = type.GetMember ("PrefixLookup*");
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var members = noValue.GetMember ("PrefixLookup*");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/MembersUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MembersUsedViaReflection.cs
@@ -16,6 +16,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestWithBindingFlags ();
 			TestWithUnknownBindingFlags (BindingFlags.Public);
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (true);
@@ -45,6 +46,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var members = type.GetMembers ();
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var members = noValue.GetMembers ();
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -36,8 +36,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 #endif
 			TestNullName ();
 			TestEmptyName ();
+			TestNoValueName ();
 			TestNonExistingName ();
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			IfElse.TestIfElse (1);
 			DerivedAndBase.TestMethodInBaseType ();
@@ -594,6 +596,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		static void TestNoValueName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			var method = typeof (MethodUsedViaReflection).GetMethod (noValue);
+		}
+
+		[Kept]
 		static void TestNonExistingName ()
 		{
 			var method = typeof (MethodUsedViaReflection).GetMethod ("NonExisting");
@@ -604,6 +614,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var method = type.GetMethod ("OnlyCalledViaReflection", BindingFlags.Static | BindingFlags.Public);
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var method = noValue.GetMethod ("OnlyCalledViaReflection", BindingFlags.Static | BindingFlags.Public);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodsUsedViaReflection.cs
@@ -18,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestBindingFlags ();
 			TestUnknownBindingFlags (BindingFlags.Public);
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (1);
@@ -50,6 +51,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var methods = type.GetMethods (BindingFlags.Static | BindingFlags.Public);
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var methods = noValue.GetMethods (BindingFlags.Static | BindingFlags.Public);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
@@ -15,11 +15,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			TestByName ();
 			TestPrivateByName ();
+			TestNullName ();
+			TestEmptyName ();
+			TestNoValueName ();
 			TestByBindingFlags ();
 			TestByUnknownBindingFlags (BindingFlags.Public);
 			TestByUnknownBindingFlagsAndName (BindingFlags.Public, "DoesntMatter");
 			TestNonExistingName ();
 			TestNullType ();
+			TestNoValue ();
 			TestIgnoreCaseBindingFlags ();
 			TestFailIgnoreCaseBindingFlags ();
 			TestUnsupportedBindingFlags ();
@@ -41,6 +45,26 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (PrivateUnreferencedNestedType)); // This will not mark the nested type as GetNestedType(string) only returns public
 			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (PrivateUnreferencedNestedType), BindingFlags.Public);
+		}
+
+		[Kept]
+		static void TestNullName ()
+		{
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (null);
+		}
+
+		[Kept]
+		static void TestEmptyName ()
+		{
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (string.Empty);
+		}
+
+		[Kept]
+		static void TestNoValueName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			var method = typeof (NestedTypeUsedViaReflection).GetNestedType (noValue);
 		}
 
 		[Kept]
@@ -85,6 +109,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			_ = type.GetNestedType ("NestedType");
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var method = noValue.GetNestedType ("NestedType");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/NestedTypesUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/NestedTypesUsedViaReflection.cs
@@ -18,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestByBindingFlags ();
 			TestByUnknownBindingFlags (BindingFlags.Public);
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIgnoreCaseBindingFlags ();
@@ -60,6 +61,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			_ = type.GetNestedTypes (BindingFlags.Public);
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			_ = noValue.GetNestedTypes (BindingFlags.Public);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -53,6 +53,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			EnumerationOverInstances.Test ();
 
 			DataFlowUnusedGetType.Test ();
+
+			NullValue.Test ();
+			NoValue.Test ();
 		}
 
 		[Kept]
@@ -1456,6 +1459,45 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				if (GetBaseInstance ().GetType () is DerivedFromAnnotatedBase) {
 					Console.WriteLine ("Never get here");
 				}
+			}
+		}
+
+		[Kept]
+		class NullValue
+		{
+			[Kept]
+			class TestType
+			{
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresAll) + "(Type)", nameof (Object.GetType) + "()")]
+			public static void Test ()
+			{
+				TestType nullInstance = null;
+				// Even though this throws at runtime, we warn about the return value of GetType
+				nullInstance.GetType ().RequiresAll ();
+			}
+		}
+
+		[Kept]
+		class NoValue
+		{
+			[Kept]
+			class TestType
+			{
+			}
+
+			[Kept]
+			static TestType GetInstance () => null;
+
+			[Kept]
+			[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions.RequiresAll) + "(Type)", nameof (Object.GetType) + "()")]
+			public static void Test ()
+			{
+				TestType noValue = GetInstance ();
+				// Even though this throws at runtime, we warn about the return value of GetType
+				noValue.GetType ().RequiresAll ();
 			}
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertiesUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertiesUsedViaReflection.cs
@@ -19,6 +19,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestUnknownBindingFlags (BindingFlags.Public);
 			TestPropertiesOfArray ();
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestDataFlowWithAnnotation (typeof (MyType));
 			TestIfElse (1);
@@ -57,6 +58,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var properties = type.GetProperties (BindingFlags.Public);
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var methods = noValue.GetProperties (BindingFlags.Public);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -21,9 +21,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestUnknownBindingFlagsAndName (BindingFlags.Public, "IrrelevantName");
 			TestNullName ();
 			TestEmptyName ();
+			TestNoValueName ();
 			TestNonExistingName ();
 			TestPropertyOfArray ();
 			TestNullType ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestIfElse (1);
 			TestPropertyInBaseType ();
@@ -98,6 +100,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		static void TestNoValueName ()
+		{
+			Type t = null;
+			string noValue = t.AssemblyQualifiedName;
+			var method = typeof (PropertyUsedViaReflection).GetProperty (noValue);
+		}
+
+		[Kept]
 		static void TestNonExistingName ()
 		{
 			var property = typeof (PropertyUsedViaReflection).GetProperty ("NonExisting");
@@ -115,6 +125,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			var property = type.GetProperty ("GetterOnly");
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var method = noValue.GetProperty ("GetterOnly");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
@@ -15,6 +15,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestRunClassConstructor ();
 			TestNonKeptStaticConstructor ();
 			TestNull ();
+			TestNoValue ();
 			TestDataFlowType ();
 			TestIfElseUsingRuntimeTypeHandle (1);
 			TestIfElseUsingType (1);
@@ -37,6 +38,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			Type type = null;
 			RuntimeHelpers.RunClassConstructor (type.TypeHandle);
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			RuntimeHelpers.RunClassConstructor (noValue.TypeHandle);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
@@ -15,7 +15,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestGetRuntimeField ();
 			TestGetRuntimeMethod ();
 			TestGetRuntimeProperty ();
-
 		}
 
 		#region GetRuntimeEvent
@@ -29,6 +28,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			GetClassWithEvent ().GetRuntimeEvent ("This string will not be reached");
 			typeof (Derived).GetRuntimeEvent ("Event");
 			GetUnknownType ().GetRuntimeEvent (GetUnknownString ()); // IL2072
+
+			Type t = null;
+			t.GetRuntimeEvent ("This string will not be reached");
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			noValue.GetRuntimeEvent ("This string  will not be reached");
+
+			typeof (ClassWithKeptMembers).GetRuntimeEvent (null);
+			typeof (ClassWithKeptMembers).GetRuntimeEvent (string.Empty);
+			string noValueString = t.AssemblyQualifiedName;
+			typeof (ClassWithKeptMembers).GetRuntimeEvent (noValueString);
 		}
 		#endregion
 
@@ -43,6 +52,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			GetClassWithField ().GetRuntimeField ("This string will not be reached");
 			typeof (Derived).GetRuntimeField ("Field");
 			GetUnknownType ().GetRuntimeField (GetUnknownString ()); // IL2072
+
+			Type t = null;
+			t.GetRuntimeField ("This string will not be reached");
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			noValue.GetRuntimeField ("This string  will not be reached");
+
+			typeof (ClassWithKeptMembers).GetRuntimeField (null);
+			typeof (ClassWithKeptMembers).GetRuntimeField (string.Empty);
+			string noValueString = t.AssemblyQualifiedName;
+			typeof (ClassWithKeptMembers).GetRuntimeField (noValueString);
 		}
 		#endregion
 
@@ -57,6 +76,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			GetClassWithMethod ().GetRuntimeMethod ("This string will not be reached", Type.EmptyTypes);
 			typeof (Derived).GetRuntimeMethod ("Method", Type.EmptyTypes);
 			GetUnknownType ().GetRuntimeMethod (GetUnknownString (), Type.EmptyTypes); // IL2072
+
+			Type t = null;
+			t.GetRuntimeMethod ("This string will not be reached", Type.EmptyTypes);
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			noValue.GetRuntimeMethod ("This string  will not be reached", Type.EmptyTypes);
+
+			typeof (ClassWithKeptMembers).GetRuntimeMethod (null, Type.EmptyTypes);
+			typeof (ClassWithKeptMembers).GetRuntimeMethod (string.Empty, Type.EmptyTypes);
+			string noValueString = t.AssemblyQualifiedName;
+			typeof (ClassWithKeptMembers).GetRuntimeMethod (noValueString, Type.EmptyTypes);
 		}
 		#endregion
 
@@ -71,6 +100,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			GetClassWithProperty ().GetRuntimeProperty ("This string will not be reached");
 			typeof (Derived).GetRuntimeProperty ("Property");
 			GetUnknownType ().GetRuntimeProperty (GetUnknownString ()); // IL2072
+
+			Type t = null;
+			t.GetRuntimeProperty ("This string will not be reached");
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			noValue.GetRuntimeProperty ("This string  will not be reached");
+
+			typeof (ClassWithKeptMembers).GetRuntimeProperty (null);
+			typeof (ClassWithKeptMembers).GetRuntimeProperty (string.Empty);
+			string noValueString = t.AssemblyQualifiedName;
+			typeof (ClassWithKeptMembers).GetRuntimeProperty (noValueString);
 		}
 		#endregion
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeDelegator.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeDelegator.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
@@ -12,7 +14,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	{
 		public static void Main ()
 		{
-			_ = new System.Reflection.TypeDelegator (typeof (TypeUsedWithDelegator)).GetMethod ("Method");
+			TestTypeUsedWithDelegator ();
+			TestNullValue ();
+			TestNoValue ();
 		}
 
 		[Kept]
@@ -23,5 +27,35 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 			public static void UnrelatedMethod () { }
 		}
+
+		[Kept]
+		static void TestTypeUsedWithDelegator ()
+		{
+			_ = new System.Reflection.TypeDelegator (typeof (TypeUsedWithDelegator)).GetMethod ("Method");
+		}
+
+		[Kept]
+		static void TestNullValue ()
+		{
+			var typeDelegator = new System.Reflection.TypeDelegator (null);
+			RequireAll (typeDelegator);
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			var typeDelegator = new System.Reflection.TypeDelegator (noValue);
+			RequireAll (typeDelegator);
+		}
+
+		[Kept]
+		public static void RequireAll (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+			System.Reflection.TypeDelegator t
+		)
+		{ }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/UnderlyingSystemType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/UnderlyingSystemType.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
@@ -15,7 +17,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	{
 		public static void Main ()
 		{
-			_ = typeof (TypeUsedWithUnderlyingSystemType).UnderlyingSystemType.GetMethod (nameof (TypeUsedWithUnderlyingSystemType.Method));
+			TestTypeUsedWithUnderlyingSystemType ();
+			TestNullValue ();
+			TestNoValue ();
 		}
 
 		[Kept]
@@ -25,6 +29,27 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static void Method () { }
 
 			public static void OtherMethod () { }
+		}
+
+		[Kept]
+		static void TestTypeUsedWithUnderlyingSystemType ()
+		{
+			_ = typeof (TypeUsedWithUnderlyingSystemType).UnderlyingSystemType.GetMethod (nameof (TypeUsedWithUnderlyingSystemType.Method));
+		}
+
+		[Kept]
+		static void TestNullValue ()
+		{
+			Type t = null;
+			t.UnderlyingSystemType.RequiresAll ();
+		}
+
+		[Kept]
+		static void TestNoValue ()
+		{
+			Type t = null;
+			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
+			t.UnderlyingSystemType.RequiresAll ();
 		}
 	}
 }


### PR DESCRIPTION
The latest analyzer is producing warnings in runtime for this pattern:
https://github.com/dotnet/runtime/blob/959a13fa0d1822dc4c7bfc99a9d5e7a0c50d6306/src/libraries/System.Data.Common/src/System/Data/Common/DbProviderFactories.cs#L129

This fixes that by ensuring that `AssemblyQualifiedName` and other similar intrinsics pass through a `TopValue` input instead of falling back on the annotations when there is no input. (The analyzer intentionally returns `TopValue` for unimplemented intrinsics, and the idea is that these should not produce any warnings.)