### PR TITLE
Factor ReflectionMethodBodyScanner to be more similar to analyzer

### DIFF
--- a/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -15,24 +15,24 @@ namespace ILLink.Shared.TrimAnalysis
 #pragma warning disable CA1822 // Mark members as static - the other partial implementations might need to be instance methods
 
 		readonly LinkContext _context;
-		readonly ReflectionMethodBodyScanner _reflectionMethodBodyScanner;
+		readonly ReflectionMarker _reflectionMarker;
 		readonly MessageOrigin _origin;
 		readonly MethodDefinition _callingMethodDefinition;
 
 		public HandleCallAction (
 			LinkContext context,
-			ReflectionMethodBodyScanner reflectionMethodBodyScanner,
+			ReflectionMarker reflectionMarker,
 			in MessageOrigin origin,
 			bool diagnosticsEnabled,
 			MethodDefinition callingMethodDefinition)
 		{
 			_context = context;
-			_reflectionMethodBodyScanner = reflectionMethodBodyScanner;
+			_reflectionMarker = reflectionMarker;
 			_origin = origin;
 			_callingMethodDefinition = callingMethodDefinition;
 			_diagnosticContext = new DiagnosticContext (origin, diagnosticsEnabled, context);
 			_annotations = context.Annotations.FlowAnnotations;
-			_requireDynamicallyAccessedMembersAction = new (context, reflectionMethodBodyScanner, origin, diagnosticsEnabled);
+			_requireDynamicallyAccessedMembersAction = new (context, reflectionMarker, origin, diagnosticsEnabled);
 		}
 
 		private partial bool MethodIsTypeConstructor (MethodProxy method)
@@ -72,33 +72,33 @@ namespace ILLink.Shared.TrimAnalysis
 		}
 
 		private partial void MarkStaticConstructor (TypeProxy type)
-			=> _reflectionMethodBodyScanner.MarkStaticConstructor (_origin, type.Type);
+			=> _reflectionMarker.MarkStaticConstructor (_origin, type.Type);
 
 		private partial void MarkEventsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
-			=> _reflectionMethodBodyScanner.MarkEventsOnTypeHierarchy (_origin, type.Type, e => e.Name == name, bindingFlags);
+			=> _reflectionMarker.MarkEventsOnTypeHierarchy (_origin, type.Type, e => e.Name == name, bindingFlags);
 
 		private partial void MarkFieldsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
-			=> _reflectionMethodBodyScanner.MarkFieldsOnTypeHierarchy (_origin, type.Type, f => f.Name == name, bindingFlags);
+			=> _reflectionMarker.MarkFieldsOnTypeHierarchy (_origin, type.Type, f => f.Name == name, bindingFlags);
 
 		private partial void MarkPropertiesOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
-			=> _reflectionMethodBodyScanner.MarkPropertiesOnTypeHierarchy (_origin, type.Type, p => p.Name == name, bindingFlags);
+			=> _reflectionMarker.MarkPropertiesOnTypeHierarchy (_origin, type.Type, p => p.Name == name, bindingFlags);
 
 		private partial void MarkPublicParameterlessConstructorOnType (TypeProxy type)
-			=> _reflectionMethodBodyScanner.MarkConstructorsOnType (_origin, type.Type, m => m.IsPublic && m.Parameters.Count == 0);
+			=> _reflectionMarker.MarkConstructorsOnType (_origin, type.Type, m => m.IsPublic && m.Parameters.Count == 0);
 
 		private partial void MarkConstructorsOnType (TypeProxy type, BindingFlags? bindingFlags)
-			=> _reflectionMethodBodyScanner.MarkConstructorsOnType (_origin, type.Type, null, bindingFlags);
+			=> _reflectionMarker.MarkConstructorsOnType (_origin, type.Type, null, bindingFlags);
 
 		private partial void MarkMethod (MethodProxy method)
-			=> _reflectionMethodBodyScanner.MarkMethod (_origin, method.Method);
+			=> _reflectionMarker.MarkMethod (_origin, method.Method);
 
 		private partial void MarkType (TypeProxy type)
