### PR TITLE
Share MakeGeneric.. and Expression.Call

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -42,6 +42,8 @@ namespace ILLink.RoslynAnalyzer
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersMismatchOnImplicitThisBetweenOverrides));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersConflictsBetweenPropertyAndAccessor));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.PropertyAccessorParameterInLinqExpressionsCannotBeStaticallyDetermined));
+			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericType));
+			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericMethod));
 			return diagDescriptorsArrayBuilder.ToImmutable ();
 
 			void AddRange (DiagnosticId first, DiagnosticId last)

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericParameterProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericParameterProxy.cs
@@ -9,6 +9,11 @@ namespace ILLink.Shared.TypeSystemProxy
 	{
 		public GenericParameterProxy (ITypeParameterSymbol typeParameterSymbol) => TypeParameterSymbol = typeParameterSymbol;
 
+		internal partial bool HasDefaultConstructorConstraint () =>
+			TypeParameterSymbol.HasConstructorConstraint |
+			TypeParameterSymbol.HasValueTypeConstraint |
+			TypeParameterSymbol.HasUnmanagedTypeConstraint;
+
 		public readonly ITypeParameterSymbol TypeParameterSymbol;
 
 		public override string ToString () => TypeParameterSymbol.ToString ();

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericParameterValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericParameterValue.cs
@@ -17,11 +17,6 @@ namespace ILLink.Shared.TrimAnalysis
 	{
 		public GenericParameterValue (ITypeParameterSymbol typeParameterSymbol) => GenericParameter = new (typeParameterSymbol);
 
-		public partial bool HasDefaultConstructorConstraint () =>
-			GenericParameter.TypeParameterSymbol.HasConstructorConstraint |
-			GenericParameter.TypeParameterSymbol.HasValueTypeConstraint |
-			GenericParameter.TypeParameterSymbol.HasUnmanagedTypeConstraint;
-
 		public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes => GenericParameter.TypeParameterSymbol.GetDynamicallyAccessedMemberTypes ();
 
 		public override IEnumerable<string> GetDiagnosticArgumentsForAnnotationMismatch ()

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodProxy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
 using ILLink.RoslynAnalyzer;
 using Microsoft.CodeAnalysis;
 
@@ -28,6 +29,19 @@ namespace ILLink.Shared.TypeSystemProxy
 		internal partial bool HasGenericParameters () => Method.IsGenericMethod;
 
 		internal partial bool HasGenericParametersCount (int genericParameterCount) => Method.TypeParameters.Length == genericParameterCount;
+
+		internal partial ImmutableArray<GenericParameterProxy> GetGenericParameters ()
+		{
+			if (Method.TypeParameters.IsEmpty)
+				return ImmutableArray<GenericParameterProxy>.Empty;
+
+			var builder = ImmutableArray.CreateBuilder<GenericParameterProxy> (Method.TypeParameters.Length);
+			foreach (var typeParameter in Method.TypeParameters) {
+				builder.Add (new GenericParameterProxy (typeParameter));
+			}
+
+			return builder.ToImmutableArray ();
+		}
 
 		internal partial bool IsStatic () => Method.IsStatic;
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
@@ -12,11 +12,19 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 
 namespace ILLink.RoslynAnalyzer.TrimAnalysis
 {
-	public readonly record struct TrimAnalysisAssignmentPattern (
-		MultiValue Source,
-		MultiValue Target,
-		IOperation Operation)
+	public readonly record struct TrimAnalysisAssignmentPattern
 	{
+		public MultiValue Source { init; get; }
+		public MultiValue Target { init; get; }
+		public IOperation Operation { init; get; }
+
+		public TrimAnalysisAssignmentPattern (MultiValue source, MultiValue target, IOperation operation)
+		{
+			Source = source.Clone ();
+			Target = target.Clone ();
+			Operation = operation;
+		}
+
 		public TrimAnalysisAssignmentPattern Merge (ValueSetLattice<SingleValue> lattice, TrimAnalysisAssignmentPattern other)
 		{
 			Debug.Assert (Operation == other.Operation);

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
@@ -13,13 +13,36 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 
 namespace ILLink.RoslynAnalyzer.TrimAnalysis
 {
-	public readonly record struct TrimAnalysisMethodCallPattern (
-		IMethodSymbol CalledMethod,
-		MultiValue Instance,
-		ImmutableArray<MultiValue> Arguments,
-		IOperation Operation,
-		ISymbol OwningSymbol)
+	public readonly record struct TrimAnalysisMethodCallPattern
 	{
+		public IMethodSymbol CalledMethod { init; get; }
+		public MultiValue Instance { init; get; }
+		public ImmutableArray<MultiValue> Arguments { init; get; }
+		public IOperation Operation { init; get; }
+		public ISymbol OwningSymbol { init; get; }
+
+		public TrimAnalysisMethodCallPattern (
+			IMethodSymbol calledMethod,
+			MultiValue instance,
+			ImmutableArray<MultiValue> arguments,
+			IOperation operation,
+			ISymbol owningSymbol)
+		{
+			CalledMethod = calledMethod;
+			Instance = instance.Clone ();
+			if (arguments.IsEmpty) {
+				Arguments = ImmutableArray<MultiValue>.Empty;
+			} else {
+				var builder = ImmutableArray.CreateBuilder<MultiValue> ();
+				foreach (var argument in arguments) {
+					builder.Add (argument.Clone ());
+				}
+				Arguments = builder.ToImmutableArray ();
+			}
+			Operation = operation;
+			OwningSymbol = owningSymbol;
+		}
+
 		public TrimAnalysisMethodCallPattern Merge (ValueSetLattice<SingleValue> lattice, TrimAnalysisMethodCallPattern other)
 		{
 			Debug.Assert (Operation == other.Operation);

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -191,6 +191,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			// TODO: consider not tracking patterns unless the target is something
 			// annotated with DAMT.
 			TrimAnalysisPatterns.Add (
+				// This will copy the values if necessary
 				new TrimAnalysisAssignmentPattern (source, target, operation),
 				isReturnValue: false
 			);
@@ -264,6 +265,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				}
 			}
 
+			// This will copy the values if necessary
 			TrimAnalysisPatterns.Add (new TrimAnalysisMethodCallPattern (
 				calledMethod,
 				instance,

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TypeProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TypeProxy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
 using ILLink.RoslynAnalyzer;
 using Microsoft.CodeAnalysis;
 
@@ -9,6 +10,20 @@ namespace ILLink.Shared.TypeSystemProxy
 	internal readonly partial struct TypeProxy
 	{
 		public TypeProxy (ITypeSymbol type) => Type = type;
+
+		internal partial ImmutableArray<GenericParameterProxy> GetGenericParameters ()
+		{
+			if (Type is not INamedTypeSymbol namedType ||
+				namedType.TypeParameters.IsEmpty)
+				return ImmutableArray<GenericParameterProxy>.Empty;
+
+			var builder = ImmutableArray.CreateBuilder<GenericParameterProxy> (namedType.TypeParameters.Length);
+			foreach (var typeParameter in namedType.TypeParameters) {
+				builder.Add (new GenericParameterProxy (typeParameter));
+			}
+
+			return builder.ToImmutableArray ();
+		}
 
 		public readonly ITypeSymbol Type;
 

--- a/src/ILLink.Shared/TrimAnalysis/GenericParameterValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/GenericParameterValue.cs
@@ -12,7 +12,5 @@ namespace ILLink.Shared.TrimAnalysis
 	sealed partial record GenericParameterValue : ValueWithDynamicallyAccessedMembers
 	{
 		public readonly GenericParameterProxy GenericParameter;
-
-		public partial bool HasDefaultConstructorConstraint ();
 	}
 }

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -799,7 +799,8 @@ namespace ILLink.Shared.TrimAnalysis
 						}
 						// We haven't found any generic parameters with annotations, so there's nothing to validate.
 					} else if (value == NullValue.Instance) {
-						// Do nothing - null value is valid and should not cause warnings nor marking
+						// At runtime this would throw - so it has no effect on analysis
+						AddReturnValue (MultiValueLattice.Top);
 					} else {
 						// We have no way to "include more" to fix this if we don't know, so we have to warn
 						_diagnosticContext.AddDiagnostic (DiagnosticId.MakeGenericType, calledMethod.GetDisplayName ());

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -671,49 +672,89 @@ namespace ILLink.Shared.TrimAnalysis
 				}
 				break;
 
+			//
+			// System.Type
+			//
+			// Type MakeGenericType (params Type[] typeArguments)
+			//
 			case IntrinsicId.Type_MakeGenericType:
 				if (instanceValue.IsEmpty () || argumentValues[0].IsEmpty ()) {
 					returnValue = MultiValueLattice.Top;
 					break;
 				}
 
-				// Contains part of the analysis done in the Linker, but is not complete
-				// instanceValue here is like argumentValues[0] in linker
 				foreach (var value in instanceValue) {
-					// Nullables without a type argument are considered SystemTypeValues
-					if (!(value is SystemTypeValue typeValue && typeValue.RepresentedType.IsTypeOf (WellKnownType.System_Nullable_T))) {
-						// We still don't want to lose track of the type if it is not Nullable<T>
-						AddReturnValue (value);
-						continue;
-					}
-					// We have a nullable
-					foreach (var argumentValue in argumentValues[0]) {
-						if ((argumentValue as ArrayValue)?.TryGetValueByIndex (0, out var underlyingMultiValue) != true) {
-							continue;
-						}
-						foreach (var underlyingValue in underlyingMultiValue) {
-							switch (underlyingValue) {
-							// Don't warn on these types - it will throw instead
-							case NullableValueWithDynamicallyAccessedMembers:
-							case NullableSystemTypeValue:
-							case SystemTypeValue maybeArrayValue when maybeArrayValue.RepresentedType.IsTypeOf (WellKnownType.System_Array):
-								AddReturnValue (MultiValueLattice.Top);
-								break;
-							case SystemTypeValue systemTypeValue:
-								AddReturnValue (new NullableSystemTypeValue (typeValue.RepresentedType, new SystemTypeValue (systemTypeValue.RepresentedType)));
-								break;
-							// Generic Parameters and method parameters with annotations
-							case ValueWithDynamicallyAccessedMembers damValue:
-								AddReturnValue (new NullableValueWithDynamicallyAccessedMembers (typeValue.RepresentedType, damValue));
-								break;
-							// Everything else assume it has no annotations
-							default:
-								AddReturnValue (GetMethodReturnValue (calledMethod, returnValueDynamicallyAccessedMemberTypes));
-								break;
+					if (value is SystemTypeValue typeValue) {
+						var genericParameterValues = GetGenericParameterValues (typeValue.RepresentedType.GetGenericParameters ());
+						if (!AnalyzeGenericInstantiationTypeArray (argumentValues[0], calledMethod, genericParameterValues)) {
+							bool hasUncheckedAnnotation = false;
+							foreach (var genericParameter in genericParameterValues) {
+								if (genericParameter.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None ||
+									(genericParameter.GenericParameter.HasDefaultConstructorConstraint () && !typeValue.RepresentedType.IsTypeOf ("System", "Nullable`1"))) {
+									// If we failed to analyze the array, we go through the analyses again
+									// and intentionally ignore one particular annotation:
+									// Special case: Nullable<T> where T : struct
+									//  The struct constraint in C# implies new() constraints, but Nullable doesn't make a use of that part.
+									//  There are several places even in the framework where typeof(Nullable<>).MakeGenericType would warn
+									//  without any good reason to do so.
+									hasUncheckedAnnotation = true;
+									break;
+								}
+							}
+							if (hasUncheckedAnnotation) {
+								_diagnosticContext.AddDiagnostic (DiagnosticId.MakeGenericType, calledMethod.GetDisplayName ());
 							}
 						}
+
+						// Nullables without a type argument are considered SystemTypeValues
+						if (typeValue.RepresentedType.IsTypeOf ("System", "Nullable`1")) {
+							foreach (var argumentValue in argumentValues[0]) {
+								if ((argumentValue as ArrayValue)?.TryGetValueByIndex (0, out var underlyingMultiValue) == true) {
+									foreach (var underlyingValue in underlyingMultiValue) {
+										switch (underlyingValue) {
+										// Don't warn on these types - it will throw instead
+										case NullableValueWithDynamicallyAccessedMembers:
+										case NullableSystemTypeValue:
+										case SystemTypeValue maybeArrayValue when maybeArrayValue.RepresentedType.IsTypeOf ("System", "Array"):
+											AddReturnValue (MultiValueLattice.Top);
+											break;
+										case SystemTypeValue systemTypeValue:
+											AddReturnValue (new NullableSystemTypeValue (typeValue.RepresentedType, new SystemTypeValue (systemTypeValue.RepresentedType)));
+											break;
+										// Generic Parameters and method parameters with annotations
+										case ValueWithDynamicallyAccessedMembers damValue:
+											AddReturnValue (new NullableValueWithDynamicallyAccessedMembers (typeValue.RepresentedType, damValue));
+											break;
+										// Everything else assume it has no annotations
+										default:
+											// TODO: This is weird - why not just propagate the input value??? we do that even if we don't understand
+											// since we don't want to loose track of the type
+											AddReturnValue (GetMethodReturnValue (calledMethod, returnValueDynamicallyAccessedMemberTypes));
+											break;
+										}
+									}
+								} else {
+									// TODO: This needs to set a return value! If there are two array values,
+									// the first one recognized we will handle it below and set a return value.
+									// The second one unrecognized and thus not an ArrayValue - we would add nothing
+									// but that needs to return unannotated value so that subsequent usage warns.
+								}
+							}
+							// We want to skip adding the `value` to the return Value because we have already added Nullable<value>
+							continue;
+						}
 						// We haven't found any generic parameters with annotations, so there's nothing to validate.
+					} else if (value == NullValue.Instance) {
+						// Do nothing - null value is valid and should not cause warnings nor marking
+					} else {
+						// We have no way to "include more" to fix this if we don't know, so we have to warn
+						_diagnosticContext.AddDiagnostic (DiagnosticId.MakeGenericType, calledMethod.GetDisplayName ());
 					}
+
+					// We don't want to lose track of the type
+					// in case this is e.g. Activator.CreateInstance(typeof(Foo<>).MakeGenericType(...));
+					// Note this is not called in the Nullable case - we skipt this via the 'continue'.
+					AddReturnValue (value);
 				}
 				break;
 
@@ -822,6 +863,34 @@ namespace ILLink.Shared.TrimAnalysis
 				}
 				break;
 
+			//
+			// System.Reflection.MethodInfo
+			//
+			// MakeGenericMethod (Type[] typeArguments)
+			//
+			case IntrinsicId.MethodInfo_MakeGenericMethod: {
+					if (instanceValue.IsEmpty ()) {
+						returnValue = MultiValueLattice.Top;
+						break;
+					}
+
+					foreach (var methodValue in instanceValue) {
+						if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
+							ValidateGenericMethodInstantiation (methodBaseValue.RepresentedMethod, argumentValues[0], calledMethod);
+						} else if (methodValue == NullValue.Instance) {
+							// Nothing to do
+						} else {
+							// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
+							// that the method may have requirements which we can't fullfil -> warn.
+							_diagnosticContext.AddDiagnostic (DiagnosticId.MakeGenericMethod, calledMethod.GetDisplayName ());
+						}
+					}
+
+					// MakeGenericMethod doesn't change the identity of the MethodBase we're tracking so propagate to the return value
+					AddReturnValue (instanceValue);
+				}
+				break;
+
 			case IntrinsicId.None:
 				// Verify the argument values match the annotations on the parameter definition
 				if (requiresDataFlowAnalysis) {
@@ -891,6 +960,82 @@ namespace ILLink.Shared.TrimAnalysis
 			// "unknown" and consumers may warn.
 			if (!foundAny)
 				yield return NullValue.Instance;
+		}
+
+		bool AnalyzeGenericInstantiationTypeArray (in MultiValue arrayParam, in MethodProxy calledMethod, ImmutableArray<GenericParameterValue> genericParameters)
+		{
+			bool hasRequirements = false;
+			foreach (var genericParameter in genericParameters) {
+				if (genericParameter.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None) {
+					hasRequirements = true;
+					break;
+				}
+			}
+
+			// If there are no requirements, then there's no point in warning
+			if (!hasRequirements)
+				return true;
+
+			foreach (var typesValue in arrayParam) {
+				if (typesValue is not ArrayValue array) {
+					return false;
+				}
+
+				int? size = array.Size.AsConstInt ();
+				if (size == null || size != genericParameters.Length) {
+					return false;
+				}
+
+				bool allIndicesKnown = true;
+				for (int i = 0; i < size.Value; i++) {
+					if (!array.TryGetValueByIndex (i, out MultiValue value) || value.AsSingleValue () is UnknownValue) {
+						allIndicesKnown = false;
+						break;
+					}
+				}
+
+				if (!allIndicesKnown) {
+					return false;
+				}
+
+				for (int i = 0; i < size.Value; i++) {
+					if (array.TryGetValueByIndex (i, out MultiValue value)) {
+						// https://github.com/dotnet/linker/issues/2428
+						// We need to report the target as "this" - as that was the previous behavior
+						// but with the annotation from the generic parameter.
+						var targetValue = GetMethodThisParameterValue (calledMethod, genericParameters[i].DynamicallyAccessedMemberTypes);
+						_requireDynamicallyAccessedMembersAction.Invoke (value, targetValue);
+					}
+				}
+			}
+			return true;
+		}
+
+		void ValidateGenericMethodInstantiation (
+			MethodProxy genericMethod,
+			in MultiValue genericParametersArray,
+			MethodProxy reflectionMethod)
+		{
+			if (!genericMethod.HasGenericParameters ()) {
+				return;
+			}
+
+			var genericParameterValues = GetGenericParameterValues (genericMethod.GetGenericParameters ());
+			if (!AnalyzeGenericInstantiationTypeArray (genericParametersArray, reflectionMethod, genericParameterValues)) {
+				_diagnosticContext.AddDiagnostic (DiagnosticId.MakeGenericMethod, reflectionMethod.GetDisplayName ());
+			}
+		}
+
+		ImmutableArray<GenericParameterValue> GetGenericParameterValues(ImmutableArray<GenericParameterProxy> genericParameters)
+		{
+			if (genericParameters.IsEmpty)
+				return ImmutableArray<GenericParameterValue>.Empty;
+
+			var builder = ImmutableArray.CreateBuilder<GenericParameterValue> (genericParameters.Length);
+			foreach (var genericParameter in genericParameters) {
+				builder.Add (GetGenericParameterValue (genericParameter));
+			}
+			return builder.ToImmutableArray ();
 		}
 
 		internal static BindingFlags? GetBindingFlagsFromValue (in MultiValue parameter) => (BindingFlags?) parameter.AsConstInt ();

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -716,7 +716,7 @@ namespace ILLink.Shared.TrimAnalysis
 							systemType.RepresentedType.IsTypeOf ("System", "Nullable`1")
 								// This will happen if there's typeof(Nullable<>).MakeGenericType(unknown) - we know the return value is Nullable<>
 								// but we don't know of what. So we represent it as known type, but not as known nullable type.
-								// Has to be special cases here, since we need to return "unknown" type.
+								// Has to be special cased here, since we need to return "unknown" type.
 								? GetMethodReturnValue (calledMethod, returnValueDynamicallyAccessedMemberTypes)
 								: MultiValueLattice.Top, // This returns null at runtime, so return empty value
 						NullableSystemTypeValue nullableSystemType => nullableSystemType.UnderlyingTypeValue,

--- a/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -23,7 +23,7 @@ namespace ILLink.Shared.TrimAnalysis
 			foreach (var uniqueValue in value) {
 				if (targetValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
 					&& uniqueValue is GenericParameterValue genericParam
-					&& genericParam.HasDefaultConstructorConstraint ()) {
+					&& genericParam.GenericParameter.HasDefaultConstructorConstraint ()) {
 					// We allow a new() constraint on a generic parameter to satisfy DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
 				} else if (uniqueValue is ValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers) {
 					if (uniqueValue is NullableValueWithDynamicallyAccessedMembers nullableValue) {

--- a/src/ILLink.Shared/TypeSystemProxy/GenericParameterProxy.cs
+++ b/src/ILLink.Shared/TypeSystemProxy/GenericParameterProxy.cs
@@ -5,5 +5,6 @@ namespace ILLink.Shared.TypeSystemProxy
 {
 	internal readonly partial struct GenericParameterProxy
 	{
+		internal partial bool HasDefaultConstructorConstraint ();
 	}
 }

--- a/src/ILLink.Shared/TypeSystemProxy/MethodProxy.cs
+++ b/src/ILLink.Shared/TypeSystemProxy/MethodProxy.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
+
 namespace ILLink.Shared.TypeSystemProxy
 {
 	internal readonly partial struct MethodProxy : IMemberProxy
@@ -16,6 +18,7 @@ namespace ILLink.Shared.TypeSystemProxy
 		internal partial bool HasParameterOfType (int parameterIndex, string fullTypeName);
 		internal partial bool HasGenericParameters ();
 		internal partial bool HasGenericParametersCount (int genericParameterCount);
+		internal partial ImmutableArray<GenericParameterProxy> GetGenericParameters ();
 		internal partial bool IsStatic ();
 		internal partial bool ReturnsVoid ();
 	}

--- a/src/ILLink.Shared/TypeSystemProxy/TypeProxy.cs
+++ b/src/ILLink.Shared/TypeSystemProxy/TypeProxy.cs
@@ -1,9 +1,12 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
+
 namespace ILLink.Shared.TypeSystemProxy
 {
 	internal readonly partial struct TypeProxy : IMemberProxy
 	{
+		internal partial ImmutableArray<GenericParameterProxy> GetGenericParameters ();
 	}
 }

--- a/src/linker/Linker.Dataflow/GenericParameterProxy.cs
+++ b/src/linker/Linker.Dataflow/GenericParameterProxy.cs
@@ -11,6 +11,8 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		public static implicit operator GenericParameterProxy (GenericParameter genericParameter) => new (genericParameter);
 
+		internal partial bool HasDefaultConstructorConstraint () => GenericParameter.HasDefaultConstructorConstraint;
+
 		public readonly GenericParameter GenericParameter;
 
 		public override string ToString () => GenericParameter.ToString ();

--- a/src/linker/Linker.Dataflow/GenericParameterValue.cs
+++ b/src/linker/Linker.Dataflow/GenericParameterValue.cs
@@ -21,8 +21,6 @@ namespace ILLink.Shared.TrimAnalysis
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 		}
 
-		public partial bool HasDefaultConstructorConstraint () => GenericParameter.GenericParameter.HasDefaultConstructorConstraint;
-
 		public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes { get; }
 
 		public override IEnumerable<string> GetDiagnosticArgumentsForAnnotationMismatch ()

--- a/src/linker/Linker.Dataflow/MethodProxy.cs
+++ b/src/linker/Linker.Dataflow/MethodProxy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
 using Mono.Cecil;
 using Mono.Linker;
 
@@ -29,6 +30,19 @@ namespace ILLink.Shared.TypeSystemProxy
 		internal partial bool HasGenericParameters () => Method.HasGenericParameters;
 
 		internal partial bool HasGenericParametersCount (int genericParameterCount) => Method.GenericParameters.Count == genericParameterCount;
+
+		internal partial ImmutableArray<GenericParameterProxy> GetGenericParameters ()
+		{
+			if (!Method.HasGenericParameters)
+				return ImmutableArray<GenericParameterProxy>.Empty;
+
+			var builder = ImmutableArray.CreateBuilder<GenericParameterProxy> (Method.GenericParameters.Count);
+			foreach (var genericParameter in Method.GenericParameters) {
+				builder.Add (new GenericParameterProxy (genericParameter));
+			}
+
+			return builder.ToImmutableArray ();
+		}
 
 		internal partial bool IsStatic () => Method.IsStatic;
 

--- a/src/linker/Linker.Dataflow/TypeProxy.cs
+++ b/src/linker/Linker.Dataflow/TypeProxy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
 using Mono.Cecil;
 using Mono.Linker;
 
@@ -11,6 +12,19 @@ namespace ILLink.Shared.TypeSystemProxy
 		public TypeProxy (TypeDefinition type) => Type = type;
 
 		public static implicit operator TypeProxy (TypeDefinition type) => new (type);
+
+		internal partial ImmutableArray<GenericParameterProxy> GetGenericParameters ()
+		{
+			if (!Type.HasGenericParameters)
+				return ImmutableArray<GenericParameterProxy>.Empty;
+
+			var builder = ImmutableArray.CreateBuilder<GenericParameterProxy> (Type.GenericParameters.Count);
+			foreach (var genericParameter in Type.GenericParameters) {
+				builder.Add(new GenericParameterProxy (genericParameter));
+			}
+
+			return builder.ToImmutableArray ();
+		}
 
 		public TypeDefinition Type { get; }
 

--- a/src/linker/Linker.Dataflow/TypeProxy.cs
+++ b/src/linker/Linker.Dataflow/TypeProxy.cs
@@ -20,7 +20,7 @@ namespace ILLink.Shared.TypeSystemProxy
 
 			var builder = ImmutableArray.CreateBuilder<GenericParameterProxy> (Type.GenericParameters.Count);
 			foreach (var genericParameter in Type.GenericParameters) {
-				builder.Add(new GenericParameterProxy (genericParameter));
+				builder.Add (new GenericParameterProxy (genericParameter));
 			}
 
 			return builder.ToImmutableArray ();

--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -92,8 +92,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task MakeGenericDataFlow ()
 		{
-			// https://github.com/dotnet/linker/issues/2273
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -49,8 +49,13 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task ExpressionCallString ()
 		{
-			// https://github.com/dotnet/linker/issues/2578
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task ExpressionCallStringAndLocals ()
+		{
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReflectionTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReflectionTests.g.cs
@@ -38,12 +38,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task ExpressionCallStringAndLocals ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
 		public Task ObjectGetTypeLibraryMode ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -608,9 +608,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedGenerics).RequiresPublicMethods ();
 			}
 
-			// Intrinsic is disabled https://github.com/dotnet/linker/issues/2559
 			// This should produce IL2071 https://github.com/dotnet/linker/issues/2144
-			[ExpectedWarning ("IL2070", "MakeGenericMethod", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2070", "MakeGenericMethod")]
 			static void InstantiateGeneric (Type type = null)
 			{
 				// This should warn due to MakeGenericMethod - in this case the generic parameter is unannotated type

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
@@ -82,7 +82,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				inputType.MakeGenericType (typeof (TestType));
 			}
 
-			[ExpectedWarning ("IL2055", nameof (Type.MakeGenericType))]
+			// https://github.com/dotnet/linker/issues/2755
+			[ExpectedWarning ("IL2055", nameof (Type.MakeGenericType), ProducedBy = ProducedBy.Trimmer)]
 			static void TestWithUnknownTypeArray (Type[] types)
 			{
 				typeof (GenericWithPublicFieldsArgument<>).MakeGenericType (types);
@@ -96,7 +97,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (GenericWithPublicFieldsArgument<>).MakeGenericType (types);
 			}
 
-			[ExpectedWarning ("IL2055", nameof (Type.MakeGenericType))]
+			// https://github.com/dotnet/linker/issues/2755
+			[ExpectedWarning ("IL2055", nameof (Type.MakeGenericType), ProducedBy = ProducedBy.Trimmer)]
 			static void TestWithArrayUnknownLengthSet (int arrayLen)
 			{
 				Type[] types = new Type[arrayLen];
@@ -331,13 +333,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (TestType).GetRuntimeMethod ("NoSuchMethod", new Type[] { }).MakeGenericMethod (unknownType);
 			}
 
-			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]
+			// https://github.com/dotnet/linker/issues/2755
+			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod), ProducedBy = ProducedBy.Trimmer)]
 			static void TestUnknownMethod (MethodInfo mi)
 			{
 				mi.MakeGenericMethod (typeof (TestType));
 			}
 
-			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]
+			// https://github.com/dotnet/linker/issues/2755
+			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod), ProducedBy = ProducedBy.Trimmer)]
 			static void TestUnknownMethodButNoTypeArguments (MethodInfo mi)
 			{
 				// Thechnically linker could figure this out, but it's not worth the complexity - such call will always fail at runtime.
@@ -447,7 +451,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					.MakeGenericMethod (noValue);
 			}
 
-			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]
+			// https://github.com/dotnet/linker/issues/2755
+			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod), ProducedBy = ProducedBy.Trimmer)]
 			static void TestWithUnknownTypeArray (Type[] types)
 			{
 				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static)
