### PR TITLE
Avoid running GetDisplayNameTests in parallel

### DIFF
--- a/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
+++ b/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace Mono.Linker.Tests
 {
+	[NonParallelizable]
 	[TestFixture]
 	public class GetDisplayNameTests
 	{


### PR DESCRIPTION
There seems to be a race condition on Cecil while trying to get GenericParameters, if a multithreaded test asks simultaneously about GenericParameters on the same type Cecil answers could vary creating test failures. 
Fixes #2693