### PR TITLE
Fix empty/null handling for Type.BaseType intrinsic

### DIFF
--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -544,6 +544,11 @@ namespace ILLink.Shared.TrimAnalysis
 			// Type.BaseType
 			//
 			case IntrinsicId.Type_get_BaseType: {
+					if (instanceValue.IsEmpty ()) {
+						returnValue = MultiValueLattice.Top;
+						break;
+					}
+
 					foreach (var value in instanceValue) {
 						if (value is ValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers) {
 							DynamicallyAccessedMemberTypes propagatedMemberTypes = DynamicallyAccessedMemberTypes.None;
@@ -580,6 +585,7 @@ namespace ILLink.Shared.TrimAnalysis
 								AddReturnValue (GetMethodReturnValue (calledMethod, returnValueDynamicallyAccessedMemberTypes));
 						} else if (value == NullValue.Instance) {
 							// Ignore nulls - null.BaseType will fail at runtime, but it has no effect on static analysis
+							returnValue ??= MultiValueLattice.Top;
 							continue;
 						} else {
 							// Unknown input - propagate a return value without any annotation - we know it's a Type but we know nothing about it

--- a/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
@@ -229,19 +229,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			type.BaseType.RequiresPublicMethods ();
 		}
 
-		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
 		static void TestNull ()
 		{
 			Type type = null;
 			type.BaseType.RequiresPublicMethods ();
 		}
 
-		[ExpectedWarning ("IL2072", nameof (DataFlowTypeExtensions) + "." + nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
 		static void TestNoValue ()
 		{
 			Type t = null;
 			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
-			// Warns about the base type even though the above throws an exception at runtime.
+			// No warning because the above throws an exception at runtime.
 			noValue.BaseType.RequiresPublicMethods ();
 		}
 


### PR DESCRIPTION
@vitek-karas this should fix some of the issues you are seeing with dataflow in foreach loops involving `Type.BaseType`.

@vitek-karas shared the following testcase which was warning:

```csharp
// Can only work with All annotation as NonPublicProperties doesn't propagate to base types
static void EnumeratePrivatePropertiesOnBaseTypesWithForeach ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type type)
{
	const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
	Type? t = type;
	while (t != null) {
		foreach (var p in t.GetProperties (DeclaredOnlyLookup)) {
			// Do nothing
		}
		t = t.BaseType;
	}
}
```

This was producing a warning because during the first pass of the analysis over `t.BaseType`, the analyzer hadn't yet figured out that `t` had annotation `All`. (The reason for this has to do with exception handling - the statement is reachable only through a finally block which we hadn't visited yet). `BaseType` gave back `None`, which produced a warning on the call to `GetProperties`.

What this indicates to me is that https://github.com/dotnet/linker/issues/2667 is important not just to be precise about the warning behavior when there are empty inputs, but also for the correctness of the solver.
