### PR TITLE
Understand String.Empty

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -70,7 +70,14 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public override MultiValue VisitFieldReference (IFieldReferenceOperation fieldRef, StateValue state)
 		{
-			return fieldRef.Field.Type.IsTypeInterestingForDataflow () ? new FieldValue (fieldRef.Field) : TopValue;
+			if (!fieldRef.Field.Type.IsTypeInterestingForDataflow ())
+				return TopValue;
+
+			var field = fieldRef.Field;
+			if (field.Name is "Empty" && field.ContainingType.HasName ("System.String"))
+				return new KnownStringValue (string.Empty);
+
+			return new FieldValue (fieldRef.Field);
 		}
 
 		public override MultiValue VisitTypeOf (ITypeOfOperation typeOfOperation, StateValue state)

--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -100,10 +100,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return RunTest (allowMissingWarnings: true);
 		}
 
-		[Fact (Skip = "https://github.com/dotnet/linker/issues/2273")]
+		[Fact]
 		public Task GetTypeDataFlow ()
 		{
-			return RunTest (nameof (GetTypeDataFlow));
+			// https://github.com/dotnet/linker/issues/2273
+			return RunTest (allowMissingWarnings: true);
 		}
 
 		[Fact]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -34,6 +34,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.WriteUnknownValue ();
 
 			_ = _annotationOnWrongType;
+
+			TestStringEmpty ();
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
@@ -146,6 +148,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			static void MakeArrayValuesUnknown (object[] array)
 			{
 			}
+		}
+
+		private static void TestStringEmpty ()
+		{
+			RequirePublicMethods (string.Empty);
+		}
+
+		private static void RequirePublicMethods (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			string s)
+		{
 		}
 
 		private static void RequirePublicParameterlessConstructor (


### PR DESCRIPTION
Also enable a skipped test with `allowMissingWarnings`.

Runtime is producing warnings with the latest analyzer on https://github.com/dotnet/runtime/blob/959a13fa0d1822dc4c7bfc99a9d5e7a0c50d6306/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemAttribute.cs#L90. This fixes that by detecting string.Empty like the linker does. The other field that the linker handles specially is System.Type.EmptyTypes - I'm not addressing that here because we don't track arrays yet.