### PR TITLE
Lambda and local function suppressions

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -60,6 +60,9 @@ namespace ILLink.RoslynAnalyzer
 			if (member.HasAttribute (requiresAttribute) && !member.IsStaticConstructor ())
 				return true;
 
+			if (member.ContainingSymbol is IMethodSymbol containingMethod)
+				return containingMethod.IsInRequiresScope (requiresAttribute, checkAssociatedSymbol);
+
 			if (member.ContainingType is ITypeSymbol containingType && containingType.HasAttribute (requiresAttribute))
 				return true;
 

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -57,11 +57,13 @@ namespace ILLink.RoslynAnalyzer
 			if (member is ITypeSymbol)
 				return false;
 
-			if (member.HasAttribute (requiresAttribute) && !member.IsStaticConstructor ())
-				return true;
-
-			if (member.ContainingSymbol is IMethodSymbol containingMethod)
-				return containingMethod.IsInRequiresScope (requiresAttribute, checkAssociatedSymbol);
+			while (true) {
+				if (member.HasAttribute (requiresAttribute) && !member.IsStaticConstructor ())
+					return true;
+				if (member.ContainingSymbol is not IMethodSymbol method)
+					break;
+				member = method;
+			}
 
 			if (member.ContainingType is ITypeSymbol containingType && containingType.HasAttribute (requiresAttribute))
 				return true;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2903,7 +2903,7 @@ namespace Mono.Linker.Steps
 
 			MethodDefinition? owningMethod;
 			while (Context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (member, out owningMethod)) {
-				Debug.Assert (owningMethod != originMember);
+				Debug.Assert (owningMethod != member);
 				if (Annotations.IsMethodInRequiresUnreferencedCodeScope (owningMethod))
 					return true;
 				member = owningMethod;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2901,13 +2901,15 @@ namespace Mono.Linker.Steps
 			if (originMember is not IMemberDefinition member)
 				return false;
 
-			MethodDefinition? userDefinedMethod = Context.CompilerGeneratedState.GetUserDefinedMethodForCompilerGeneratedMember (member);
-			if (userDefinedMethod == null)
-				return false;
+			MethodDefinition? owningMethod;
+			while (Context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (member, out owningMethod)) {
+				Debug.Assert (owningMethod != originMember);
+				if (Annotations.IsMethodInRequiresUnreferencedCodeScope (owningMethod))
+					return true;
+				member = owningMethod;
+			}
 
-			Debug.Assert (userDefinedMethod != originMember);
-
-			return Annotations.IsMethodInRequiresUnreferencedCodeScope (userDefinedMethod);
+			return false;
 		}
 
 		internal void CheckAndReportRequiresUnreferencedCode (MethodDefinition method)

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -559,28 +559,6 @@ namespace Mono.Linker.Steps
 
 		protected virtual void EnqueueMethod (MethodDefinition method, in DependencyInfo reason, in MarkScopeStack.Scope scope)
 		{
-			if (GeneratedNames.IsGeneratedMemberName (method.Name)) {
-				// We only expect a generated method to represent a lambda or local function.
-				// TODO: what about implicit Main? Async main?
-				Debug.Assert (GeneratedNames.TryParseLambdaMethodName (method.Name, out _) || GeneratedNames.TryParseLocalFunctionMethodName (method.Name, out _, out _));
-				// We rely on the callers of compiler-generated methods being marked first... which might not always be true,
-				// if they are marked for a reason other than a discovered call to them.
-				// Might need to postpone processing of such methods. But for now just check the assumption.
-
-				// Forget the reason assert. There are too many.
-				// Debug.Assert (reason.Kind is DependencyKind.DirectCall or DependencyKind.VirtualCall or DependencyKind.Newobj or DependencyKind.Ldftn
-				// // Could be a directcall to a generic LocalFunction... :/
-				// 	or DependencyKind.ElementMethod
-				// 	// Or could by dynamically accessed... hopefully not the first time?
-				// 	or DependencyKind.DynamicallyAccessedMember);
-				// We might mark a generic instantiation, which gets resolved to the definition, and the source
-				// is the generic instance. Which doesn't satisfy the above.
-				if (reason.Kind is not (DependencyKind.ElementMethod or DependencyKind.MethodOnGenericInstance)) {
-					Debug.Assert (Annotations.IsMarked ( (IMetadataTokenProvider) reason.Source));
-					MethodDefinition caller = (MethodDefinition) reason.Source;
-					Context.CompilerGeneratedState.TrackCallToLambdaOrLocalFunction (caller, method);
-				}
-			}
 			_methods.Enqueue ((method, reason, scope));
 		}
 

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -593,25 +593,21 @@ namespace Mono.Linker
 		/// </summary>
 		/// <remarks>Unlike <see cref="IsMethodInRequiresUnreferencedCodeScope(MethodDefinition)"/> only static methods 
 		/// and .ctors are reported as requiring unreferenced code when the declaring type has RUC on it.</remarks>
