### PR TITLE
Inline simple wrapper functions in TypeProxy

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TypeProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TypeProxy.cs
@@ -18,16 +18,16 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		public string? Namespace { get => Type.ContainingNamespace?.Name; }
 
-		[MethodImpl(AggressiveInlining)]
+		[MethodImpl (AggressiveInlining)]
 		public bool IsTypeOf (string @namespace, string name) => Type.IsTypeOf (@namespace, name);
 
-		[MethodImpl(AggressiveInlining)]
+		[MethodImpl (AggressiveInlining)]
 		public bool IsTypeOf (WellKnownType wellKnownType) => Type.IsTypeOf (wellKnownType);
 
-		[MethodImpl(AggressiveInlining)]
+		[MethodImpl (AggressiveInlining)]
 		public string GetDisplayName () => Type.GetDisplayName ();
 
-		[MethodImpl(AggressiveInlining)]
+		[MethodImpl (AggressiveInlining)]
 		public override string ToString () => Type.ToString ();
 	}
 }

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TypeProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TypeProxy.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using ILLink.RoslynAnalyzer;
 using Microsoft.CodeAnalysis;
+using static System.Runtime.CompilerServices.MethodImplOptions;
 
 namespace ILLink.Shared.TypeSystemProxy
 {
@@ -16,12 +18,16 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		public string? Namespace { get => Type.ContainingNamespace?.Name; }
 
+		[MethodImpl(AggressiveInlining)]
 		public bool IsTypeOf (string @namespace, string name) => Type.IsTypeOf (@namespace, name);
 
+		[MethodImpl(AggressiveInlining)]
 		public bool IsTypeOf (WellKnownType wellKnownType) => Type.IsTypeOf (wellKnownType);
 
+		[MethodImpl(AggressiveInlining)]
 		public string GetDisplayName () => Type.GetDisplayName ();
 
+		[MethodImpl(AggressiveInlining)]
 		public override string ToString () => Type.ToString ();
 	}
 }

--- a/src/linker/Linker.Dataflow/TypeProxy.cs
+++ b/src/linker/Linker.Dataflow/TypeProxy.cs
@@ -20,16 +20,16 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		public string? Namespace { get => Type.Namespace; }
 
-		[MethodImpl(AggressiveInlining)]
+		[MethodImpl (AggressiveInlining)]
 		public bool IsTypeOf (string @namespace, string name) => Type.IsTypeOf (@namespace, name);
 
-		[MethodImpl(AggressiveInlining)]
+		[MethodImpl (AggressiveInlining)]
 		public bool IsTypeOf (WellKnownType wellKnownType) => Type.IsTypeOf (wellKnownType);
 
-		[MethodImpl(AggressiveInlining)]
+		[MethodImpl (AggressiveInlining)]
 		public string GetDisplayName () => Type.GetDisplayName ();
 
-		[MethodImpl(AggressiveInlining)]
+		[MethodImpl (AggressiveInlining)]
 		public override string ToString () => Type.ToString ();
 	}
 }

--- a/src/linker/Linker.Dataflow/TypeProxy.cs
+++ b/src/linker/Linker.Dataflow/TypeProxy.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Mono.Cecil;
 using Mono.Linker;
+using static System.Runtime.CompilerServices.MethodImplOptions;
 
 namespace ILLink.Shared.TypeSystemProxy
 {
@@ -18,12 +20,16 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		public string? Namespace { get => Type.Namespace; }
 
+		[MethodImpl(AggressiveInlining)]
 		public bool IsTypeOf (string @namespace, string name) => Type.IsTypeOf (@namespace, name);
 
+		[MethodImpl(AggressiveInlining)]
 		public bool IsTypeOf (WellKnownType wellKnownType) => Type.IsTypeOf (wellKnownType);
 
+		[MethodImpl(AggressiveInlining)]
 		public string GetDisplayName () => Type.GetDisplayName ();
 
+		[MethodImpl(AggressiveInlining)]
 		public override string ToString () => Type.ToString ();
 	}
 }


### PR DESCRIPTION
To limit the overhead of the wrapper functions in TypeProxy, we could inline the methods that redirect to a method on the `Type` field.