-			=> _reflectionMethodBodyScanner.MarkType (_origin, type.Type);
+			=> _reflectionMarker.MarkType (_origin, type.Type);
 
 		private partial bool MarkAssociatedProperty (MethodProxy method)
 		{
 			if (method.Method.TryGetProperty (out PropertyDefinition? propertyDefinition)) {
-				_reflectionMethodBodyScanner.MarkProperty (_origin, propertyDefinition);
+				_reflectionMarker.MarkProperty (_origin, propertyDefinition);
 				return true;
 			}
 

--- a/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -22,17 +22,16 @@ namespace ILLink.Shared.TrimAnalysis
 		public HandleCallAction (
 			LinkContext context,
 			ReflectionMarker reflectionMarker,
-			in MessageOrigin origin,
-			bool diagnosticsEnabled,
+			in DiagnosticContext diagnosticContext,
 			MethodDefinition callingMethodDefinition)
 		{
 			_context = context;
 			_reflectionMarker = reflectionMarker;
-			_origin = origin;
+			_diagnosticContext = diagnosticContext;
+			_origin = diagnosticContext.Origin;
 			_callingMethodDefinition = callingMethodDefinition;
-			_diagnosticContext = new DiagnosticContext (origin, diagnosticsEnabled, context);
 			_annotations = context.Annotations.FlowAnnotations;
-			_requireDynamicallyAccessedMembersAction = new (context, reflectionMarker, origin, diagnosticsEnabled);
+			_requireDynamicallyAccessedMembersAction = new (context, reflectionMarker, diagnosticContext);
 		}
 
 		private partial bool MethodIsTypeConstructor (MethodProxy method)

--- a/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -16,7 +16,6 @@ namespace ILLink.Shared.TrimAnalysis
 
 		readonly LinkContext _context;
 		readonly ReflectionMarker _reflectionMarker;
-		readonly MessageOrigin _origin;
 		readonly MethodDefinition _callingMethodDefinition;
 
 		public HandleCallAction (
@@ -28,7 +27,6 @@ namespace ILLink.Shared.TrimAnalysis
 			_context = context;
 			_reflectionMarker = reflectionMarker;
 			_diagnosticContext = diagnosticContext;
-			_origin = diagnosticContext.Origin;
 			_callingMethodDefinition = callingMethodDefinition;
 			_annotations = context.Annotations.FlowAnnotations;
 			_requireDynamicallyAccessedMembersAction = new (context, reflectionMarker, diagnosticContext);
@@ -71,33 +69,33 @@ namespace ILLink.Shared.TrimAnalysis
 		}
 
 		private partial void MarkStaticConstructor (TypeProxy type)
-			=> _reflectionMarker.MarkStaticConstructor (_origin, type.Type);
+			=> _reflectionMarker.MarkStaticConstructor (_diagnosticContext.Origin, type.Type);
 
 		private partial void MarkEventsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
-			=> _reflectionMarker.MarkEventsOnTypeHierarchy (_origin, type.Type, e => e.Name == name, bindingFlags);
+			=> _reflectionMarker.MarkEventsOnTypeHierarchy (_diagnosticContext.Origin, type.Type, e => e.Name == name, bindingFlags);
 
 		private partial void MarkFieldsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
-			=> _reflectionMarker.MarkFieldsOnTypeHierarchy (_origin, type.Type, f => f.Name == name, bindingFlags);
+			=> _reflectionMarker.MarkFieldsOnTypeHierarchy (_diagnosticContext.Origin, type.Type, f => f.Name == name, bindingFlags);
 
 		private partial void MarkPropertiesOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)
-			=> _reflectionMarker.MarkPropertiesOnTypeHierarchy (_origin, type.Type, p => p.Name == name, bindingFlags);
+			=> _reflectionMarker.MarkPropertiesOnTypeHierarchy (_diagnosticContext.Origin, type.Type, p => p.Name == name, bindingFlags);
 
 		private partial void MarkPublicParameterlessConstructorOnType (TypeProxy type)
-			=> _reflectionMarker.MarkConstructorsOnType (_origin, type.Type, m => m.IsPublic && m.Parameters.Count == 0);
+			=> _reflectionMarker.MarkConstructorsOnType (_diagnosticContext.Origin, type.Type, m => m.IsPublic && m.Parameters.Count == 0);
 
 		private partial void MarkConstructorsOnType (TypeProxy type, BindingFlags? bindingFlags)
-			=> _reflectionMarker.MarkConstructorsOnType (_origin, type.Type, null, bindingFlags);
+			=> _reflectionMarker.MarkConstructorsOnType (_diagnosticContext.Origin, type.Type, null, bindingFlags);
 
 		private partial void MarkMethod (MethodProxy method)
