### PR TITLE
Don't throw on write to get-only property

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -103,7 +103,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				break;
 			case IPropertyReferenceOperation propertyRef:
 				// A property assignment is really a call to the property setter.
-				var setMethod = propertyRef.Property.SetMethod!;
+				var setMethod = propertyRef.Property.SetMethod;
+				if (setMethod == null) {
+					// This can happen in a constructor - there it is possible to assign to a property
+					// without a setter. This turns into an assignment to the compiler-generated backing field.
+					// To match the linker, this should warn about the compiler-generated backing field.
+					// For now, just don't warn.
+					break;
+				}
 				TValue instanceValue = Visit (propertyRef.Instance, state);
 				// The return value of a property set expression is the value,
 				// even though a property setter has no return value.

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -36,6 +36,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestAutomaticPropagation ();
 
 			PropertyWithAttributeMarkingItself.Test ();
+			new TestWriteToGetOnlyProperty ();
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
@@ -68,24 +69,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (PropertyWithPublicConstructor) + ".set", nameof (GetTypeWithPublicParameterlessConstructor))]
 		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (PropertyWithPublicConstructor) + ".set", nameof (GetTypeWithNonPublicConstructors))]
-		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (PropertyWithPublicConstructor) + ".set", nameof (GetUnkownType))]
+		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (PropertyWithPublicConstructor) + ".set", nameof (GetUnknownType))]
 		private void WriteToInstanceProperty ()
 		{
 			PropertyWithPublicConstructor = GetTypeWithPublicParameterlessConstructor ();
 			PropertyWithPublicConstructor = GetTypeWithPublicConstructors ();
 			PropertyWithPublicConstructor = GetTypeWithNonPublicConstructors ();
-			PropertyWithPublicConstructor = GetUnkownType ();
+			PropertyWithPublicConstructor = GetUnknownType ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (StaticPropertyWithPublicConstructor) + ".set", nameof (GetTypeWithPublicParameterlessConstructor))]
 		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (StaticPropertyWithPublicConstructor) + ".set", nameof (GetTypeWithNonPublicConstructors))]
-		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (StaticPropertyWithPublicConstructor) + ".set", nameof (GetUnkownType))]
+		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (StaticPropertyWithPublicConstructor) + ".set", nameof (GetUnknownType))]
 		private void WriteToStaticProperty ()
 		{
 			StaticPropertyWithPublicConstructor = GetTypeWithPublicParameterlessConstructor ();
 			StaticPropertyWithPublicConstructor = GetTypeWithPublicConstructors ();
 			StaticPropertyWithPublicConstructor = GetTypeWithNonPublicConstructors ();
-			StaticPropertyWithPublicConstructor = GetUnkownType ();
+			StaticPropertyWithPublicConstructor = GetUnknownType ();
 		}
 
 		[ExpectedWarning ("IL2072", nameof (PropertyDataFlow) + "." + nameof (StaticPropertyWithPublicConstructor) + ".set", nameof (GetTypeWithNonPublicConstructors))]
@@ -436,6 +437,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
+		class TestWriteToGetOnlyProperty
+		{
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+			public Type GetOnlyProperty { get; }
+
+			// Analyzer doesn't warn about compiler-generated backing field of property
+			[ExpectedWarning ("IL2074", nameof (TestWriteToGetOnlyProperty), nameof (GetUnknownType),
+				ProducedBy = ProducedBy.Trimmer)]
+			public TestWriteToGetOnlyProperty ()
+			{
+				GetOnlyProperty = GetUnknownType ();
+			}
+		}
+
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		private static Type GetTypeWithPublicParameterlessConstructor ()
 		{
@@ -454,7 +469,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			return null;
 		}
 
-		private static Type GetUnkownType ()
+		private static Type GetUnknownType ()
 		{
 			return null;
 		}


### PR DESCRIPTION
This fixes one of NREs encountered in https://github.com/dotnet/linker/issues/2718, where the analyzer failed to analyze an assignment to a get-only property. The linker will warn about the compiler-generated backing field in this case.

This fix just skips this case in the analyzer. It would be more correct to produce a warning because this represents a legitimate dataflow issue. The problem is that the analyzer has no insight into the compiler-generated backing field, as far as I know.

One option would be to produce a warning with the same code as the linker, but adjust the message so that it mentions the property instead of the backing field - it would require some changesto the DiagnosticId infrastructure since we would need slightly different messages for all of the warnings where a field assignment in the linker is seen as a property assignment in the analyzer. Or maybe we could ignore the discrepancy and just emit a warning with the same text, pretending that the property name is the name of the backing field. @vitek-karas curious about your opinion on this.