### PR TITLE
Don't remove MethodImpl if overridden method is not in a link assembly

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -482,10 +482,10 @@ namespace Mono.Linker.Steps
 		/// <summary>
 		/// Returns true if the assembly of the <paramref name="scope"></paramref> is not set to link (i.e. action=copy is set for that assembly)
 		/// </summary>
-	    private bool IgnoreScope (IMetadataScope scope)
+		private bool IgnoreScope (IMetadataScope scope)
 		{
-		   AssemblyDefinition? assembly = Context.Resolve (scope);
-		   return assembly != null && Annotations.GetAction (assembly) != AssemblyAction.Link;
+			AssemblyDefinition? assembly = Context.Resolve (scope);
+			return assembly != null && Annotations.GetAction (assembly) != AssemblyAction.Link;
 		}
 
 		void SweepDebugInfo (Collection<MethodDefinition> methods)

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -472,12 +472,22 @@ namespace Mono.Linker.Steps
 		void SweepOverrides (MethodDefinition method)
 		{
 			for (int i = 0; i < method.Overrides.Count;) {
-				if (Context.Resolve (method.Overrides[i]) is MethodDefinition ov && ShouldRemove (ov))
+				if (Context.Resolve (method.Overrides[i]) is MethodDefinition ov && ShouldRemove (ov) && !IgnoreScope (ov.DeclaringType.Scope))
 					method.Overrides.RemoveAt (i);
 				else
 					i++;
 			}
 		}
