### PR TITLE
Fix headers in new files

### DIFF
--- a/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/linker/Linker.Dataflow/FieldValue.cs
+++ b/src/linker/Linker.Dataflow/FieldValue.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/linker/Linker.Dataflow/GenericParameterValue.cs
+++ b/src/linker/Linker.Dataflow/GenericParameterValue.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/linker/Linker.Dataflow/MethodParameterValue.cs
+++ b/src/linker/Linker.Dataflow/MethodParameterValue.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/linker/Linker.Dataflow/MethodReturnValue.cs
+++ b/src/linker/Linker.Dataflow/MethodReturnValue.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/linker/Linker.Dataflow/MethodThisParameterValue.cs
+++ b/src/linker/Linker.Dataflow/MethodThisParameterValue.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/linker/Linker.Dataflow/RuntimeMethodHandleValue.cs
+++ b/src/linker/Linker.Dataflow/RuntimeMethodHandleValue.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ILLink.Shared.DataFlow;
 using Mono.Cecil;

--- a/src/linker/Linker.Dataflow/SingleValueExtensions.cs
+++ b/src/linker/Linker.Dataflow/SingleValueExtensions.cs
@@ -1,5 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Fixes new headers which were causing the build to fail after https://github.com/dotnet/linker/commit/4f0d349e43a71d44ef71339293701fcfc2da997e.