### PR TITLE
Fix handling of special intrinsics in analyzer

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using ILLink.RoslynAnalyzer.DataFlow;
@@ -29,7 +30,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 		// Limit tracking array values to 32 values for performance reasons.
 		// There are many arrays much longer than 32 elements in .NET,
 		// but the interesting ones for the linker are nearly always less than 32 elements.
-		private const int MaxTrackedArrayValues = 32;
+		const int MaxTrackedArrayValues = 32;
 
 		public TrimAnalysisVisitor (
 			LocalStateLattice<MultiValue, ValueSetLattice<SingleValue>> lattice,
@@ -259,12 +260,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 					break;
 
 				default:
-					if (!calledMethod.ReturnsVoid && calledMethod.ReturnType.IsTypeInterestingForDataflow ())
-						methodReturnValue = new MethodReturnValue (calledMethod);
-					else
-						methodReturnValue = TopValue;
-
-					break;
+					throw new InvalidOperationException ($"Unexpected method {calledMethod.GetDisplayName ()} unhandled by HandleCallAction.");
 				}
 			}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -169,6 +169,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task TypeDelegator ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task TypeHierarchyReflectionWarnings ()
 		{
 			// https://github.com/dotnet/linker/issues/2578

--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReflectionTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReflectionTests.g.cs
@@ -62,12 +62,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task TypeDelegator ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
 		public Task TypeHierarchyLibraryModeSuppressions ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeDelegator.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeDelegator.cs
@@ -7,9 +7,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
+	[ExpectedNoWarnings]
 	public class TypeDelegator
 	{
 		public static void Main ()
@@ -17,6 +19,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestTypeUsedWithDelegator ();
 			TestNullValue ();
 			TestNoValue ();
+			TestDataFlowPropagation ();
+			TestDataFlowOfUnannotated ();
 		}
 
 		[Kept]
@@ -38,7 +42,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static void TestNullValue ()
 		{
 			var typeDelegator = new System.Reflection.TypeDelegator (null);
-			RequireAll (typeDelegator);
+			typeDelegator.RequiresAll ();
 		}
 
 		[Kept]
@@ -47,15 +51,27 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Type t = null;
 			Type noValue = Type.GetTypeFromHandle (t.TypeHandle);
 			var typeDelegator = new System.Reflection.TypeDelegator (noValue);
-			RequireAll (typeDelegator);
+			typeDelegator.RequiresAll ();
 		}
 
 		[Kept]
-		public static void RequireAll (
+		[ExpectedWarning ("IL2067", nameof (DataFlowTypeExtensions.RequiresPublicFields))]
+		static void TestDataFlowPropagation (
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
-			System.Reflection.TypeDelegator t
-		)
-		{ }
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			Type typeWithPublicMethods = null)
+		{
+			var typeDelegator = new System.Reflection.TypeDelegator (typeWithPublicMethods);
+			typeDelegator.RequiresPublicMethods (); // Should not warn
+			typeDelegator.RequiresPublicFields (); // Should warn
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL2067", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
+		static void TestDataFlowOfUnannotated (Type unknownType = null)
+		{
+			var typeDelegator = new System.Reflection.TypeDelegator (unknownType);
+			unknownType.RequiresPublicMethods ();
+		}
 	}
 }


### PR DESCRIPTION
Some intrinsics require generic instantiation handling. Currently the shared code doesn't have the abitlity to do this, so we leave it as a special case and analyzer/linker have special code to handle it.
In the analyzer this code was missing from the diagnsotic reporting part and thus the intrinsic was handled as a normal method call - which caused problems with TypeDelegator.

Added tests for TypeDelegator which cover these issues.

This is blocking linker->runtime flow: https://github.com/dotnet/runtime/pull/68386