+
+		/// <summary>
+		/// Returns true if the assembly of the <paramref name="scope"></paramref> is not set to link (i.e. action=copy is set for that assembly)
+		/// </summary>
+	    private bool IgnoreScope (IMetadataScope scope)
+		{
+		   AssemblyDefinition? assembly = Context.Resolve (scope);
+		   return assembly != null && Annotations.GetAction (assembly) != AssemblyAction.Link;
+		}
+
 		void SweepDebugInfo (Collection<MethodDefinition> methods)
 		{
 			List<ScopeDebugInformation>? sweptScopes = null;

--- a/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/CopyLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/CopyLibrary.cs
@@ -13,5 +13,6 @@ namespace Mono.Linker.Tests.Cases.Libraries.Dependencies
 	{
 		static abstract void CopyLibraryStaticInterfaceMethod ();
 		static abstract void CopyLibraryExplicitImplementationStaticInterfaceMethod ();
+		public static abstract void PublicStaticInterfaceMethod ();
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/SkipLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/SkipLibrary.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Mono.Linker.Tests.Cases.Libraries.Dependencies
+{
+	public interface ISkipLibraryStaticInterface
+	{
+		static abstract void StaticInterfaceMethod ();
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
@@ -12,7 +12,9 @@ using Mono.Linker.Tests.Cases.Libraries.Dependencies;
 namespace Mono.Linker.Tests.Cases.Libraries
 {
 	[SetupCompileBefore ("copylibrary.dll", new[] { "Dependencies/CopyLibrary.cs" })]
+	[SetupCompileBefore ("skiplibrary.dll", new[] { "Dependencies/SkipLibrary.cs" })]
 	[SetupLinkerAction ("copy", "copylibrary")]
+	[SetupLinkerAction ("skip", "skiplibrary")]
 	[SetupLinkerArgument ("-a", "test.exe", "library")]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
 	[VerifyMetadataNames]
@@ -188,6 +190,7 @@ namespace Mono.Linker.Tests.Cases.Libraries
 		[KeptInterface (typeof (IInternalStaticInterface))]
 		[KeptInterface (typeof (ICopyLibraryInterface))]
 		[KeptInterface (typeof (ICopyLibraryStaticInterface))]
+		[KeptInterface (typeof (ISkipLibraryStaticInterface))]
 		public class UninstantiatedPublicClassWithInterface :
 			IPublicInterface,
 			IPublicStaticInterface,
@@ -195,7 +198,8 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			IInternalStaticInterface,
 			IEnumerator,
 			ICopyLibraryInterface,
-			ICopyLibraryStaticInterface
+			ICopyLibraryStaticInterface,
+			ISkipLibraryStaticInterface
 		{
 			internal UninstantiatedPublicClassWithInterface () { }
 
@@ -241,7 +245,12 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			public static void CopyLibraryStaticInterfaceMethod () { }
 
 			[Kept]
+			[KeptOverride (typeof(ICopyLibraryStaticInterface))]
 			static void ICopyLibraryStaticInterface.CopyLibraryExplicitImplementationStaticInterfaceMethod () { }
+
+			[Kept]
+			[KeptOverride (typeof(ISkipLibraryStaticInterface))]
+			static void ISkipLibraryStaticInterface.StaticInterfaceMethod () { }
 		}
 
 		[Kept]
@@ -325,6 +334,7 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			public static void CopyLibraryStaticInterfaceMethod () { }
 
 			[Kept]
+			[KeptOverride(typeof(ICopyLibraryStaticInterface))]
 			static void ICopyLibraryStaticInterface.CopyLibraryExplicitImplementationStaticInterfaceMethod () { }
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
@@ -245,11 +245,11 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			public static void CopyLibraryStaticInterfaceMethod () { }
 
 			[Kept]
-			[KeptOverride (typeof(ICopyLibraryStaticInterface))]
+			[KeptOverride (typeof (ICopyLibraryStaticInterface))]
 			static void ICopyLibraryStaticInterface.CopyLibraryExplicitImplementationStaticInterfaceMethod () { }
 
 			[Kept]
-			[KeptOverride (typeof(ISkipLibraryStaticInterface))]
+			[KeptOverride (typeof (ISkipLibraryStaticInterface))]
 			static void ISkipLibraryStaticInterface.StaticInterfaceMethod () { }
 		}
 
@@ -334,7 +334,7 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			public static void CopyLibraryStaticInterfaceMethod () { }
 
 			[Kept]
-			[KeptOverride(typeof(ICopyLibraryStaticInterface))]
+			[KeptOverride (typeof (ICopyLibraryStaticInterface))]
 			static void ICopyLibraryStaticInterface.CopyLibraryExplicitImplementationStaticInterfaceMethod () { }
 		}
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -219,7 +219,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				return;
 			var expectedBaseTypesOverridden = new HashSet<string> (original.CustomAttributes
 				.Where (ca => ca.AttributeType.Name == nameof (KeptOverrideAttribute))
-				.Select (ca => (ca.ConstructorArguments[0].Value as TypeDefinition).FullName));
+				.Select (ca => (ca.ConstructorArguments[0].Value as TypeReference).FullName));
 			var originalBaseTypesOverridden = new HashSet<string> (original.Overrides.Select (ov => ov.DeclaringType.FullName));
 			var linkedBaseTypesOverridden = new HashSet<string> (linked.Overrides.Select (ov => ov.DeclaringType.FullName));
 			foreach (var expectedBaseType in expectedBaseTypesOverridden) {
@@ -232,7 +232,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			var expectedBaseTypesNotOverridden = new HashSet<string> (original.CustomAttributes
 				.Where (ca => ca.AttributeType.Name == nameof (RemovedOverrideAttribute))
-				.Select (ca => (ca.ConstructorArguments[0].Value as TypeDefinition).FullName));
+				.Select (ca => (ca.ConstructorArguments[0].Value as TypeReference).FullName));
 			foreach (var expectedRemovedBaseType in expectedBaseTypesNotOverridden) {
 				Assert.IsTrue (originalBaseTypesOverridden.Contains (expectedRemovedBaseType),
 					$"Method {linked.FullName} was expected to remove override {expectedRemovedBaseType}::{linked.Name}, " +


### PR DESCRIPTION
Before removing overrides, we should check if the overridden method is
in an ignore scope.

In the linker we consider types and methods in a `skip` assembly as "removed", so when the linker would check if an overridden method is removed, it would see that it is considered removed, even though it should be considered kept. The workaround is to use the IgnoreScope helper to determine if the interface method is in a `link` assembly and removed, and only remove the MethodImpl if both are true.

Now, whether `ShouldRemove` should return true or false for things in a skip assembly, I'm not sure. It depends on whether it does / should mean "Actively removed from the assembly" or "not in the final output".

This PR fixes the issues found in https://github.com/dotnet/runtime/pull/68612.