### PR TITLE
[release/6.0.2xx] Remove special logic for TypeConverterAttribute (#2659)

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -819,7 +819,6 @@ namespace Mono.Linker.Steps
 						continue;
 
 					MarkCustomAttribute (ca, reason);
-					MarkSpecialCustomAttributeDependencies (ca, provider);
 				}
 			}
 
@@ -1570,7 +1569,6 @@ namespace Mono.Linker.Steps
 				markOccurred = true;
 				using (ScopeStack.PushScope (scope)) {
 					MarkCustomAttribute (customAttribute, reason);
-					MarkSpecialCustomAttributeDependencies (customAttribute, provider);
 				}
 			}
 
@@ -2070,28 +2068,8 @@ namespace Mono.Linker.Steps
 					if (MarkMethodsIf (type.Methods, MethodDefinitionExtensions.IsPublicInstancePropertyMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, type)))
 						Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
 					break;
-				case "TypeDescriptionProviderAttribute" when attrType.Namespace == "System.ComponentModel":
-					MarkTypeConverterLikeDependency (attribute, l => l.IsDefaultConstructor (), type);
-					break;
 				}
 			}
-		}
-
-		//
-		// Used for known framework attributes which can be applied to any element
-		//
-		bool MarkSpecialCustomAttributeDependencies (CustomAttribute ca, ICustomAttributeProvider provider)
-		{
-			var dt = ca.Constructor.DeclaringType;
-			if (dt.Name == "TypeConverterAttribute" && dt.Namespace == "System.ComponentModel") {
-				MarkTypeConverterLikeDependency (ca, l =>
-					l.IsDefaultConstructor () ||
-					l.Parameters.Count == 1 && l.Parameters[0].ParameterType.IsTypeOf ("System", "Type"),
-					provider);
-				return true;
-			}
-
-			return false;
 		}
 
 		void MarkMethodSpecialCustomAttributes (MethodDefinition method)
@@ -2114,34 +2092,6 @@ namespace Mono.Linker.Steps
 				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
 				MarkNamedMethod (type, name, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 			}
-		}
-
-		protected virtual void MarkTypeConverterLikeDependency (CustomAttribute attribute, Func<MethodDefinition, bool> predicate, ICustomAttributeProvider provider)
-		{
-			var args = attribute.ConstructorArguments;
-			if (args.Count < 1)
-				return;
-
-			TypeDefinition? typeDefinition = null;
-			switch (attribute.ConstructorArguments[0].Value) {
-			case string s:
-				if (!Context.TypeNameResolver.TryResolveTypeName (s, ScopeStack.CurrentScope.Origin.Provider, out TypeReference? typeRef, out AssemblyDefinition? assemblyDefinition))
-					break;
-				typeDefinition = Context.TryResolve (typeRef);
-				if (typeDefinition != null)
-					MarkingHelpers.MarkMatchingExportedType (typeDefinition, assemblyDefinition, new DependencyInfo (DependencyKind.CustomAttribute, provider));
-
-				break;
-			case TypeReference type:
-				typeDefinition = Context.Resolve (type);
-				break;
-			}
-
-			if (typeDefinition == null)
-				return;
-
-			Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, provider), marked: false);
-			MarkMethodsIf (typeDefinition.Methods, predicate, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 		}
 
 		static readonly Regex DebuggerDisplayAttributeValueRegex = new Regex ("{[^{}]+}", RegexOptions.Compiled);

--- a/test/Mono.Linker.Tests.Cases/ComponentModel/TypeDescriptionProviderAttributeOnType.cs
+++ b/test/Mono.Linker.Tests.Cases/ComponentModel/TypeDescriptionProviderAttributeOnType.cs
@@ -1,37 +1,69 @@
+using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
+
 namespace Mono.Linker.Tests.Cases.ComponentModel
 {
-	[TypeDescriptionProvider (typeof (CustomTDP))]
-
-	[Kept]
-	[KeptAttributeAttribute (typeof (TypeDescriptionProviderAttribute))]
-	class CustomTypeDescriptionProvider_1
-	{
-		[Kept]
-		public CustomTypeDescriptionProvider_1 ()
-		{
-		}
-
-		[Kept]
-		[KeptBaseType (typeof (TypeDescriptionProvider))]
-		class CustomTDP : TypeDescriptionProvider
-		{
-			[Kept]
-			public CustomTDP ()
-			{
-			}
-		}
-	}
-
 	[Reference ("System.dll")]
+	[ExpectedNoWarnings]
 	public class TypeDescriptionProviderAttributeOnType
 	{
 		public static void Main ()
 		{
 			var r1 = new CustomTypeDescriptionProvider_1 ();
+			IInterface v = InterfaceTypeConverter.CreateVisual (typeof (System.String));
+		}
+
+		[TypeDescriptionProvider (typeof (CustomTDP))]
+		[Kept]
+		[KeptAttributeAttribute (typeof (TypeDescriptionProviderAttribute))]
+		class CustomTypeDescriptionProvider_1
+		{
+			[Kept]
+			public CustomTypeDescriptionProvider_1 ()
+			{
+			}
+
+			[Kept]
+			[KeptBaseType (typeof (TypeDescriptionProvider))]
+			class CustomTDP : TypeDescriptionProvider
+			{
+				[Kept]
+				public CustomTDP ()
+				{
+				}
+			}
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TypeConverterAttribute))]
+		[TypeConverter (typeof (InterfaceTypeConverter))]
+		public interface IInterface
+		{ }
+
+		[Kept]
+		[KeptBaseType (typeof (TypeConverter))]
+		public class InterfaceTypeConverter : TypeConverter
+		{
+			[Kept]
+			public static IInterface CreateVisual (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+				Type visualType)
+			{
+				try {
+					return (IInterface) Activator.CreateInstance (visualType);
+				} catch {
+				}
+
+				return null;
+			}
+
+			[Kept]
+			public InterfaceTypeConverter () { }
 		}
 	}
 }


### PR DESCRIPTION
(cherry picked from commit b10e1bc3da22862b4ddedc2b50639dee9d8dacfd)

# Summary

The linker has had a special case for the TypeConverterAttribute for a while. In .NET 6, the logic was properly annotated, and the special casing can actually produce spurious warnings. This change removes the special casing.

# Impact

Consumers like MAUI use TypeConverterAttribute and are seeing lots of spurious warnings, which is harming their ability to make things trimmable for .NET 6.

# Risk

Low. Removes special casing.

