### PR TITLE
Don't let RUC on cctor silence warnings

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -57,11 +57,15 @@ namespace ILLink.RoslynAnalyzer
 			if (member is ITypeSymbol)
 				return false;
 
-			if (member.HasAttribute (requiresAttribute)
-				|| (member.ContainingType is ITypeSymbol containingType &&
-					containingType.HasAttribute (requiresAttribute))) {
+			if (member.HasAttribute (requiresAttribute) && !member.IsStaticConstructor ())
 				return true;
-			}
+
+			if (member.ContainingSymbol is IMethodSymbol containingMethod)
+				return containingMethod.IsInRequiresScope (requiresAttribute, checkAssociatedSymbol);
+
+			if (member.ContainingType is ITypeSymbol containingType && containingType.HasAttribute (requiresAttribute))
+				return true;
+
 			// Only check associated symbol if not override or virtual method
 			if (checkAssociatedSymbol && member is IMethodSymbol { AssociatedSymbol: { } associated } && associated.HasAttribute (requiresAttribute))
 				return true;

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -60,9 +60,6 @@ namespace ILLink.RoslynAnalyzer
 			if (member.HasAttribute (requiresAttribute) && !member.IsStaticConstructor ())
 				return true;
 
-			if (member.ContainingSymbol is IMethodSymbol containingMethod)
-				return containingMethod.IsInRequiresScope (requiresAttribute, checkAssociatedSymbol);
-
 			if (member.ContainingType is ITypeSymbol containingType && containingType.HasAttribute (requiresAttribute))
 				return true;
 

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -618,8 +618,10 @@ namespace Mono.Linker
 		/// instance methods (not just statics and .ctors).</remarks>
 		internal bool IsMethodInRequiresUnreferencedCodeScope (MethodDefinition method)
 		{
-			if (HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method) ||
-				(method.DeclaringType is not null && HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method.DeclaringType)))
+			if (HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method) && !method.IsStaticConstructor ())
+				return true;
+
+			if (method.DeclaringType is not null && HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method.DeclaringType))
 				return true;
 
 			return false;

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnStaticConstructor.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnStaticConstructor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -28,10 +28,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class StaticCtor
 		{
+			[ExpectedWarning ("IL2026", "--MethodWithRequires--")]
+			[ExpectedWarning ("IL3002", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
+			[ExpectedWarning ("IL3050", "--MethodWithRequires--", ProducedBy = ProducedBy.Analyzer)]
 			[ExpectedWarning ("IL2116", "StaticCtor..cctor()")]
 			[RequiresUnreferencedCode ("Message for --TestStaticCtor--")]
 			static StaticCtor ()
 			{
+				MethodWithRequires ();
 			}
 		}
 
@@ -122,6 +126,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		static void TestTypeIsBeforeFieldInit ()
 		{
 			var x = TypeIsBeforeFieldInit.field + 42;
+		}
+
+		[RequiresUnreferencedCode ("--MethodWithRequires--")]
+		[RequiresAssemblyFiles ("--MethodWithRequires--")]
+		[RequiresDynamicCode ("--MethodWithRequires--")]
+		static void MethodWithRequires ()
+		{
 		}
 	}
 }


### PR DESCRIPTION
We don't allow RUC on static constructors, and putting one there produces a warning. The current behavior happens to silence warnings from the cctor but it seems more consistent for it not to have any effect on the warnings since it isn't supported.