@@ -463,7 +468,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					.MakeGenericMethod (types);
 			}
 
-			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]
+			// https://github.com/dotnet/linker/issues/2158 - analyzer doesn't work the same as linker, it simply doesn't handle refs
+			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod), ProducedBy = ProducedBy.Trimmer)]
 			static void TestWithArrayUnknownIndexSetByRef (int indexToSet)
 			{
 				Type[] types = new Type[1];
@@ -474,7 +480,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					.MakeGenericMethod (types);
 			}
 
-			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]
+			// https://github.com/dotnet/linker/issues/2755
+			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod), ProducedBy = ProducedBy.Trimmer)]
 			static void TestWithArrayUnknownLengthSet (int arrayLen)
 			{
 				Type[] types = new Type[arrayLen];

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -284,7 +284,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			[ExpectedWarning ("IL2060", "Expression.Call")]
+			// https://github.com/dotnet/linker/issues/2755
+			[ExpectedWarning ("IL2060", "Expression.Call", ProducedBy = ProducedBy.Trimmer)]
 			static void TestMethodWithRequirementsUnknownTypeArray (Type[] types)
 			{
 				// The passed in types array cannot be analyzed, so a warning is produced.
@@ -358,6 +359,32 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
+			[KeptMember (".cctor()")]
+			class TwoKnownTypeArrays
+			{
+				[Kept]
+				public static void GenericMethodWithRequirements<
+					[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
+				{ }
+
+				[Kept]
+				static string _unknownMethodName = "NoMethod";
+
+				[Kept]
+				[ExpectedWarning ("IL2060", "Expression.Call")]
+				public static void Test (int p = 0)
+				{
+					Type[] types = p switch {
+						0 => new Type[] { typeof (TestType) },
+						1 => new Type[] { typeof (TestType) }
+					};
+
+					Expression.Call (typeof (TwoKnownTypeArrays), _unknownMethodName, types);
+				}
+			}
+
+			[Kept]
 			public static void Test ()
 			{
 				TestWithNoTypeParameters ();
@@ -369,6 +396,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				UnknownMethodWithRequirements.TestWithoutTypeParameters ();
 				UnknownTypeWithRequirements.TestWithTypeParameters ();
 				UnknownTypeWithRequirements.TestWithoutTypeParameters ();
+				TwoKnownTypeArrays.Test ();
 			}
 
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallStringAndLocals.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallStringAndLocals.cs
@@ -6,6 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Reflection
 {
 	[Reference ("System.Core.dll")]
+	[ExpectedNoWarnings]
 	public class ExpressionCallStringAndLocals
 	{
 		public static void Main ()


### PR DESCRIPTION
Moves the intrinsic handling of `MakeGenericType`, `MakeGenericMethod` and `Expression.Call` into the shared code.

Other changes:
* Some small refactorings on the shared type system and value system.
* Expose generic parameters on type system proxies
* Fix a bug in analyzer when we're recording patterns, the values must be cloned (as they can mutate during analysis after the record is taken)
* Fix some problems in Nullable<T> handling in MakeGenericType - specifically if we don't know what the T is going to be, we now return just Nullable<> known type (but unknown T).
* Add couple new tests - update existing ones (mainly due to limitation in the analyzer)