-		internal bool DoesMethodRequireUnreferencedCode (MethodDefinition method, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
+		internal bool DoesMethodRequireUnreferencedCode (MethodDefinition originalMethod, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
-			if (method.IsStaticConstructor ()) {
-				attribute = null;
-				return false;
-			}
-			if (TryGetLinkerAttribute (method, out attribute))
-				return true;
-
-			if ((method.IsStatic || method.IsConstructor) && method.DeclaringType is not null &&
-				TryGetLinkerAttribute (method.DeclaringType, out attribute))
-				return true;
-
-			MethodDefinition? owningMethod;
-			while (context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (method, out owningMethod)) {
-				if (DoesMethodRequireUnreferencedCode (owningMethod, out attribute))
+			MethodDefinition? method = originalMethod;
+			do {
+				if (method.IsStaticConstructor ()) {
+					attribute = null;
+					return false;
+				}
+				if (TryGetLinkerAttribute (method, out attribute))
 					return true;
-				method = owningMethod;
-			}
+
+				if ((method.IsStatic || method.IsConstructor) && method.DeclaringType is not null &&
+					TryGetLinkerAttribute (method.DeclaringType, out attribute))
+					return true;
+			} while (context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (method, out method));
 
 			return false;
 		}

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -606,6 +606,13 @@ namespace Mono.Linker
 				TryGetLinkerAttribute (method.DeclaringType, out attribute))
 				return true;
 
+			MethodDefinition? owningMethod;
+			while (context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (method, out owningMethod)) {
+				if (DoesMethodRequireUnreferencedCode (owningMethod, out attribute))
+					return true;
+				method = owningMethod;
+			}
+
 			return false;
 		}
 

