### PR TITLE
Make FlowAnnotations and ReflectionAccessAnalyzer structs

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial class FlowAnnotations
+	readonly partial struct FlowAnnotations
 	{
 		public static bool RequiresDataFlowAnalysis (IMethodSymbol method)
 		{

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/ReflectionAccessAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/ReflectionAccessAnalyzer.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.RoslynAnalyzer.TrimAnalysis
 {
-	class ReflectionAccessAnalyzer
+	readonly struct ReflectionAccessAnalyzer
 	{
 #pragma warning disable CA1822 // Mark members as static - the other partial implementations might need to be instance methods
 		internal void GetReflectionAccessDiagnostics (in DiagnosticContext diagnosticContext, ITypeSymbol typeSymbol, DynamicallyAccessedMemberTypes requiredMemberTypes, bool declaredOnly = false)

--- a/src/ILLink.Shared/TrimAnalysis/FlowAnnotations.cs
+++ b/src/ILLink.Shared/TrimAnalysis/FlowAnnotations.cs
@@ -7,7 +7,7 @@ using ILLink.Shared.TypeSystemProxy;
 namespace ILLink.Shared.TrimAnalysis
 {
 	// Shared helpers to go from MethodProxy to dataflow values.
-	partial class FlowAnnotations
+	readonly partial struct FlowAnnotations
 	{
 		internal partial bool MethodRequiresDataFlowAnalysis (MethodProxy method);
 

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -13,7 +13,7 @@ using Mono.Linker.Dataflow;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial class FlowAnnotations
+	readonly partial struct FlowAnnotations
 	{
 		readonly LinkContext _context;
 		readonly Dictionary<TypeDefinition, TypeAnnotations> _annotations = new Dictionary<TypeDefinition, TypeAnnotations> ();


### PR DESCRIPTION
To avoid unnecessary allocations, as per the feedback from @vitek-karas: https://github.com/dotnet/linker/pull/2757#discussion_r858524693