### PR TITLE
Update array data flow test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -37,7 +37,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestArrayResetAfterCall ();
 			TestArrayResetAfterAssignment ();
 			TestMultiDimensionalArray.Test ();
-			tmpDeleteThisTest ();
 		}
 
 		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
@@ -163,10 +162,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		// https://github.com/dotnet/linker/issues/2680 - analyzer doesn't reset array in this case
 		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicFields), ProducedBy = ProducedBy.Trimmer)]
 		// https://github.com/dotnet/linker/issues/2632 - Ref params don't reset or track.
-		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicMethods), ProducedBy = ProducedBy.Analyzer)]
+		// [ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
 		static void TestArrayResetGetElementOnByRefArray (int i = 0)
 		{
-			Type[] arr = new Type[] { typeof (TestType), typeof(TestType) };
+			Type[] arr = new Type[] { typeof (TestType), typeof (TestType) };
 			arr[0].RequiresPublicProperties ();
 
 			TakesTypeByRef (ref arr[0]); // Should reset index 0 - linker doesn't

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -37,6 +37,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestArrayResetAfterCall ();
 			TestArrayResetAfterAssignment ();
 			TestMultiDimensionalArray.Test ();
+			tmpDeleteThisTest ();
 		}
 
 		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
@@ -161,16 +162,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		// https://github.com/dotnet/linker/issues/2680 - analyzer doesn't reset array in this case
 		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicFields), ProducedBy = ProducedBy.Trimmer)]
+		// https://github.com/dotnet/linker/issues/2632 - Ref params don't reset or track.
+		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicMethods), ProducedBy = ProducedBy.Analyzer)]
 		static void TestArrayResetGetElementOnByRefArray (int i = 0)
 		{
-			Type[] arr = new Type[] { typeof (TestType) };
+			Type[] arr = new Type[] { typeof (TestType), typeof(TestType) };
 			arr[0].RequiresPublicProperties ();
 
-			TakesTypeByRef (ref arr[0]); // No reset - known index
-			arr[0].RequiresPublicMethods (); // Doesn't warn
+			TakesTypeByRef (ref arr[0]); // Should reset index 0 - linker doesn't
+			arr[0].RequiresPublicMethods (); // Should warn -- linker doesn't
+			arr[1].RequiresPublicMethods (); // Shouldn't warn
 
 			TakesTypeByRef (ref arr[i]); // Reset - unknown index
-			arr[0].RequiresPublicFields (); // Warns
+			arr[1].RequiresPublicFields (); // Warns
 		}
 
 		static void TakesTypeByRef (ref Type type) { }


### PR DESCRIPTION
It looks like there was a mistake on the tests for array tracking. Passing an array element as a ref parameter should reset that element, but not others. Previously it expected that it would not reset the known index.