### PR TITLE
Use attributes on lambdas in tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
     <MicrosoftDotNetApiCompatVersion>7.0.0-beta.22154.3</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21271.1</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
-    <MicrosoftCodeAnalysisVersion>3.10.0-2.final</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>4.0.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.*</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <!-- This controls the version of the cecil package, or the version of cecil in the project graph

--- a/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
@@ -116,6 +116,18 @@ namespace ILLink.RoslynAnalyzer.Tests
 			ValidateDiagnostics (node, node.AttributeLists);
 		}
 
+		public override void VisitSimpleLambdaExpression (SimpleLambdaExpressionSyntax node)
+		{
+			base.VisitSimpleLambdaExpression (node);
+			ValidateDiagnostics (node, node.AttributeLists);
+		}
+
+		public override void VisitParenthesizedLambdaExpression (ParenthesizedLambdaExpressionSyntax node)
+		{
+			base.VisitParenthesizedLambdaExpression (node);
+			ValidateDiagnostics (node, node.AttributeLists);
+		}
+
 		public override void VisitAccessorDeclaration (AccessorDeclarationSyntax node)
 		{
 			base.VisitAccessorDeclaration (node);

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -913,7 +913,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestCall ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
 				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				() => MethodWithRequires ();
@@ -922,7 +922,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestCallWithClosure (int p = 0)
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
 				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				() => {
@@ -934,7 +934,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestReflectionAccess ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", "--MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
 				() => {
 					typeof (RequiresInCompilerGeneratedCode)
 						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
@@ -945,7 +945,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestLdftn ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
 				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				() => {
@@ -968,7 +968,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
 				() => {
 					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				};
@@ -999,7 +999,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestCall ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026")]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				() => MethodWithRequires ();
@@ -1012,7 +1012,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				// This should not produce warning because the Requires
 				Action<Type> _ =
-					[ExpectedWarning ("IL2067", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2067", ProducedBy = ProducedBy.Trimmer)]
 				(t) => t.RequiresPublicMethods ();
 			}
 
@@ -1022,7 +1022,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestCallWithClosure (int p = 0)
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026")]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				() => {
@@ -1037,8 +1037,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestReflectionAccess ()
 			{
 				Action _ =
-					// Analyzer doesn't recognize reflection access - so doesn't warn in this case
-					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+				// Analyzer doesn't recognize reflection access - so doesn't warn in this case
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => {
 					typeof (RequiresInCompilerGeneratedCode)
 						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
@@ -1078,8 +1078,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ =
-					// Analyzer doesn't apply DAM - so won't see this warnings
-					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+				// Analyzer doesn't apply DAM - so won't see this warnings
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => {
 					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				};
@@ -1091,9 +1091,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static async void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
 				Action _ =
-					// TODO: Fix the discrepancy between linker and analyzer
-					// https://github.com/dotnet/linker/issues/2350
-					[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
+				// TODO: Fix the discrepancy between linker and analyzer
+				// https://github.com/dotnet/linker/issues/2350
+				[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
 				() => unknownType.RequiresNonPublicMethods ();
 			}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -564,23 +564,23 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class WarnInLocalFunction
 		{
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 			static void TestCall ()
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction () => MethodWithRequires ();
 			}
 
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 			static void TestCallWithClosure (int p = 0)
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction ()
 				{
 					p++;
@@ -588,23 +588,23 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static void TestReflectionAccess ()
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => typeof (RequiresInCompilerGeneratedCode)
 					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 			}
 
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 			static void TestLdftn ()
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction ()
 				{
 					var action = new Action (MethodWithRequires);
@@ -626,11 +626,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static void TestDynamicallyAccessedMethod ()
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 			}
 
@@ -910,43 +910,47 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class WarnInLambda
 		{
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 			static void TestCall ()
 			{
-				Action _ = () => MethodWithRequires ();
+				Action _ =
+					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+					[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+					[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+					() => MethodWithRequires ();
 			}
 
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 			static void TestCallWithClosure (int p = 0)
 			{
-				Action _ = () => {
-					p++;
-					MethodWithRequires ();
-				};
+				Action _ =
+					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+					[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+					[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+					() => {
+						p++;
+						MethodWithRequires ();
+					};
 			}
 
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static void TestReflectionAccess ()
 			{
-				Action _ = () => {
-					typeof (RequiresInCompilerGeneratedCode)
-						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
-						.Invoke (null, new object[] { });
-				};
+				Action _ =
+					[ExpectedWarning ("IL2026", "--MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+					() => {
+						typeof (RequiresInCompilerGeneratedCode)
+							.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
+							.Invoke (null, new object[] { });
+					};
 			}
 
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 			static void TestLdftn ()
 			{
-				Action _ = () => {
-					var action = new Action (MethodWithRequires);
-				};
+				Action _ =
+					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+					[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+					[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+					() => {
+						var action = new Action (MethodWithRequires);
+					};
 			}
 
 			[ExpectedWarning ("IL2026", "--MethodWithRequiresAndReturns--", CompilerGeneratedCode = true)]
@@ -961,12 +965,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				};
 			}
 
-			[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			static void TestDynamicallyAccessedMethod ()
 			{
-				Action _ = () => {
-					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
-				};
+				Action _ =
+					[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
+					() => {
+						typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
+					};
 			}
 
 			public static void Test ()
@@ -987,68 +992,72 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			// C# 10 allows attributes on lambdas
 			// - This would be useful as a workaround for the limitation as Requires could be applied to the lambda directly
-			// - Would be useful for testing - have to use the CompilerGeneratedCode = true trick instead
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static void TestCall ()
 			{
-				Action _ = () => MethodWithRequires ();
+				Action _ =
+					[ExpectedWarning ("IL2026")]
+					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
+					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
+					() => MethodWithRequires ();
 			}
 
-			[ExpectedWarning ("IL2067", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static void TestCallWithReflectionAnalysisWarning ()
 			{
 				// This should not produce warning because the Requires
-				Action<Type> _ = (t) => t.RequiresPublicMethods ();
+				Action<Type> _ =
+					[ExpectedWarning ("IL2067", ProducedBy = ProducedBy.Trimmer)]
+					(t) => t.RequiresPublicMethods ();
 			}
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static void TestCallWithClosure (int p = 0)
 			{
-				Action _ = () => {
-					p++;
-					MethodWithRequires ();
-				};
+				Action _ =
+					[ExpectedWarning ("IL2026")]
+					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
+					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
+					() => {
+						p++;
+						MethodWithRequires ();
+					};
 			}
 
-			// Analyzer doesn't recognize reflection access - so doesn't warn in this case
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static void TestReflectionAccess ()
 			{
-				Action _ = () => {
-					typeof (RequiresInCompilerGeneratedCode)
-						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
-						.Invoke (null, new object[] { });
-				};
+				Action _ =
+					// Analyzer doesn't recognize reflection access - so doesn't warn in this case
+					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+					() => {
+						typeof (RequiresInCompilerGeneratedCode)
+							.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
+							.Invoke (null, new object[] { });
+					};
 			}
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static void TestLdftn ()
 			{
-				Action _ = () => {
-					var action = new Action (MethodWithRequires);
-				};
+				Action _ =
+					[ExpectedWarning ("IL2026")]
+					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
+					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
+					() => {
+						var action = new Action (MethodWithRequires);
+					};
 			}
 
 			[ExpectedWarning ("IL2026", "--MethodWithRequiresAndReturns--", CompilerGeneratedCode = true)]
@@ -1063,27 +1072,29 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				};
 			}
 
-			// Analyzer doesn't apply DAM - so won't see this warnings
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static void TestDynamicallyAccessedMethod ()
 			{
-				Action _ = () => {
-					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
-				};
+				Action _ =
+					// Analyzer doesn't apply DAM - so won't see this warnings
+					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+					() => {
+						typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
+					};
 			}
 
-			// TODO: Fix the discrepancy between linker and analyzer
-			// https://github.com/dotnet/linker/issues/2350
-			[ExpectedWarning ("IL2077", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static async void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
-				Action _ = () => unknownType.RequiresNonPublicMethods ();
+				Action _ =
+					// TODO: Fix the discrepancy between linker and analyzer
+					// https://github.com/dotnet/linker/issues/2350
+					[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
+					() => unknownType.RequiresNonPublicMethods ();
 			}
 
 			// The warning is currently not detected by roslyn analyzer since it doesn't analyze DAM yet
@@ -1130,15 +1141,15 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class WarnInComplex
 		{
-			[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
-			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 			static async void TestIteratorLocalFunctionInAsync ()
 			{
 				await MethodAsync ();
 				LocalFunction ();
 				await MethodAsync ();
 
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--", CompilerGeneratedCode = true)]
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -914,43 +914,43 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
-					[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-					() => MethodWithRequires ();
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				() => MethodWithRequires ();
 			}
 
 			static void TestCallWithClosure (int p = 0)
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
-					[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-					() => {
-						p++;
-						MethodWithRequires ();
-					};
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				() => {
+					p++;
+					MethodWithRequires ();
+				};
 			}
 
 			static void TestReflectionAccess ()
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", "--MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
-					() => {
-						typeof (RequiresInCompilerGeneratedCode)
-							.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
-							.Invoke (null, new object[] { });
-					};
+				() => {
+					typeof (RequiresInCompilerGeneratedCode)
+						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
+						.Invoke (null, new object[] { });
+				};
 			}
 
 			static void TestLdftn ()
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
-					[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
-					() => {
-						var action = new Action (MethodWithRequires);
-					};
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				() => {
+					var action = new Action (MethodWithRequires);
+				};
 			}
 
 			[ExpectedWarning ("IL2026", "--MethodWithRequiresAndReturns--", CompilerGeneratedCode = true)]
@@ -969,9 +969,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", "--TypeWithMethodWithRequires.MethodWithRequires--", ProducedBy = ProducedBy.Trimmer)]
-					() => {
-						typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
-					};
+				() => {
+					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
+				};
 			}
 
 			public static void Test ()
@@ -1000,9 +1000,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026")]
-					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
-					() => MethodWithRequires ();
+				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
+				() => MethodWithRequires ();
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
@@ -1013,7 +1013,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				// This should not produce warning because the Requires
 				Action<Type> _ =
 					[ExpectedWarning ("IL2067", ProducedBy = ProducedBy.Trimmer)]
-					(t) => t.RequiresPublicMethods ();
+				(t) => t.RequiresPublicMethods ();
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
@@ -1023,12 +1023,12 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026")]
-					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
-					() => {
-						p++;
-						MethodWithRequires ();
-					};
+				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
+				() => {
+					p++;
+					MethodWithRequires ();
+				};
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
@@ -1039,11 +1039,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				Action _ =
 					// Analyzer doesn't recognize reflection access - so doesn't warn in this case
 					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
-					() => {
-						typeof (RequiresInCompilerGeneratedCode)
-							.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
-							.Invoke (null, new object[] { });
-					};
+				() => {
+					typeof (RequiresInCompilerGeneratedCode)
+						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
+						.Invoke (null, new object[] { });
+				};
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
@@ -1053,11 +1053,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026")]
-					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
-					() => {
-						var action = new Action (MethodWithRequires);
-					};
+				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
+				() => {
+					var action = new Action (MethodWithRequires);
+				};
 			}
 
 			[ExpectedWarning ("IL2026", "--MethodWithRequiresAndReturns--", CompilerGeneratedCode = true)]
@@ -1080,9 +1080,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				Action _ =
 					// Analyzer doesn't apply DAM - so won't see this warnings
 					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
-					() => {
-						typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
-					};
+				() => {
+					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
+				};
 			}
 
 			[RequiresUnreferencedCode ("Suppress in body")]
@@ -1094,7 +1094,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 					// TODO: Fix the discrepancy between linker and analyzer
 					// https://github.com/dotnet/linker/issues/2350
 					[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
-					() => unknownType.RequiresNonPublicMethods ();
+				() => unknownType.RequiresNonPublicMethods ();
 			}
 
 			// The warning is currently not detected by roslyn analyzer since it doesn't analyze DAM yet

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -342,57 +342,64 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInLambda
 		{
-			// Suppression currently doesn't propagate to local functions
+			// Suppression currently doesn't propagate to lambdas
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
-				Action _ = () => RequiresUnreferencedCodeMethod ();
+				Action _ =
+					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+					() => RequiresUnreferencedCodeMethod ();
 			}
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestReflectionAccessRUCMethod ()
 			{
-				Action _ = () => typeof (SuppressWarningsInCompilerGeneratedCode)
+				Action _ =
+					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+					() => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 			}
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestLdftnOnRUCMethod ()
 			{
-				Action _ = () => { var _ = new Action (RequiresUnreferencedCodeMethod); };
+				Action _ =
+					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+					() => { var _ = new Action (RequiresUnreferencedCodeMethod); };
 			}
 
-			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestDynamicallyAccessedMethod ()
 			{
-				Action _ = () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				Action _ =
+					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+					() => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
-			[ExpectedWarning ("IL2077", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2077")]
 			static void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
-				Action _ = () => unknownType.RequiresNonPublicMethods ();
+				Action _ =
+					[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
+					() => unknownType.RequiresNonPublicMethods ();
 			}
 
-			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericMethodParameterRequirement<TUnknown> ()
 			{
-				Action _ = () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				Action _ =
+					[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
+					() => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
-			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericTypeParameterRequirement<TUnknown> ()
 			{
-				Action _ = () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				Action _ =
+					[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
+					() => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
 			public static void Test ()

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -348,7 +348,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestCallRUCMethod ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -356,7 +356,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestReflectionAccessRUCMethod ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
@@ -366,7 +366,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestLdftnOnRUCMethod ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => { var _ = new Action (RequiresUnreferencedCodeMethod); };
 			}
 
@@ -374,7 +374,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
@@ -382,7 +382,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
 				Action _ =
-					[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
 				() => unknownType.RequiresNonPublicMethods ();
 			}
 
@@ -390,7 +390,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestGenericMethodParameterRequirement<TUnknown> ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				() => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
@@ -398,7 +398,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestGenericTypeParameterRequirement<TUnknown> ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
+				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				() => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -349,7 +349,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
-					() => RequiresUnreferencedCodeMethod ();
+				() => RequiresUnreferencedCodeMethod ();
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
@@ -357,7 +357,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
-					() => typeof (SuppressWarningsInCompilerGeneratedCode)
+				() => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
 			}
@@ -367,7 +367,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
-					() => { var _ = new Action (RequiresUnreferencedCodeMethod); };
+				() => { var _ = new Action (RequiresUnreferencedCodeMethod); };
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
@@ -375,7 +375,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				Action _ =
 					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
-					() => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				() => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2077")]
@@ -383,7 +383,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				Action _ =
 					[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
-					() => unknownType.RequiresNonPublicMethods ();
+				() => unknownType.RequiresNonPublicMethods ();
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
@@ -391,7 +391,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				Action _ =
 					[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
-					() => MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				() => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
@@ -399,7 +399,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				Action _ =
 					[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
-					() => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				() => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
 			public static void Test ()

--- a/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
     <!-- This reference is purely so that the linker can resolve this


### PR DESCRIPTION
This updates a few of the compiler-generated code tests to put the `ExpectedWarning` attribute on lambdas and local functions when possible, removing the need for `CompilerGeneratedCode = true` in these places.

Unfortunately the formatting became weird - dotnet format seems to require the lambda to not be indented following the attribute, and I couldn't find a good workaround so I'm leaving it as-is. (Filed https://github.com/dotnet/format/issues/1548) edit: Ok, I changed it to at least unindent the attributes as well to match the lambda expression. Otherwise multiple attributes on lambdas have inconsistent indentation.