-			=> _reflectionMarker.MarkMethod (_origin, method.Method);
+			=> _reflectionMarker.MarkMethod (_diagnosticContext.Origin, method.Method);
 
 		private partial void MarkType (TypeProxy type)
-			=> _reflectionMarker.MarkType (_origin, type.Type);
+			=> _reflectionMarker.MarkType (_diagnosticContext.Origin, type.Type);
 
 		private partial bool MarkAssociatedProperty (MethodProxy method)
 		{
 			if (method.Method.TryGetProperty (out PropertyDefinition? propertyDefinition)) {
-				_reflectionMarker.MarkProperty (_origin, propertyDefinition);
+				_reflectionMarker.MarkProperty (_diagnosticContext.Origin, propertyDefinition);
 				return true;
 			}
 

--- a/src/linker/Linker.Dataflow/ReflectionMarker.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMarker.cs
@@ -51,12 +51,12 @@ namespace Mono.Linker.Dataflow
 			// Only difference here is whether we treat arrays specially. Maybe we should do that more frequently elsewhere too.
 			// _reflectionMarker.MarkType (origin, );
 			if (!_context.TypeNameResolver.TryResolveTypeName (typeName, origin.Provider, out TypeReference? typeRef, out AssemblyDefinition? typeAssembly)
-				|| ReflectionMethodBodyScanner.ResolveToTypeDefinition (_context, typeRef) is not TypeDefinition foundType) {
+				|| typeRef.ResolveToTypeDefinition (_context) is not TypeDefinition foundType) {
 				type = default;
 				return false;
 
 			}
-			
+
 			_markStep.MarkTypeVisibleToReflection (typeRef, foundType, new DependencyInfo (DependencyKind.AccessedViaReflection, origin.Provider), origin);
 			_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType), origin);
 

