### PR TITLE
Fix IndexOutOfRangeException

### DIFF
--- a/src/linker/Linker/CompilerGeneratedNames.cs
+++ b/src/linker/Linker/CompilerGeneratedNames.cs
@@ -34,7 +34,7 @@ namespace Mono.Linker
 				return false;
 
 			// Ignore the method ordinal/generation and lambda ordinal/generation.
-			return methodName[i + 1] == 'b';
+			return (methodName.Length > i + 1) && methodName[i + 1] == 'b';
 		}
 
 		// Local functions have generated names like "<UserMethod>g__LocalFunction|0_1" where "UserMethod" is the name
@@ -50,7 +50,7 @@ namespace Mono.Linker
 				return false;
 
 			// Ignore the method ordinal/generation and local function ordinal/generation.
-			return methodName[i + 1] == 'g';
+			return (methodName.Length > i + 1) && methodName[i + 1] == 'g';
 		}
 	}
 }


### PR DESCRIPTION
Forgot to check for array length in https://github.com/dotnet/linker/pull/2689.

I'll see if I can find out what methods were hitting this in https://github.com/dotnet/runtime/pull/67381#issuecomment-1086214962, to see if they need different handling.

edit: the logs from that run suggest it might have been hit for the method `SimpleWasmTestRunner.<Main>(String[])`. I'm not clear on why the main method would be emitted with that name, but in any case this seems to be one example.