--- a/src/linker/Linker/CallGraph.cs
+++ b/src/linker/Linker/CallGraph.cs
@@ -28,13 +28,13 @@ namespace Mono.Linker
 			visited.Add (start);
 			queue.Enqueue (start);
 			while (queue.TryDequeue (out MethodDefinition? method)) {
-				if (!callGraph.TryGetValue (method, out HashSet<MethodDefinition>? neighbors))
+				if (!callGraph.TryGetValue (method, out HashSet<MethodDefinition>? callees))
 					continue;
 
-				foreach (var neighbor in neighbors) {
-					if (visited.Add (neighbor)) {
-						queue.Enqueue (neighbor);
-						yield return neighbor;
+				foreach (var callee in callees) {
+					if (visited.Add (callee)) {
+						queue.Enqueue (callee);
+						yield return callee;
 					}
 				}
 			}

--- a/src/linker/Linker/CallGraph.cs
+++ b/src/linker/Linker/CallGraph.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace Mono.Linker
+{
+	class CallGraph
+	{
+		readonly Dictionary<MethodDefinition, HashSet<MethodDefinition>> callGraph;
+
+		public CallGraph () => callGraph = new Dictionary<MethodDefinition, HashSet<MethodDefinition>> ();
+
+		public void TrackCall (MethodDefinition fromMethod, MethodDefinition toMethod)
+		{
+			if (!callGraph.TryGetValue (fromMethod, out HashSet<MethodDefinition>? toMethods)) {
+				toMethods = new HashSet<MethodDefinition> ();
+				callGraph.Add (fromMethod, toMethods);
+			}
+			toMethods.Add (toMethod);
+		}
+
+		public IEnumerable<MethodDefinition> GetReachableMethods (MethodDefinition start)
+		{
+			Queue<MethodDefinition> queue = new ();
+			HashSet<MethodDefinition> visited = new ();
+			visited.Add (start);
+			queue.Enqueue (start);
+			while (queue.TryDequeue (out MethodDefinition? method)) {
+				if (!callGraph.TryGetValue (method, out HashSet<MethodDefinition>? neighbors))
+					continue;
+
+				foreach (var neighbor in neighbors) {
+					if (visited.Add (neighbor)) {
+						queue.Enqueue (neighbor);
+						yield return neighbor;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/linker/Linker/CompilerGeneratedNames.cs
+++ b/src/linker/Linker/CompilerGeneratedNames.cs
@@ -1,40 +1,69 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace Mono.Linker {
-	class GeneratedNames {
-		internal static bool IsGeneratedMemberName(string memberName)
+namespace Mono.Linker
+{
+	class GeneratedNames
+	{
+		internal static bool IsGeneratedMemberName (string memberName)
 		{
 			return memberName.Length > 0 && memberName[0] == '<';
 		}
 
-		internal static bool IsLambdaDisplayClass(string className)
+		internal static bool IsLambdaDisplayClass (string className)
 		{
-			if (!IsGeneratedMemberName(className))
+			if (!IsGeneratedMemberName (className))
 				return false;
 
 			// This is true for static lambdas (which are emitted into a class like <>c)
 			// and for instance lambdas (which are emitted into a class like <>c__DisplayClass1_0)
-			return className.StartsWith("<>c");
+			return className.StartsWith ("<>c");
 		}
 
 		// Lambda methods have generated names like "<UserMethod>c__0_1" where "UserMethod" is the name
 		// of the original user code that contains the lambda method declaration.
 		// Note: this might not be the immediately containing method, if the containing method is
 		// a lambda or local function. This is the name of the user method.
-		internal static bool TryParseLambdaMethodName(string methodName, [NotNullWhen (true)] out string? userMethodName)
+		internal static bool TryParseLambdaMethodName (string methodName, [NotNullWhen (true)] out string? userMethodName)
 		{
 			userMethodName = null;
-			if (!IsGeneratedMemberName(methodName))
+			if (!IsGeneratedMemberName (methodName))
 				return false;
 
-			int i = methodName.IndexOf('>', 1);
+			int i = methodName.IndexOf ('>', 1);
 			if (i == -1)
 				return false;
-			if (methodName[i+1] != 'b')
+			if (methodName[i + 1] != 'b')
 				return false;
 
-			// Ignore the method ordinal and entity ordinal for now.
-			userMethodName = methodName.Substring(1, i - 1);
+			// Ignore the method ordinal/generation and lambda ordinal/generation.
+			userMethodName = methodName.Substring (1, i - 1);
+			return true;
+		}
+
+		internal static bool TryParseLocalFunctionMethodName (string methodName, [NotNullWhen (true)] out string? userMethodName, [NotNullWhen (true)] out string? localFunctionName)
+		{
+			userMethodName = null;
+			localFunctionName = null;
+			if (!IsGeneratedMemberName (methodName))
+				return false;
+
+			int i = methodName.IndexOf ('>', 1);
+			if (i == -1)
+				return false;
+			if (methodName[i + 1] != 'g')
+				return false;
+
+			// Ignore the method ordinal/generation and local function ordinal/generation.
+			userMethodName = methodName[1..i];
+			i += 2;
+			if (methodName[i++] != '_' || methodName[i++] != '_')
+				return false;
+
+			int j = methodName.IndexOf ('|', i);
+			if (j == -1)
+				return false;
+
+			localFunctionName = methodName[i..j];
 			return true;
 		}
 	}

--- a/src/linker/Linker/CompilerGeneratedNames.cs
+++ b/src/linker/Linker/CompilerGeneratedNames.cs
@@ -22,10 +22,8 @@ namespace Mono.Linker
 
 		internal static bool IsLambdaOrLocalFunction (string methodName) => IsLambdaMethod (methodName) || IsLocalFunction (methodName);
 
-		// Lambda methods have generated names like "<UserMethod>c__0_1" where "UserMethod" is the name
+		// Lambda methods have generated names like "<UserMethod>b__0_1" where "UserMethod" is the name
 		// of the original user code that contains the lambda method declaration.
-		// Note: this might not be the immediately containing method, if the containing method is
-		// a lambda or local function. This is the name of the user method.
 		internal static bool IsLambdaMethod (string methodName)
 		{
 			if (!IsGeneratedMemberName (methodName))
@@ -39,6 +37,9 @@ namespace Mono.Linker
 			return methodName[i + 1] == 'b';
 		}
 
+		// Local functions have generated names like "<UserMethod>g__LocalFunction|0_1" where "UserMethod" is the name
+		// of the original user code that contains the lambda method declaration, and "LocalFunction" is the name of
+		// the local function.
 		internal static bool IsLocalFunction (string methodName)
 		{
 			if (!IsGeneratedMemberName (methodName))

--- a/src/linker/Linker/CompilerGeneratedNames.cs
+++ b/src/linker/Linker/CompilerGeneratedNames.cs
@@ -1,8 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Mono.Linker
 {
-	class GeneratedNames
+	class CompilerGeneratedNames
 	{
 		internal static bool IsGeneratedMemberName (string memberName)
 		{
@@ -19,52 +20,36 @@ namespace Mono.Linker
 			return className.StartsWith ("<>c");
 		}
 
+		internal static bool IsLambdaOrLocalFunction (string methodName) => IsLambdaMethod (methodName) || IsLocalFunction (methodName);
+
 		// Lambda methods have generated names like "<UserMethod>c__0_1" where "UserMethod" is the name
 		// of the original user code that contains the lambda method declaration.
 		// Note: this might not be the immediately containing method, if the containing method is
 		// a lambda or local function. This is the name of the user method.
-		internal static bool TryParseLambdaMethodName (string methodName, [NotNullWhen (true)] out string? userMethodName)
+		internal static bool IsLambdaMethod (string methodName)
 		{
-			userMethodName = null;
 			if (!IsGeneratedMemberName (methodName))
 				return false;
 
 			int i = methodName.IndexOf ('>', 1);
 			if (i == -1)
-				return false;
-			if (methodName[i + 1] != 'b')
 				return false;
 
 			// Ignore the method ordinal/generation and lambda ordinal/generation.
-			userMethodName = methodName.Substring (1, i - 1);
-			return true;
+			return methodName[i + 1] == 'b';
 		}
 
-		internal static bool TryParseLocalFunctionMethodName (string methodName, [NotNullWhen (true)] out string? userMethodName, [NotNullWhen (true)] out string? localFunctionName)
+		internal static bool IsLocalFunction (string methodName)
 		{
-			userMethodName = null;
-			localFunctionName = null;
 			if (!IsGeneratedMemberName (methodName))
 				return false;
 
 			int i = methodName.IndexOf ('>', 1);
 			if (i == -1)
 				return false;
-			if (methodName[i + 1] != 'g')
-				return false;
 
 			// Ignore the method ordinal/generation and local function ordinal/generation.
-			userMethodName = methodName[1..i];
-			i += 2;
-			if (methodName[i++] != '_' || methodName[i++] != '_')
-				return false;
-
-			int j = methodName.IndexOf ('|', i);
-			if (j == -1)
-				return false;
-
-			localFunctionName = methodName[i..j];
-			return true;
+			return methodName[i + 1] == 'g';
 		}
 	}
 }

--- a/src/linker/Linker/CompilerGeneratedNames.cs
+++ b/src/linker/Linker/CompilerGeneratedNames.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Mono.Linker {
+	class GeneratedNames {
+		internal static bool IsGeneratedMemberName(string memberName)
+		{
+			return memberName.Length > 0 && memberName[0] == '<';
+		}
+
+		internal static bool IsLambdaDisplayClass(string className)
+		{
+			if (!IsGeneratedMemberName(className))
+				return false;
+
+			// This is true for static lambdas (which are emitted into a class like <>c)
+			// and for instance lambdas (which are emitted into a class like <>c__DisplayClass1_0)
+			return className.StartsWith("<>c");
+		}
+
+		// Lambda methods have generated names like "<UserMethod>c__0_1" where "UserMethod" is the name
+		// of the original user code that contains the lambda method declaration.
+		// Note: this might not be the immediately containing method, if the containing method is
+		// a lambda or local function. This is the name of the user method.
+		internal static bool TryParseLambdaMethodName(string methodName, [NotNullWhen (true)] out string? userMethodName)
+		{
+			userMethodName = null;
+			if (!IsGeneratedMemberName(methodName))
+				return false;
+
+			int i = methodName.IndexOf('>', 1);
+			if (i == -1)
+				return false;
+			if (methodName[i+1] != 'b')
+				return false;
+
+			// Ignore the method ordinal and entity ordinal for now.
+			userMethodName = methodName.Substring(1, i - 1);
+			return true;
+		}
+	}
+}

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -29,7 +29,6 @@ namespace Mono.Linker
 		static bool HasRoslynCompilerGeneratedName (TypeDefinition type) =>
 			CompilerGeneratedNames.IsGeneratedMemberName (type.Name) || (type.DeclaringType != null && HasRoslynCompilerGeneratedName (type.DeclaringType));
 
-
 		void PopulateCacheForType (TypeDefinition type)
 		{
 			// Avoid repeat scans of the same type

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -124,24 +124,24 @@ namespace Mono.Linker
 					return userDefinedMethod;
 			}
 
-			TypeDefinition compilerGeneratedType = (sourceMember as TypeDefinition) ?? sourceMember.DeclaringType;
-			if (_compilerGeneratedTypeToUserCodeMethod.TryGetValue (compilerGeneratedType, out userDefinedMethod))
+			TypeDefinition sourceType = (sourceMember as TypeDefinition) ?? sourceMember.DeclaringType;
+			if (_compilerGeneratedTypeToUserCodeMethod.TryGetValue (sourceType, out userDefinedMethod))
 				return userDefinedMethod;
 
-			// Only handle async or iterator state machine
-			// So go to the declaring type and check if it's compiler generated (as a perf optimization)
-			if (!HasRoslynCompilerGeneratedName (compilerGeneratedType) || compilerGeneratedType.DeclaringType == null)
+			if (sourceType.DeclaringType == null)
 				return null;
+
+			var typeToCache = HasRoslynCompilerGeneratedName (sourceType) ? sourceType.DeclaringType : sourceType;
 
 			// Now go to its declaring type and search all methods to find the one which points to the type as its
 			// state machine implementation.
-			PopulateCacheForType (compilerGeneratedType.DeclaringType);
+			PopulateCacheForType (typeToCache);
 			if (compilerGeneratedMethod != null) {
 				if (_compilerGeneratedMethodToUserCodeMethod.TryGetValue (compilerGeneratedMethod, out userDefinedMethod))
 					return userDefinedMethod;
 			}
 
-			if (_compilerGeneratedTypeToUserCodeMethod.TryGetValue (compilerGeneratedType, out userDefinedMethod))
+			if (_compilerGeneratedTypeToUserCodeMethod.TryGetValue (sourceType, out userDefinedMethod))
 				return userDefinedMethod;
 
 			return null;

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -26,7 +26,7 @@ namespace Mono.Linker
 			_typesWithPopulatedCache = new HashSet<TypeDefinition> ();
 		}
 
-		IEnumerable<TypeDefinition> GetCompilerGeneratedNestedTypes (TypeDefinition type)
+		static IEnumerable<TypeDefinition> GetCompilerGeneratedNestedTypes (TypeDefinition type)
 		{
 			foreach (var nestedType in type.NestedTypes) {
 				if (!CompilerGeneratedNames.IsGeneratedMemberName (nestedType.Name))
@@ -109,8 +109,8 @@ namespace Mono.Linker
 			// Also scan compiler-generated state machine methods (in case they have calls to nested functions),
 			// and nested functions inside compiler-generated closures (in case they call other nested functions).
 
-			// State machines can be emitted into lambda display classes, so we need to go down at least two levels
-			// level to find calls from iterator nested functions to other nested functions. We just recurse into
+			// State machines can be emitted into lambda display classes, so we need to go down at least two
+			// levels to find calls from iterator nested functions to other nested functions. We just recurse into
 			// all compiler-generated nested types to avoid depending on implementation details.
 
 			foreach (var nestedType in GetCompilerGeneratedNestedTypes (type)) {

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -55,13 +55,15 @@ namespace Mono.Linker
 			if (provider is not IMemberDefinition member)
 				return false;
 
-			MethodDefinition? userDefinedMethod = _context.CompilerGeneratedState.GetUserDefinedMethodForCompilerGeneratedMember (member);
-			if (userDefinedMethod == null)
-				return false;
+			MethodDefinition? owningMethod;
+			while (_context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (member, out owningMethod)) {
+				Debug.Assert (owningMethod != provider);
+				if (IsSuppressed (id, owningMethod, out info))
+					return true;
+				member = owningMethod;
+			}
 
-			Debug.Assert (userDefinedMethod != provider);
-
-			return IsSuppressed (id, userDefinedMethod, out info);
+			return false;
 		}
 
 		bool IsSuppressed (int id, ICustomAttributeProvider warningOrigin, out SuppressMessageInfo info)

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -57,7 +57,7 @@ namespace Mono.Linker
 
 			MethodDefinition? owningMethod;
 			while (_context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (member, out owningMethod)) {
-				Debug.Assert (owningMethod != provider);
+				Debug.Assert (owningMethod != member);
 				if (IsSuppressed (id, owningMethod, out info))
 					return true;
 				member = owningMethod;

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -1161,6 +1161,22 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class SuppressInComplex
 		{
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestIteratorLocalFunction ()
+			{
+				LocalFunction ();
+
+				IEnumerable<int> LocalFunction ()
+				{
+					yield return 0;
+					MethodWithRequires ();
+					yield return 1;
+				}
+			}
+
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
@@ -1190,9 +1206,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				LocalFunction ();
 				await MethodAsync ();
 
-				[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
-				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;
@@ -1215,6 +1228,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[UnconditionalSuppressMessage ("AOT", "IL3050")]
 			public static void Test ()
 			{
+				TestIteratorLocalFunction ();
 				TestIteratorLocalFunctionInAsync ();
 				TestIteratorLocalFunctionInAsyncWithoutInner ();
 				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -576,6 +576,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			static void TestCallUnused ()
 			{
+				// Analyzer emits warnings for code in unused local functions.
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction () => MethodWithRequires ();
 			}
 
@@ -595,6 +599,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			static void TestCallWithClosureUnused (int p = 0)
 			{
+				// Analyzer emits warnings for code in unused local functions.
+				[ExpectedWarning ("IL2026", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+				[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction ()
 				{
 					p++;

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -654,9 +654,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction () => MethodWithRequires ();
 			}
 
@@ -667,9 +664,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction ()
 				{
 					p++;
@@ -696,9 +690,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction ()
 				{
 					var action = new Action (MethodWithRequires);
@@ -817,9 +808,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				var _ = new Action (LocalFunction);
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction () => MethodWithRequires ();
 			}
 
@@ -983,9 +971,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestCall ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				() => MethodWithRequires ();
 			}
 
@@ -1005,9 +990,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestCallWithClosure (int p = 0)
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				() => {
 					p++;
 					MethodWithRequires ();
@@ -1033,9 +1015,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestLdftn ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				() => {
 					var action = new Action (MethodWithRequires);
 				};

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -1200,10 +1200,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static async void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
 				Action _ =
-				// TODO: Fix the discrepancy between linker and analyzer
-				// https://github.com/dotnet/linker/issues/2350
-				// [ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
-				// TODO: add a separate testcase for this.
 				() => unknownType.RequiresNonPublicMethods ();
 			}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -1647,7 +1647,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[RequiresUnreferencedCode ("--TestLocalFunctionWithClosureWithRequires--")]
 				[RequiresAssemblyFiles ("--TestLocalFunctionWithClosureWithRequires--")]
 				[RequiresDynamicCode ("--TestLocalFunctionWithClosureWithRequires--")]
-				void LocalFunction () {
+				void LocalFunction ()
+				{
 					p++;
 					MethodWithRequires ();
 				}
@@ -1670,7 +1671,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				void LocalFunction () {
+				void LocalFunction ()
+				{
 					p++;
 					MethodWithRequires ();
 				}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -987,19 +987,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class SuppressInLambda
 		{
-			// Bug https://github.com/dotnet/linker/issues/2001
-			// Requires should propagate into lambdas
-
-			// C# 10 allows attributes on lambdas
-			// - This would be useful as a workaround for the limitation as Requires could be applied to the lambda directly
-
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static void TestCall ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				() => MethodWithRequires ();
@@ -1012,7 +1006,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				// This should not produce warning because the Requires
 				Action<Type> _ =
-				[ExpectedWarning ("IL2067", ProducedBy = ProducedBy.Trimmer)]
 				(t) => t.RequiresPublicMethods ();
 			}
 
@@ -1022,7 +1015,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestCallWithClosure (int p = 0)
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				() => {
@@ -1037,8 +1030,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestReflectionAccess ()
 			{
 				Action _ =
-				// Analyzer doesn't recognize reflection access - so doesn't warn in this case
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => {
 					typeof (RequiresInCompilerGeneratedCode)
 						.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
@@ -1052,7 +1043,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestLdftn ()
 			{
 				Action _ =
-					[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				() => {
@@ -1078,8 +1069,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ =
-				// Analyzer doesn't apply DAM - so won't see this warnings
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => {
 					typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 				};
@@ -1093,24 +1082,22 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				Action _ =
 				// TODO: Fix the discrepancy between linker and analyzer
 				// https://github.com/dotnet/linker/issues/2350
-				[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
+				// [ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
+				// TODO: add a separate testcase for this.
 				() => unknownType.RequiresNonPublicMethods ();
 			}
 
-			// The warning is currently not detected by roslyn analyzer since it doesn't analyze DAM yet
-			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
 			static void TestGenericMethodParameterRequirement<TUnknown> ()
 			{
-				Action _ = () => {
+				Action _ =
+				() => {
 					MethodWithGenericWhichRequiresMethods<TUnknown> ();
 				};
 			}
 
-			// The warning is currently not detected by roslyn analyzer since it doesn't analyze DAM yet
-			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -914,7 +914,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 					// code for the lambda contained in Outer(int i).
 				}
 
-				static void Outer(int i) {
+				static void Outer (int i)
+				{
 					LocalFunction ();
 
 					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
@@ -1221,7 +1222,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 					// code for the lambda contained in Outer(int i).
 				}
 
-				static void Outer(int i) {
+				static void Outer (int i)
+				{
 					var lambda =
 					[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
 					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -27,6 +27,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			WarnInLocalFunction.Test ();
 			SuppressInLocalFunction.Test ();
+			WarnInNonNestedLocalFunctionTest ();
+			SuppressInNonNestedLocalFunctionTest ();
 
 			WarnInLambda.Test ();
 			SuppressInLambda.Test ();
@@ -998,6 +1000,34 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				TestSuppressionOnOuterAndLocalFunction ();
 				TestSuppressionOnOuterWithSameName.Test ();
 			}
+		}
+
+		static void WarnInNonNestedLocalFunctionTest ()
+		{
+			LocalFunction ();
+
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+			static void LocalFunction () => MethodWithRequires ();
+		}
+
+		[ExpectedWarning ("IL2026", "--MethodWithNonNestedLocalFunction--")]
+		[ExpectedWarning ("IL3002", "--MethodWithNonNestedLocalFunction--", ProducedBy = ProducedBy.Analyzer)]
+		[ExpectedWarning ("IL3050", "--MethodWithNonNestedLocalFunction--", ProducedBy = ProducedBy.Analyzer)]
+		static void SuppressInNonNestedLocalFunctionTest ()
+		{
+			MethodWithNonNestedLocalFunction ();
+		}
+
+		[RequiresUnreferencedCode ("--MethodWithNonNestedLocalFunction--")]
+		[RequiresAssemblyFiles ("--MethodWithNonNestedLocalFunction--")]
+		[RequiresDynamicCode ("--MethodWithNonNestedLocalFunction--")]
+		static void MethodWithNonNestedLocalFunction ()
+		{
+			LocalFunction ();
+
+			static void LocalFunction () => MethodWithRequires ();
 		}
 
 		class WarnInLambda

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -647,9 +647,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class SuppressInLocalFunction
 		{
-			// Requires doesn't propagate into local functions yet
-			// so its suppression effect also doesn't propagate
-
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
@@ -657,7 +654,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction () => MethodWithRequires ();
@@ -670,7 +667,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction ()
@@ -687,7 +684,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => typeof (RequiresInCompilerGeneratedCode)
 					.GetMethod ("MethodWithRequires", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
@@ -700,7 +696,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction ()
@@ -731,7 +727,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => typeof (TypeWithMethodWithRequires).RequiresNonPublicMethods ();
 			}
 
@@ -742,7 +737,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => unknownType.RequiresNonPublicMethods ();
 			}
 
@@ -753,7 +747,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
@@ -764,7 +757,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
@@ -788,8 +780,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				LocalFunction<TUnknown> ();
 
-				[ExpectedWarning ("IL2087", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2087", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction<TSecond> ()
 				{
 					typeof (TUnknown).RequiresPublicMethods ();
@@ -827,7 +817,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				var _ = new Action (LocalFunction);
 
-				[ExpectedWarning ("IL2026")]
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
 				[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 				void LocalFunction () => MethodWithRequires ();

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -844,7 +844,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 			static void TestSuppressionLocalFunction ()
 			{
-				LocalFunction (); // This will produce a warning since the location function has Requires on it
+				LocalFunction (); // This will produce a warning since the local function has Requires on it
 
 				[RequiresUnreferencedCode ("Suppress in body")]
 				[RequiresAssemblyFiles ("Suppress in body")]
@@ -1098,6 +1098,38 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				};
 			}
 
+			[ExpectedWarning ("IL2026")]
+			[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
+			[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
+			static void TestSuppressionOnLambda ()
+			{
+				var lambda =
+				[RequiresUnreferencedCode ("Suppress in body")]
+				[RequiresAssemblyFiles ("Suppress in body")]
+				[RequiresDynamicCode ("Suppress in body")]
+				() => MethodWithRequires ();
+
+				lambda (); // This will produce a warning since the lambda has Requires on it
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestSuppressionOnOuterAndLambda ()
+			{
+				var lambda =
+				[RequiresUnreferencedCode ("Suppress in body")]
+				[RequiresAssemblyFiles ("Suppress in body")]
+				[RequiresDynamicCode ("Suppress in body")]
+				(Type unknownType) => {
+					MethodWithRequires ();
+					unknownType.RequiresNonPublicMethods ();
+				};
+
+				lambda (null);
+			}
+
+
 			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
 			[UnconditionalSuppressMessage ("SingleFile", "IL3002")]
 			[UnconditionalSuppressMessage ("AOT", "IL3050")]
@@ -1113,6 +1145,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				TestMethodParameterWithRequirements ();
 				TestGenericMethodParameterRequirement<TestType> ();
 				TestGenericTypeParameterRequirement<TestType> ();
+				TestSuppressionOnLambda ();
+				TestSuppressionOnOuterAndLambda ();
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -917,7 +917,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				{
 					NestedLocalFunction ();
 
-					// The linker doesn't have enough information to associate the RUC on LocalFunction
+					// The linker doesn't have enough information to associate the Requires on LocalFunction
 					// with this nested local function.
 					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 					void NestedLocalFunction () => MethodWithRequires ();
@@ -1278,8 +1278,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[RequiresAssemblyFiles ("Suppress in body")]
 				[RequiresDynamicCode ("Suppress in body")]
 				() => {
-					// The linker doesn't have enough information to associate the RUC on lambda
-					// with this nested lambda.
+					// The linker doesn't try to associate the Requires on lambda with this nested
+					// lambda. It would be possible to do this because the declaration site will contain
+					// an IL reference to the generated lambda method, unlike local functions.
+					// However, we don't make this association, for consistency with local functions.
 					var nestedLambda =
 					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 					() => MethodWithRequires ();

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -1318,6 +1318,112 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[RequiresUnreferencedCode ("Suppress in body")]
 			[RequiresAssemblyFiles ("Suppress in body")]
 			[RequiresDynamicCode ("Suppress in body")]
+			static void TestAsyncLocalFunction ()
+			{
+				LocalFunction ();
+
+				async Task<int> LocalFunction ()
+				{
+					await MethodAsync ();
+					MethodWithRequires ();
+					return 1;
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestIteratorLocalFunctionWithClosure (int p = 0)
+			{
+				LocalFunction ();
+
+				IEnumerable<int> LocalFunction ()
+				{
+					p++;
+					yield return 0;
+					MethodWithRequires ();
+					yield return 1;
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestAsyncLocalFunctionWithClosure (int p = 0)
+			{
+				LocalFunction ();
+
+				async Task<int> LocalFunction ()
+				{
+					p++;
+					await MethodAsync ();
+					MethodWithRequires ();
+					return 1;
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestCallToLocalFunctionInIteratorLocalFunctionWithClosure (int p = 0)
+			{
+				LocalFunction ();
+
+				IEnumerable<int> LocalFunction ()
+				{
+					p++;
+					yield return 0;
+					LocalFunction2 ();
+					yield return 1;
+
+					void LocalFunction2 ()
+					{
+						MethodWithRequires ();
+					}
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestAsyncLambda ()
+			{
+				Func<Task<int>> _ = async Task<int> () => {
+					await MethodAsync ();
+					MethodWithRequires ();
+					return 1;
+				};
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestAsyncLambdaWithClosure (int p = 0)
+			{
+				Func<Task<int>> _ = async Task<int> () => {
+					p++;
+					await MethodAsync ();
+					MethodWithRequires ();
+					return 1;
+				};
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestLambdaInAsyncLambdaWithClosure (int p = 0)
+			{
+				Func<Task<int>> _ = async Task<int> () => {
+					p++;
+					await MethodAsync ();
+					var lambda = () => MethodWithRequires ();
+					return 1;
+				};
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
 			static async void TestIteratorLocalFunctionInAsync ()
 			{
 				await MethodAsync ();
@@ -1367,6 +1473,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			public static void Test ()
 			{
 				TestIteratorLocalFunction ();
+				TestAsyncLocalFunction ();
+				TestIteratorLocalFunctionWithClosure ();
+				TestAsyncLocalFunctionWithClosure ();
+				TestCallToLocalFunctionInIteratorLocalFunctionWithClosure ();
+				TestAsyncLambda ();
+				TestAsyncLambdaWithClosure ();
+				TestLambdaInAsyncLambdaWithClosure ();
 				TestIteratorLocalFunctionInAsync ();
 				TestIteratorLocalFunctionInAsyncWithoutInner ();
 				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -820,9 +820,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				{
 					typeof (DynamicallyAccessedLocalFunction).RequiresNonPublicMethods ();
 
-					[ExpectedWarning ("IL2026")]
-					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 					void LocalFunction () => MethodWithRequires ();
 				}
 			}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -393,6 +393,21 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInComplex
 		{
+			[RequiresUnreferencedCode ("Suppress in body")]
+			[RequiresAssemblyFiles ("Suppress in body")]
+			[RequiresDynamicCode ("Suppress in body")]
+			static void TestIteratorLocalFunction ()
+			{
+				LocalFunction ();
+
+				IEnumerable<int> LocalFunction ()
+				{
+					yield return 0;
+					RequiresUnreferencedCodeMethod ();
+					yield return 1;
+				}
+			}
+
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static async void TestIteratorLocalFunctionInAsync ()
 			{
@@ -416,7 +431,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				LocalFunction ();
 				await MethodAsync ();
 
-				[ExpectedWarning ("IL2026", CompilerGeneratedCode = true, ProducedBy = ProducedBy.Trimmer)]
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;
@@ -460,6 +474,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 			public static void Test ()
 			{
+				TestIteratorLocalFunction ();
 				TestIteratorLocalFunctionInAsync ();
 				TestIteratorLocalFunctionInAsyncWithoutInner ();
 				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -350,8 +350,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 					LocalFunction ();
 
 					[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--")]
-					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 					void LocalFunction () => RequiresUnreferencedCodeMethod ();
 				}
 			}
@@ -511,8 +509,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				{
 					var lambda =
 					[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--")]
-					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]
-					[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer)]
 					() => RequiresUnreferencedCodeMethod ();
 
 					lambda ();

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -345,7 +345,8 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 					// code for the lambda contained in Outer(int i).
 				}
 
-				static void Outer(int i) {
+				static void Outer (int i)
+				{
 					LocalFunction ();
 
 					[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--")]
@@ -440,7 +441,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				() => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
-class DynamicallyAccessedLambda
+			class DynamicallyAccessedLambda
 			{
 				[UnconditionalSuppressMessage ("Test", "IL2026")]
 				public static void TestCallRUCMethodInDynamicallyAccessedLambda ()
@@ -506,7 +507,8 @@ class DynamicallyAccessedLambda
 					// code for the lambda contained in Outer(int i).
 				}
 
-				static void Outer(int i) {
+				static void Outer (int i)
+				{
 					var lambda =
 					[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--")]
 					[ExpectedWarning ("IL3002", ProducedBy = ProducedBy.Analyzer)]

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -342,13 +342,10 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInLambda
 		{
-			// Suppression currently doesn't propagate to lambdas
-
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -356,7 +353,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestReflectionAccessRUCMethod ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
@@ -366,7 +362,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestLdftnOnRUCMethod ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => { var _ = new Action (RequiresUnreferencedCodeMethod); };
 			}
 
@@ -374,7 +369,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				() => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
@@ -382,7 +376,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
 				Action _ =
-				[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
 				() => unknownType.RequiresNonPublicMethods ();
 			}
 
@@ -390,7 +383,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestGenericMethodParameterRequirement<TUnknown> ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				() => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
@@ -398,7 +390,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			static void TestGenericTypeParameterRequirement<TUnknown> ()
 			{
 				Action _ =
-				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				() => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -278,7 +278,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				{
 					typeof (DynamicallyAccessedLocalFunction).RequiresNonPublicMethods ();
 
-					[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 					void LocalFunction () => RequiresUnreferencedCodeMethod ();
 				}
 			}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -158,14 +158,11 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInLocalFunction
 		{
-			// Suppression currently doesn't propagate to local functions
-
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -174,7 +171,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
@@ -185,7 +181,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction ()
 				{ var _ = new Action (RequiresUnreferencedCodeMethod); }
 			}
@@ -195,7 +190,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
@@ -204,7 +198,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => unknownType.RequiresNonPublicMethods ();
 			}
 
@@ -213,7 +206,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
@@ -222,7 +214,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2091", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
@@ -242,8 +233,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction<TUnknown> ();
 
-				[ExpectedWarning ("IL2087", ProducedBy = ProducedBy.Trimmer)]
-				[ExpectedWarning ("IL2087", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction<TSecond> ()
 				{
 					typeof (TUnknown).RequiresPublicMethods ();
@@ -279,7 +268,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				var _ = new Action (LocalFunction);
 
-				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Trimmer)]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -311,7 +299,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				[ExpectedWarning ("IL2067", ProducedBy = ProducedBy.Trimmer)]
 				[UnconditionalSuppressMessage ("Test", "IL2026")] // This supresses the RequiresUnreferencedCodeMethod
 				void LocalFunction (Type unknownType = null)
 				{
@@ -446,11 +433,31 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				yield return 0;
 			}
 
+			static void TestSuppressionOnLambda ()
+			{
+				var l =
+				[UnconditionalSuppressMessage ("Test", "IL2026")]
+				() => RequiresUnreferencedCodeMethod ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2067")]
+			static void TestSuppressionOnOuterAndLambda ()
+			{
+				var l =
+				[UnconditionalSuppressMessage ("Test", "IL2026")]
+				(Type unknownType) => {
+					RequiresUnreferencedCodeMethod ();
+					unknownType.RequiresNonPublicMethods ();
+				};
+			}
+
 			public static void Test ()
 			{
 				TestIteratorLocalFunctionInAsync ();
 				TestIteratorLocalFunctionInAsyncWithoutInner ();
 				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();
+				TestSuppressionOnLambda ();
+				TestSuppressionOnOuterAndLambda ();
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -393,9 +393,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInComplex
 		{
-			[RequiresUnreferencedCode ("Suppress in body")]
-			[RequiresAssemblyFiles ("Suppress in body")]
-			[RequiresDynamicCode ("Suppress in body")]
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestIteratorLocalFunction ()
 			{
 				LocalFunction ();

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -435,20 +435,28 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 			static void TestSuppressionOnLambda ()
 			{
-				var l =
+				var lambda =
+				// https://github.com/dotnet/roslyn/issues/59746
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[UnconditionalSuppressMessage ("Test", "IL2026")]
 				() => RequiresUnreferencedCodeMethod ();
+
+				lambda ();
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2067")]
 			static void TestSuppressionOnOuterAndLambda ()
 			{
-				var l =
+				var lambda =
+				// https://github.com/dotnet/roslyn/issues/59746
+				[ExpectedWarning ("IL2026", ProducedBy = ProducedBy.Analyzer)]
 				[UnconditionalSuppressMessage ("Test", "IL2026")]
 				(Type unknownType) => {
 					RequiresUnreferencedCodeMethod ();
 					unknownType.RequiresNonPublicMethods ();
 				};
+
+				lambda (null);
 			}
 
 			public static void Test ()


### PR DESCRIPTION
This adds support for `RequiresUnreferencedCode` and `UnconditionalSuppressMessage` on lambdas and local functions, relying on heuristics and knowledge of compiler implementation details to detect lambdas and local functions.

This approach scans the code for IL references to lambdas and local functions, which has some limitations.
- Unused local functions aren't referenced by the containing method, so warnings from these will not be suppressed by suppressions on the containing method. Lambdas don't seem to have this problem, because they contain a reference to the generated method as part of the delegate conversion.
- The IL doesn't in general contain enough information to determine the nesting of the scopes of lambdas and local functions, so we make no attempt to do this. We only try to determine to which user method a lambda or local function belongs. So suppressions on a lambda or local function will not silence warnings from a nested lambda or local function in the same scope.

This also adds warnings for reflection access to compiler-generated state machine members, and to lambdas or local functions. For these, the analyzer makes no attempt to determine what the actual IL corresponding to the user code will be, so it produces fewer warnings (see tests for some examples). The linker will warn for what is actually in IL.

One way to work around the first limitation would be to rely on the compiler-generated names to determine the name of the user method, but this is fragile due to the issue @vitek-karas [pointed out](https://github.com/dotnet/linker/pull/2689#pullrequestreview-911356059).