--- a/src/linker/Linker.Dataflow/ReflectionMarker.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMarker.cs
@@ -1,0 +1,109 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Mono.Cecil;
+using Mono.Linker.Steps;
+
+namespace Mono.Linker.Dataflow
+{
+	public readonly struct ReflectionMarker
+	{
+		readonly LinkContext _context;
+		readonly MarkStep _markStep;
+
+		public ReflectionMarker (LinkContext context, MarkStep markStep)
+		{
+			_context = context;
+			_markStep = markStep;
+		}
+
+		internal void MarkTypeForDynamicallyAccessedMembers (in MessageOrigin origin, TypeDefinition typeDefinition, DynamicallyAccessedMemberTypes requiredMemberTypes, DependencyKind dependencyKind, bool declaredOnly = false)
+		{
+			foreach (var member in typeDefinition.GetDynamicallyAccessedMembers (_context, requiredMemberTypes, declaredOnly)) {
+				switch (member) {
+				case MethodDefinition method:
+					MarkMethod (origin, method, dependencyKind);
+					break;
+				case FieldDefinition field:
+					MarkField (origin, field, dependencyKind);
+					break;
+				case TypeDefinition nestedType:
+					MarkType (origin, nestedType, dependencyKind);
+					break;
+				case PropertyDefinition property:
+					MarkProperty (origin, property, dependencyKind);
+					break;
+				case EventDefinition @event:
+					MarkEvent (origin, @event, dependencyKind);
+					break;
+				case InterfaceImplementation interfaceImplementation:
+					MarkInterfaceImplementation (origin, interfaceImplementation, dependencyKind);
+					break;
+				}
+			}
+		}
+
+		internal void MarkType (in MessageOrigin origin, TypeReference typeReference, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		{
+			if (_context.TryResolve (typeReference) is TypeDefinition type)
+				_markStep.MarkTypeVisibleToReflection (typeReference, type, new DependencyInfo (dependencyKind, origin.Provider), origin);
+		}
+
+		internal void MarkMethod (in MessageOrigin origin, MethodDefinition method, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		{
+			_markStep.MarkMethodVisibleToReflection (method, new DependencyInfo (dependencyKind, origin.Provider), origin);
+		}
+
+		void MarkField (in MessageOrigin origin, FieldDefinition field, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		{
+			_markStep.MarkFieldVisibleToReflection (field, new DependencyInfo (dependencyKind, origin.Provider), origin);
+		}
+
+		internal void MarkProperty (in MessageOrigin origin, PropertyDefinition property, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		{
+			_markStep.MarkPropertyVisibleToReflection (property, new DependencyInfo (dependencyKind, origin.Provider), origin);
+		}
+
+		void MarkEvent (in MessageOrigin origin, EventDefinition @event, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		{
+			_markStep.MarkEventVisibleToReflection (@event, new DependencyInfo (dependencyKind, origin.Provider), origin);
+		}
+
+		void MarkInterfaceImplementation (in MessageOrigin origin, InterfaceImplementation interfaceImplementation, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		{
+			_markStep.MarkInterfaceImplementation (interfaceImplementation, null, new DependencyInfo (dependencyKind, origin.Provider));
+		}
+
+		internal void MarkConstructorsOnType (in MessageOrigin origin, TypeDefinition type, Func<MethodDefinition, bool>? filter, BindingFlags? bindingFlags = null)
+		{
+			foreach (var ctor in type.GetConstructorsOnType (filter, bindingFlags))
+				MarkMethod (origin, ctor);
+		}
+
+		internal void MarkFieldsOnTypeHierarchy (in MessageOrigin origin, TypeDefinition type, Func<FieldDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
+		{
+			foreach (var field in type.GetFieldsOnTypeHierarchy (_context, filter, bindingFlags))
+				MarkField (origin, field);
+		}
+
+		internal void MarkPropertiesOnTypeHierarchy (in MessageOrigin origin, TypeDefinition type, Func<PropertyDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
+		{
+			foreach (var property in type.GetPropertiesOnTypeHierarchy (_context, filter, bindingFlags))
+				MarkProperty (origin, property);
+		}
+
+		internal void MarkEventsOnTypeHierarchy (in MessageOrigin origin, TypeDefinition type, Func<EventDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
+		{
+			foreach (var @event in type.GetEventsOnTypeHierarchy (_context, filter, bindingFlags))
+				MarkEvent (origin, @event);
+		}
+
+		internal void MarkStaticConstructor (in MessageOrigin origin, TypeDefinition type)
+		{
+			_markStep.MarkStaticConstructorVisibleToReflection (type, new DependencyInfo (DependencyKind.AccessedViaReflection, origin.Provider), origin);
+		}
+	}
+}

--- a/src/linker/Linker.Dataflow/ReflectionMarker.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMarker.cs
@@ -48,13 +48,10 @@ namespace Mono.Linker.Dataflow
 
 		internal bool TryResolveTypeNameAndMark (string typeName, MessageOrigin origin, [NotNullWhen (true)] out TypeDefinition? type)
 		{
-			// Only difference here is whether we treat arrays specially. Maybe we should do that more frequently elsewhere too.
-			// _reflectionMarker.MarkType (origin, );
 			if (!_context.TypeNameResolver.TryResolveTypeName (typeName, origin.Provider, out TypeReference? typeRef, out AssemblyDefinition? typeAssembly)
 				|| typeRef.ResolveToTypeDefinition (_context) is not TypeDefinition foundType) {
 				type = default;
 				return false;
-
 			}
 
 			_markStep.MarkTypeVisibleToReflection (typeRef, foundType, new DependencyInfo (DependencyKind.AccessedViaReflection, origin.Provider), origin);

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -90,7 +90,7 @@ namespace Mono.Linker.Dataflow
 				var parameterValue = _annotations.GetMethodParameterValue (method, i);
 				if (parameterValue.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None) {
 					MultiValue value = GetValueNodeForCustomAttributeArgument (arguments[i]);
-					var diagnosticContext = new DiagnosticContext (_origin, diagnosticsEnabled: true ,_context);
+					var diagnosticContext = new DiagnosticContext (_origin, diagnosticsEnabled: true, _context);
 					RequireDynamicallyAccessedMembers (diagnosticContext, value, parameterValue);
 				}
 			}

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -531,7 +531,7 @@ namespace Mono.Linker.Dataflow
 			// static CreateInstance (string assemblyName, string typeName, object?[]? activationAttributes)
 			//
 			case IntrinsicId.Activator_CreateInstance_AssemblyName_TypeName:
-				ProcessCreateInstanceByName (_origin, diagnosticContext, calledMethodDefinition, methodParams);
+				ProcessCreateInstanceByName (diagnosticContext, calledMethodDefinition, methodParams);
 				break;
 
 			//
@@ -542,7 +542,7 @@ namespace Mono.Linker.Dataflow
 			// static CreateInstanceFrom (string assemblyFile, string typeName, object? []? activationAttributes)
 			//
 			case IntrinsicId.Activator_CreateInstanceFrom:
-				ProcessCreateInstanceByName (_origin, diagnosticContext, calledMethodDefinition, methodParams);
+				ProcessCreateInstanceByName (diagnosticContext, calledMethodDefinition, methodParams);
 				break;
 
 			//
@@ -591,7 +591,7 @@ namespace Mono.Linker.Dataflow
 					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceAndUnwrap
 					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFrom
 					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
-				ProcessCreateInstanceByName (_origin, diagnosticContext, calledMethodDefinition, methodParams);
+				ProcessCreateInstanceByName (diagnosticContext, calledMethodDefinition, methodParams);
 				break;
 
 			//
@@ -699,9 +699,8 @@ namespace Mono.Linker.Dataflow
 			return false;
 		}
 
-		void ProcessCreateInstanceByName (in MessageOrigin origin, in DiagnosticContext diagnosticContext, MethodDefinition calledMethod, ValueNodeList methodParams)
+		void ProcessCreateInstanceByName (in DiagnosticContext diagnosticContext, MethodDefinition calledMethod, ValueNodeList methodParams)
 		{
-			Debug.Assert (diagnosticContext.Origin == origin);
 			BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 			bool parameterlessConstructor = true;
 			if (calledMethod.Parameters.Count == 8 && calledMethod.Parameters[2].ParameterType.MetadataType == MetadataType.Boolean) {
@@ -745,7 +744,7 @@ namespace Mono.Linker.Dataflow
 								continue;
 							}
 
-							_reflectionMarker.MarkConstructorsOnType (origin, resolvedType, parameterlessConstructor ? m => m.Parameters.Count == 0 : null, bindingFlags);
+							_reflectionMarker.MarkConstructorsOnType (diagnosticContext.Origin, resolvedType, parameterlessConstructor ? m => m.Parameters.Count == 0 : null, bindingFlags);
 						} else {
 							diagnosticContext.AddDiagnostic (DiagnosticId.UnrecognizedParameterInMethodCreateInstance, calledMethod.Parameters[1].Name, calledMethod.GetDisplayName ());
 						}

--- a/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
@@ -18,13 +18,12 @@ namespace ILLink.Shared.TrimAnalysis
 		public RequireDynamicallyAccessedMembersAction (
 			LinkContext context,
 			ReflectionMarker reflectionMarker,
-			in MessageOrigin origin,
-			bool diagnosticsEnabled)
+			in DiagnosticContext diagnosticContext)
 		{
-			_diagnosticContext = new DiagnosticContext (origin, diagnosticsEnabled, context);
 			_context = context;
-			_origin = origin;
 			_reflectionMarker = reflectionMarker;
+			_origin = diagnosticContext.Origin;
+			_diagnosticContext = diagnosticContext;
 		}
 
 		private partial bool TryResolveTypeNameAndMark (string typeName, out TypeProxy type)

--- a/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
@@ -13,7 +13,6 @@ namespace ILLink.Shared.TrimAnalysis
 	{
 		readonly LinkContext _context;
 		readonly ReflectionMarker _reflectionMarker;
-		readonly MessageOrigin _origin;
 
 		public RequireDynamicallyAccessedMembersAction (
 			LinkContext context,
@@ -22,19 +21,18 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			_context = context;
 			_reflectionMarker = reflectionMarker;
-			_origin = diagnosticContext.Origin;
 			_diagnosticContext = diagnosticContext;
 		}
 
 		private partial bool TryResolveTypeNameAndMark (string typeName, out TypeProxy type)
 		{
-			if (!_context.TypeNameResolver.TryResolveTypeName (typeName, _origin.Provider, out TypeReference? typeRef, out AssemblyDefinition? typeAssembly)
+			if (!_context.TypeNameResolver.TryResolveTypeName (typeName, _diagnosticContext.Origin.Provider, out TypeReference? typeRef, out AssemblyDefinition? typeAssembly)
 				|| typeRef.ResolveToTypeDefinition (_context) is not TypeDefinition foundType) {
 				type = default;
 				return false;
 			} else {
-				_reflectionMarker.MarkType (_origin, typeRef);
-				_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType), _origin);
+				_reflectionMarker.MarkType (_diagnosticContext.Origin, typeRef);
+				_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType), _diagnosticContext.Origin);
 				type = new TypeProxy (foundType);
 				return true;
 			}
@@ -42,7 +40,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 		private partial void MarkTypeForDynamicallyAccessedMembers (in TypeProxy type, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
-			_reflectionMarker.MarkTypeForDynamicallyAccessedMembers (_origin, type.Type, dynamicallyAccessedMemberTypes, DependencyKind.DynamicallyAccessedMember);
+			_reflectionMarker.MarkTypeForDynamicallyAccessedMembers (_diagnosticContext.Origin, type.Type, dynamicallyAccessedMemberTypes, DependencyKind.DynamicallyAccessedMember);
 		}
 	}
 }

--- a/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
@@ -12,19 +12,19 @@ namespace ILLink.Shared.TrimAnalysis
 	partial struct RequireDynamicallyAccessedMembersAction
 	{
 		readonly LinkContext _context;
-		readonly ReflectionMethodBodyScanner _reflectionMethodBodyScanner;
+		readonly ReflectionMarker _reflectionMarker;
 		readonly MessageOrigin _origin;
 
 		public RequireDynamicallyAccessedMembersAction (
 			LinkContext context,
-			ReflectionMethodBodyScanner reflectionMethodBodyScanner,
+			ReflectionMarker reflectionMarker,
 			in MessageOrigin origin,
 			bool diagnosticsEnabled)
 		{
 			_diagnosticContext = new DiagnosticContext (origin, diagnosticsEnabled, context);
 			_context = context;
 			_origin = origin;
-			_reflectionMethodBodyScanner = reflectionMethodBodyScanner;
+			_reflectionMarker = reflectionMarker;
 		}
 
 		private partial bool TryResolveTypeNameAndMark (string typeName, out TypeProxy type)
@@ -34,7 +34,7 @@ namespace ILLink.Shared.TrimAnalysis
 				type = default;
 				return false;
 			} else {
-				_reflectionMethodBodyScanner.MarkType (_origin, typeRef);
+				_reflectionMarker.MarkType (_origin, typeRef);
 				_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType), _origin);
 				type = new TypeProxy (foundType);
 				return true;
@@ -43,7 +43,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 		private partial void MarkTypeForDynamicallyAccessedMembers (in TypeProxy type, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
-			_reflectionMethodBodyScanner.MarkTypeForDynamicallyAccessedMembers (_origin, type.Type, dynamicallyAccessedMemberTypes, DependencyKind.DynamicallyAccessedMember);
+			_reflectionMarker.MarkTypeForDynamicallyAccessedMembers (_origin, type.Type, dynamicallyAccessedMemberTypes, DependencyKind.DynamicallyAccessedMember);
 		}
 	}
 }

--- a/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
@@ -26,15 +26,12 @@ namespace ILLink.Shared.TrimAnalysis
 
 		private partial bool TryResolveTypeNameAndMark (string typeName, out TypeProxy type)
 		{
-			if (!_context.TypeNameResolver.TryResolveTypeName (typeName, _diagnosticContext.Origin.Provider, out TypeReference? typeRef, out AssemblyDefinition? typeAssembly)
-				|| typeRef.ResolveToTypeDefinition (_context) is not TypeDefinition foundType) {
+			if (_reflectionMarker.TryResolveTypeNameAndMark (typeName, _diagnosticContext.Origin, out TypeDefinition? foundType)) {
+				type = new (foundType);
+				return true;
+			} else {
 				type = default;
 				return false;
-			} else {
-				_reflectionMarker.MarkType (_diagnosticContext.Origin, typeRef);
-				_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType), _diagnosticContext.Origin);
-				type = new TypeProxy (foundType);
-				return true;
 			}
 		}
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/linker/pull/2747. This is a factoring change only and doesn't introduce functional changes.

This does two things to move the method body scanner to be more similar to the trim analysis visitor:
- Uses `DiagnosticContext` to record diagnostics. Right now, this still happens inline as we run the scanner, but the idea will be to move this out to a driver that runs the analysis, and then records diagnostics from the recorded patterns (like how it is done in the analyzer)
- Moves reflection-marking helpers out of `ReflectionMethodBodyScanner` to a separate class. This prevents us from having to pass around the scanner to other helpers, and makes it more obvious which parts of the code to scanning only vs other things. The new `ReflectionMarker` is conceptually similar to `ReflectionAccessAnalyzer` in the Roslyn analyzer and could be a candidate for future code sharing.