### PR TITLE
Share Type.GetType and similar intrinsics

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -46,6 +46,8 @@ namespace ILLink.RoslynAnalyzer
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericMethod));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.CaseInsensitiveTypeGetTypeCallIsNotSupported));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.UnrecognizedTypeNameInTypeGetType));
+			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.UnrecognizedParameterInMethodCreateInstance));
+			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.ParametersOfAssemblyCreateInstanceCannotBeAnalyzed));
 			return diagDescriptorsArrayBuilder.ToImmutable ();
 
 			void AddRange (DiagnosticId first, DiagnosticId last)

--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -44,6 +44,8 @@ namespace ILLink.RoslynAnalyzer
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.PropertyAccessorParameterInLinqExpressionsCannotBeStaticallyDetermined));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericType));
 			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericMethod));
+			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.CaseInsensitiveTypeGetTypeCallIsNotSupported));
+			diagDescriptorsArrayBuilder.Add (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.UnrecognizedTypeNameInTypeGetType));
 			return diagDescriptorsArrayBuilder.ToImmutable ();
 
 			void AddRange (DiagnosticId first, DiagnosticId last)
@@ -94,6 +96,8 @@ namespace ILLink.RoslynAnalyzer
 						}
 					}
 
+					if (context.OwningSymbol.ToDisplayString ().Contains ("TestTypeOverloadWith5ParametersWithoutIgnoreCase"))
+						Debug.WriteLine ("");
 					foreach (var operationBlock in context.OperationBlocks) {
 						ControlFlowGraph cfg = context.GetControlFlowGraph (operationBlock);
 						TrimDataFlowAnalysis trimDataFlowAnalysis = new (context, cfg);

--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -96,8 +96,6 @@ namespace ILLink.RoslynAnalyzer
 						}
 					}
 
-					if (context.OwningSymbol.ToDisplayString ().Contains ("TestTypeOverloadWith5ParametersWithoutIgnoreCase"))
-						Debug.WriteLine ("");
 					foreach (var operationBlock in context.OperationBlocks) {
 						ControlFlowGraph cfg = context.GetControlFlowGraph (operationBlock);
 						TrimDataFlowAnalysis trimDataFlowAnalysis = new (context, cfg);

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
@@ -67,6 +67,16 @@ namespace ILLink.Shared.TrimAnalysis
 			return false;
 		}
 
+		private partial bool TryResolveTypeNameForCreateInstance (in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType)
+		{
+			// Intentionally never resolve anything. Analyzer can really only see types from the current compilation unit. For other assemblies
+			// it typically only sees reference assemblies and thus just public API. It's not worth (at least for now) to try to resolve
+			// the assembly name and type name as it should be rare this is actually ever used and even rarer to have problems (Warnings).
+			// In any case the trimmer will process this correctly as it has a global view.
+			resolvedType = default;
+			return false;
+		}
+
 		// TODO: Does the analyzer need to do something here?
 		private partial void MarkStaticConstructor (TypeProxy type) { }
 
@@ -82,8 +92,8 @@ namespace ILLink.Shared.TrimAnalysis
 		private partial void MarkPublicParameterlessConstructorOnType (TypeProxy type)
 			=> _reflectionAccessAnalyzer.GetReflectionAccessDiagnosticsForPublicParameterlessConstructor (_diagnosticContext, type.Type);
 
-		private partial void MarkConstructorsOnType (TypeProxy type, BindingFlags? bindingFlags)
-			=> _reflectionAccessAnalyzer.GetReflectionAccessDiagnosticsForConstructorsOnType (_diagnosticContext, type.Type, bindingFlags);
+		private partial void MarkConstructorsOnType (TypeProxy type, BindingFlags? bindingFlags, int? parameterCount)
+			=> _reflectionAccessAnalyzer.GetReflectionAccessDiagnosticsForConstructorsOnType (_diagnosticContext, type.Type, bindingFlags, parameterCount);
 
 		private partial void MarkMethod (MethodProxy method)
 			=> ReflectionAccessAnalyzer.GetReflectionAccessDiagnosticsForMethod (_diagnosticContext, method.Method);

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodProxy.cs
@@ -26,6 +26,8 @@ namespace ILLink.Shared.TypeSystemProxy
 		internal partial bool HasParameterOfType (int parameterIndex, string fullTypeName)
 			=> Method.Parameters.Length > parameterIndex && IsTypeOf (Method.Parameters[parameterIndex].Type, fullTypeName);
 
+		internal partial string GetParameterDisplayName (int parameterIndex) => Method.Parameters[parameterIndex].GetDisplayName ();
+
 		internal partial bool HasGenericParameters () => Method.IsGenericMethod;
 
 		internal partial bool HasGenericParametersCount (int genericParameterCount) => Method.TypeParameters.Length == genericParameterCount;

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/ReflectionAccessAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/ReflectionAccessAnalyzer.cs
@@ -59,9 +59,9 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				GetReflectionAccessDiagnosticsForProperty (diagnosticContext, prop);
 		}
 
-		internal void GetReflectionAccessDiagnosticsForConstructorsOnType (in DiagnosticContext diagnosticContext, ITypeSymbol typeSymbol, BindingFlags? bindingFlags)
+		internal void GetReflectionAccessDiagnosticsForConstructorsOnType (in DiagnosticContext diagnosticContext, ITypeSymbol typeSymbol, BindingFlags? bindingFlags, int? parameterCount)
 		{
-			foreach (var c in typeSymbol.GetConstructorsOnType (filter: null, bindingFlags: bindingFlags))
+			foreach (var c in typeSymbol.GetConstructorsOnType (filter: parameterCount.HasValue ? c => c.Parameters.Length == parameterCount.Value : null, bindingFlags: bindingFlags))
 				GetReflectionAccessDiagnosticsForMethod (diagnosticContext, c);
 		}
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -21,7 +21,7 @@ namespace ILLink.Shared.TrimAnalysis
 			_reflectionAccessAnalyzer = reflectionAccessAnalyzer;
 		}
 
-		private partial bool TryResolveTypeNameAndMark (string typeName, out TypeProxy type)
+		public partial bool TryResolveTypeNameAndMark (string typeName, bool needsAssemblyName, out TypeProxy type)
 		{
 			// TODO: Implement type name resolution to type symbol
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -65,6 +65,8 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 					return new ConstIntValue (enumConstantValue);
 				else if (operation.Type?.SpecialType == SpecialType.System_Int32 && constantValue is int intConstantValue)
 					return new ConstIntValue (intConstantValue);
+				else if (operation.Type?.SpecialType == SpecialType.System_Boolean && constantValue is bool boolConstantValue)
+					return new ConstIntValue (boolConstantValue ? 1 : 0);
 			}
 
 			return returnValue;

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -595,7 +595,7 @@ namespace ILLink.Shared.TrimAnalysis
 					var targetValue = _annotations.GetMethodParameterValue (calledMethod, 0, DynamicallyAccessedMemberTypes.PublicParameterlessConstructor);
 					foreach (var value in argumentValues[0]) {
 						if (value is SystemTypeValue systemTypeValue) {
-							MarkConstructorsOnType (systemTypeValue.RepresentedType, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+							MarkConstructorsOnType (systemTypeValue.RepresentedType, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, parameterCount: null);
 						} else {
 							_requireDynamicallyAccessedMembersAction.Invoke (value, targetValue);
 						}
@@ -967,7 +967,7 @@ namespace ILLink.Shared.TrimAnalysis
 								&& ctorParameterCount == 0) {
 								MarkPublicParameterlessConstructorOnType (systemTypeValue.RepresentedType);
 							} else {
-								MarkConstructorsOnType (systemTypeValue.RepresentedType, bindingFlags);
+								MarkConstructorsOnType (systemTypeValue.RepresentedType, bindingFlags, parameterCount: null);
 							}
 						} else {
 							// Otherwise fall back to the bitfield requirements
@@ -1009,6 +1009,139 @@ namespace ILLink.Shared.TrimAnalysis
 					// MakeGenericMethod doesn't change the identity of the MethodBase we're tracking so propagate to the return value
 					AddReturnValue (instanceValue);
 				}
+				break;
+
+			//
+			// System.Activator
+			//
+			// static CreateInstance (System.Type type)
+			// static CreateInstance (System.Type type, bool nonPublic)
+			// static CreateInstance (System.Type type, params object?[]? args)
+			// static CreateInstance (System.Type type, object?[]? args, object?[]? activationAttributes)
+			// static CreateInstance (System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture)
+			// static CreateInstance (System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture, object?[]? activationAttributes) { throw null; }
+			//
+			case IntrinsicId.Activator_CreateInstance_Type: {
+					int? ctorParameterCount = null;
+					BindingFlags bindingFlags = BindingFlags.Instance;
+					if (calledMethod.GetParametersCount () > 1) {
+						if (calledMethod.HasParameterOfType (1, "System.Boolean")) {
+							// The overload that takes a "nonPublic" bool
+							bool nonPublic = argumentValues[1].AsConstInt () != 0;
+
+							if (nonPublic)
+								bindingFlags |= BindingFlags.NonPublic | BindingFlags.Public;
+							else
+								bindingFlags |= BindingFlags.Public;
+							ctorParameterCount = 0;
+						} else {
+							// Overload that has the parameters as the second or fourth argument
+							int argsParam = calledMethod.HasParametersCount (2) || calledMethod.HasParametersCount (3) ? 1 : 3;
+
+							if (argumentValues.Count > argsParam) {
+								if (argumentValues[argsParam].AsSingleValue () is ArrayValue arrayValue &&
+									arrayValue.Size.AsConstInt () != null)
+									ctorParameterCount = arrayValue.Size.AsConstInt ();
+								else if (argumentValues[argsParam].AsSingleValue () is NullValue)
+									ctorParameterCount = 0;
+							}
+
+							if (calledMethod.GetParametersCount () > 3) {
+								if (argumentValues[1].AsConstInt () is int constInt)
+									bindingFlags |= (BindingFlags) constInt;
+								else
+									bindingFlags |= BindingFlags.NonPublic | BindingFlags.Public;
+							} else {
+								bindingFlags |= BindingFlags.Public;
+							}
+						}
+					} else {
+						// The overload with a single System.Type argument
+						ctorParameterCount = 0;
+						bindingFlags |= BindingFlags.Public;
+					}
+
+					// Go over all types we've seen
+					foreach (var value in argumentValues[0]) {
+						if (value is SystemTypeValue systemTypeValue) {
+							// Special case known type values as we can do better by applying exact binding flags and parameter count.
+							MarkConstructorsOnType (systemTypeValue.RepresentedType, bindingFlags, ctorParameterCount);
+						} else {
+							// Otherwise fall back to the bitfield requirements
+							var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags);
+
+							// Special case the public parameterless constructor if we know that there are 0 args passed in
+							if (ctorParameterCount == 0 && requiredMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicConstructors)) {
+								requiredMemberTypes &= ~DynamicallyAccessedMemberTypes.PublicConstructors;
+								requiredMemberTypes |= DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
+							}
+
+							var targetValue = _annotations.GetMethodParameterValue (calledMethod, 0, requiredMemberTypes);
+
+							_requireDynamicallyAccessedMembersAction.Invoke (value, targetValue);
+						}
+					}
+				}
+				break;
+
+			//
+			// System.Activator
+			//
+			// static CreateInstance (string assemblyName, string typeName)
+			// static CreateInstance (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture, object?[]? activationAttributes)
+			// static CreateInstance (string assemblyName, string typeName, object?[]? activationAttributes)
+			//
+			case IntrinsicId.Activator_CreateInstance_AssemblyName_TypeName:
+				ProcessCreateInstanceByName (calledMethod, argumentValues);
+				break;
+
+			//
+			// System.Activator
+			//
+			// static CreateInstanceFrom (string assemblyFile, string typeName)
+			// static CreateInstanceFrom (string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
+			// static CreateInstanceFrom (string assemblyFile, string typeName, object? []? activationAttributes)
+			//
+			case IntrinsicId.Activator_CreateInstanceFrom:
+				ProcessCreateInstanceByName (calledMethod, argumentValues);
+				break;
+
+			//
+			// System.AppDomain
+			//
+			// CreateInstance (string assemblyName, string typeName)
+			// CreateInstance (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
+			// CreateInstance (string assemblyName, string typeName, object? []? activationAttributes)
+			//
+			// CreateInstanceAndUnwrap (string assemblyName, string typeName)
+			// CreateInstanceAndUnwrap (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
+			// CreateInstanceAndUnwrap (string assemblyName, string typeName, object? []? activationAttributes)
+			//
+			// CreateInstanceFrom (string assemblyFile, string typeName)
+			// CreateInstanceFrom (string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
+			// CreateInstanceFrom (string assemblyFile, string typeName, object? []? activationAttributes)
+			//
+			// CreateInstanceFromAndUnwrap (string assemblyFile, string typeName)
+			// CreateInstanceFromAndUnwrap (string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
+			// CreateInstanceFromAndUnwrap (string assemblyFile, string typeName, object? []? activationAttributes)
+			//
+			case var appDomainCreateInstance when appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstance
+					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceAndUnwrap
+					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFrom
+					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
+				ProcessCreateInstanceByName (calledMethod, argumentValues);
+				break;
+
+			//
+			// System.Reflection.Assembly
+			//
+			// CreateInstance (string typeName)
+			// CreateInstance (string typeName, bool ignoreCase)
+			// CreateInstance (string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder? binder, object []? args, CultureInfo? culture, object []? activationAttributes)
+			//
+			case IntrinsicId.Assembly_CreateInstance:
+				// For now always fail since we don't track assemblies (dotnet/linker/issues/1947)
+				_diagnosticContext.AddDiagnostic (DiagnosticId.ParametersOfAssemblyCreateInstanceCannotBeAnalyzed, calledMethod.GetDisplayName ());
 				break;
 
 			case IntrinsicId.None:
@@ -1158,6 +1291,50 @@ namespace ILLink.Shared.TrimAnalysis
 			return builder.ToImmutableArray ();
 		}
 
+		void ProcessCreateInstanceByName (MethodProxy calledMethod, IReadOnlyList<MultiValue> argumentValues)
+		{
+			BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+			bool parameterlessConstructor = true;
+			if (calledMethod.HasParametersCount (8) && calledMethod.HasParameterOfType (2, "System.Boolean")) {
+				parameterlessConstructor = false;
+				bindingFlags = BindingFlags.Instance;
+				if (argumentValues[3].AsConstInt () is int bindingFlagsInt)
+					bindingFlags |= (BindingFlags) bindingFlagsInt;
+				else
+					bindingFlags |= BindingFlags.Public | BindingFlags.NonPublic;
+			}
+
+			foreach (var assemblyNameValue in argumentValues[0]) {
+				if (assemblyNameValue is KnownStringValue assemblyNameStringValue) {
+					if (assemblyNameStringValue.Contents is string assemblyName && assemblyName.Length == 0) {
+						// Throws exception for zero-length assembly name.
+						continue;
+					}
+					foreach (var typeNameValue in argumentValues[1]) {
+						if (typeNameValue is NullValue) {
+							// Throws exception for null type name.
+							continue;
+						}
+						if (typeNameValue is KnownStringValue typeNameStringValue) {
+							if (!TryResolveTypeNameForCreateInstance (calledMethod, assemblyNameStringValue.Contents, typeNameStringValue.Contents, out TypeProxy resolvedType)) {
+								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
+								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
+								// but linker can't know that. In case a user tries to create an array using System.Activator we should simply ignore it, the user
+								// might expect an exception to be thrown.
+								continue;
+							}
+
+							MarkConstructorsOnType (resolvedType, bindingFlags, parameterlessConstructor ? 0 : null);
+						} else {
+							_diagnosticContext.AddDiagnostic (DiagnosticId.UnrecognizedParameterInMethodCreateInstance, calledMethod.GetParameterDisplayName (1), calledMethod.GetDisplayName ());
+						}
+					}
+				} else {
+					_diagnosticContext.AddDiagnostic (DiagnosticId.UnrecognizedParameterInMethodCreateInstance, calledMethod.GetParameterDisplayName (0), calledMethod.GetDisplayName ());
+				}
+			}
+		}
+
 		internal static BindingFlags? GetBindingFlagsFromValue (in MultiValue parameter) => (BindingFlags?) parameter.AsConstInt ();
 
 		internal static bool BindingFlagsAreUnsupported (BindingFlags? bindingFlags)
@@ -1239,6 +1416,8 @@ namespace ILLink.Shared.TrimAnalysis
 
 		private partial bool TryGetBaseType (TypeProxy type, [NotNullWhen (true)] out TypeProxy? baseType);
 
+		private partial bool TryResolveTypeNameForCreateInstance (in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType);
+
 		private partial void MarkStaticConstructor (TypeProxy type);
 
 		private partial void MarkEventsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags);
@@ -1249,7 +1428,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 		private partial void MarkPublicParameterlessConstructorOnType (TypeProxy type);
 
-		private partial void MarkConstructorsOnType (TypeProxy type, BindingFlags? bindingFlags);
+		private partial void MarkConstructorsOnType (TypeProxy type, BindingFlags? bindingFlags, int? parameterCount);
 
 		private partial void MarkMethod (MethodProxy method);
 

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -756,9 +756,6 @@ namespace ILLink.Shared.TrimAnalysis
 			// GetType (string, Func<AssemblyName, Assembly>, Func<Assembly, String, Boolean, Type>, Boolean, Boolean)
 			//
 			case IntrinsicId.Type_GetType: {
-					if (GetContainingSymbolDisplayName ().Contains ("TypeWithWarnings"))
-						Debug.WriteLine ("");
-
 					if (argumentValues[0].IsEmpty ()) {
 						returnValue = MultiValueLattice.Top;
 						break;
@@ -767,6 +764,7 @@ namespace ILLink.Shared.TrimAnalysis
 					if ((calledMethod.HasParametersCount (3) && calledMethod.HasParameterOfType (2, "System.Boolean") && argumentValues[2].AsConstInt () != 0) ||
 						(calledMethod.HasParametersCount (5) && argumentValues[4].AsConstInt () != 0)) {
 						_diagnosticContext.AddDiagnostic (DiagnosticId.CaseInsensitiveTypeGetTypeCallIsNotSupported, calledMethod.GetDisplayName ());
+						returnValue = MultiValueLattice.Top; // This effectively disables analysis of anything which uses the return value
 						break;
 					}
 

--- a/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
+++ b/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
@@ -46,7 +46,6 @@ namespace ILLink.Shared.TrimAnalysis
 		Activator_CreateInstance_Type,
 		Activator_CreateInstance_AssemblyName_TypeName,
 		Activator_CreateInstanceFrom,
-		Activator_CreateInstanceOfT,
 		AppDomain_CreateInstance,
 		AppDomain_CreateInstanceAndUnwrap,
 		AppDomain_CreateInstanceFrom,

--- a/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
+++ b/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
@@ -278,13 +278,6 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.HasParameterOfType (1, "System.String")
 					=> IntrinsicId.Activator_CreateInstanceFrom,
 
-				// static T System.Activator.CreateInstance<T> ()
-				"CreateInstance" when calledMethod.IsDeclaredOnType ("System.Activator")
-					&& calledMethod.HasGenericParameters ()
-					&& calledMethod.HasGenericParametersCount (1)
-					&& calledMethod.HasParametersCount (0)
-					=> IntrinsicId.Activator_CreateInstanceOfT,
-
 				// System.AppDomain.CreateInstance (string assemblyName, string typeName)
 				// System.AppDomain.CreateInstance (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
 				// System.AppDomain.CreateInstance (string assemblyName, string typeName, object? []? activationAttributes)

--- a/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -37,7 +37,7 @@ namespace ILLink.Shared.TrimAnalysis
 				} else if (uniqueValue is SystemTypeValue systemTypeValue) {
 					MarkTypeForDynamicallyAccessedMembers (systemTypeValue.RepresentedType, targetValue.DynamicallyAccessedMemberTypes);
 				} else if (uniqueValue is KnownStringValue knownStringValue) {
-					if (!TryResolveTypeNameAndMark (knownStringValue.Contents, out TypeProxy foundType)) {
+					if (!TryResolveTypeNameAndMark (knownStringValue.Contents, true, out TypeProxy foundType)) {
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 					} else {
 						MarkTypeForDynamicallyAccessedMembers (foundType, targetValue.DynamicallyAccessedMemberTypes);
@@ -62,7 +62,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		private partial bool TryResolveTypeNameAndMark (string typeName, out TypeProxy type);
+		public partial bool TryResolveTypeNameAndMark (string typeName, bool needsAssemblyName, out TypeProxy type);
 
 		private partial void MarkTypeForDynamicallyAccessedMembers (in TypeProxy type, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes);
 	}

--- a/src/ILLink.Shared/TypeSystemProxy/MethodProxy.cs
+++ b/src/ILLink.Shared/TypeSystemProxy/MethodProxy.cs
@@ -16,6 +16,7 @@ namespace ILLink.Shared.TypeSystemProxy
 		// Currently this only needs to work on non-nested, non-generic types.
 		// The format of the fullTypeName parameter is 'namespace.typename', so for example 'System.Reflection.Assembly'
 		internal partial bool HasParameterOfType (int parameterIndex, string fullTypeName);
+		internal partial string GetParameterDisplayName (int parameterIndex);
 		internal partial bool HasGenericParameters ();
 		internal partial bool HasGenericParametersCount (int genericParameterCount);
 		internal partial ImmutableArray<GenericParameterProxy> GetGenericParameters ();

--- a/src/linker/Linker.Dataflow/MethodProxy.cs
+++ b/src/linker/Linker.Dataflow/MethodProxy.cs
@@ -27,6 +27,8 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		internal partial bool HasParameterOfType (int parameterIndex, string fullTypeName) => Method.HasParameterOfType (parameterIndex, fullTypeName);
 
+		internal partial string GetParameterDisplayName (int parameterIndex) => Method.Parameters[parameterIndex].Name;
+
 		internal partial bool HasGenericParameters () => Method.HasGenericParameters;
 
 		internal partial bool HasGenericParametersCount (int genericParameterCount) => Method.GenericParameters.Count == genericParameterCount;

--- a/src/linker/Linker.Dataflow/ReflectionMarker.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMarker.cs
@@ -46,9 +46,9 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
-		internal bool TryResolveTypeNameAndMark (string typeName, MessageOrigin origin, [NotNullWhen (true)] out TypeDefinition? type)
+		internal bool TryResolveTypeNameAndMark (string typeName, MessageOrigin origin, bool needsAssemblyName, [NotNullWhen (true)] out TypeDefinition? type)
 		{
-			if (!_context.TypeNameResolver.TryResolveTypeName (typeName, origin.Provider, out TypeReference? typeRef, out AssemblyDefinition? typeAssembly)
+			if (!_context.TypeNameResolver.TryResolveTypeName (typeName, origin.Provider, out TypeReference? typeRef, out AssemblyDefinition? typeAssembly, needsAssemblyName)
 				|| typeRef.ResolveToTypeDefinition (_context) is not TypeDefinition foundType) {
 				type = default;
 				return false;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -287,7 +287,8 @@ namespace Mono.Linker.Dataflow
 			case IntrinsicId.Type_MakeGenericType:
 			case IntrinsicId.MethodInfo_MakeGenericMethod:
 			case IntrinsicId.Expression_Call:
-			case IntrinsicId.Expression_New: {
+			case IntrinsicId.Expression_New:
+			case IntrinsicId.Type_GetType: {
 					var instanceValue = MultiValueLattice.Top;
 					IReadOnlyList<MultiValue> parameterValues = methodParams;
 					if (calledMethodDefinition.HasImplicitThis ()) {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -14,7 +14,6 @@ using ILLink.Shared.TypeSystemProxy;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker.Steps;
-using BindingFlags = System.Reflection.BindingFlags;
 using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
 namespace Mono.Linker.Dataflow
@@ -242,10 +241,8 @@ namespace Mono.Linker.Dataflow
 			if (calledMethodDefinition == null)
 				return false;
 
-			DynamicallyAccessedMemberTypes returnValueDynamicallyAccessedMemberTypes = 0;
-
 			bool requiresDataFlowAnalysis = _context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (calledMethodDefinition);
-			returnValueDynamicallyAccessedMemberTypes = requiresDataFlowAnalysis ?
+			DynamicallyAccessedMemberTypes returnValueDynamicallyAccessedMemberTypes = requiresDataFlowAnalysis ?
 				_context.Annotations.FlowAnnotations.GetReturnParameterAnnotation (calledMethodDefinition) : 0;
 
 			_origin = _origin.WithInstructionOffset (operation.Offset);
@@ -288,7 +285,15 @@ namespace Mono.Linker.Dataflow
 			case IntrinsicId.MethodInfo_MakeGenericMethod:
 			case IntrinsicId.Expression_Call:
 			case IntrinsicId.Expression_New:
-			case IntrinsicId.Type_GetType: {
+			case IntrinsicId.Type_GetType:
+			case IntrinsicId.Activator_CreateInstance_Type:
+			case IntrinsicId.Activator_CreateInstance_AssemblyName_TypeName:
+			case IntrinsicId.Activator_CreateInstanceFrom:
+			case var appDomainCreateInstance when appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstance
+					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceAndUnwrap
+					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFrom
+					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
+			case IntrinsicId.Assembly_CreateInstance: {
 					var instanceValue = MultiValueLattice.Top;
 					IReadOnlyList<MultiValue> parameterValues = methodParams;
 					if (calledMethodDefinition.HasImplicitThis ()) {
@@ -391,165 +396,13 @@ namespace Mono.Linker.Dataflow
 				}
 				break;
 
-
-			//
-			// System.Activator
-			//
-			// static CreateInstance (System.Type type)
-			// static CreateInstance (System.Type type, bool nonPublic)
-			// static CreateInstance (System.Type type, params object?[]? args)
-			// static CreateInstance (System.Type type, object?[]? args, object?[]? activationAttributes)
-			// static CreateInstance (System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture)
-			// static CreateInstance (System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture, object?[]? activationAttributes) { throw null; }
-			//
-			case IntrinsicId.Activator_CreateInstance_Type: {
-					var parameters = calledMethod.Parameters;
-
-					int? ctorParameterCount = null;
-					BindingFlags bindingFlags = BindingFlags.Instance;
-					if (parameters.Count > 1) {
-						if (parameters[1].ParameterType.MetadataType == MetadataType.Boolean) {
-							// The overload that takes a "nonPublic" bool
-							bool nonPublic = methodParams[1].AsConstInt () != 0;
-
-							if (nonPublic)
-								bindingFlags |= BindingFlags.NonPublic | BindingFlags.Public;
-							else
-								bindingFlags |= BindingFlags.Public;
-							ctorParameterCount = 0;
-						} else {
-							// Overload that has the parameters as the second or fourth argument
-							int argsParam = parameters.Count == 2 || parameters.Count == 3 ? 1 : 3;
-
-							if (methodParams.Count > argsParam) {
-								if (methodParams[argsParam].AsSingleValue () is ArrayValue arrayValue &&
-									arrayValue.Size.AsConstInt () != null)
-									ctorParameterCount = arrayValue.Size.AsConstInt ();
-								else if (methodParams[argsParam].AsSingleValue () is NullValue)
-									ctorParameterCount = 0;
-							}
-
-							if (parameters.Count > 3) {
-								if (methodParams[1].AsConstInt () is int constInt)
-									bindingFlags |= (BindingFlags) constInt;
-								else
-									bindingFlags |= BindingFlags.NonPublic | BindingFlags.Public;
-							} else {
-								bindingFlags |= BindingFlags.Public;
-							}
-						}
-					} else {
-						// The overload with a single System.Type argument
-						ctorParameterCount = 0;
-						bindingFlags |= BindingFlags.Public;
-					}
-
-					// Go over all types we've seen
-					foreach (var value in methodParams[0]) {
-						if (value is SystemTypeValue systemTypeValue) {
-							// Special case known type values as we can do better by applying exact binding flags and parameter count.
-							_reflectionMarker.MarkConstructorsOnType (_origin, systemTypeValue.RepresentedType.Type,
-								ctorParameterCount == null ? null : m => m.Parameters.Count == ctorParameterCount, bindingFlags);
-						} else {
-							// Otherwise fall back to the bitfield requirements
-							var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags);
-
-							// Special case the public parameterless constructor if we know that there are 0 args passed in
-							if (ctorParameterCount == 0 && requiredMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicConstructors)) {
-								requiredMemberTypes &= ~DynamicallyAccessedMemberTypes.PublicConstructors;
-								requiredMemberTypes |= DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
-							}
-
-							var targetValue = _annotations.GetMethodParameterValue (calledMethodDefinition, 0, requiredMemberTypes);
-
-							RequireDynamicallyAccessedMembers (diagnosticContext, value, targetValue);
-						}
-					}
-				}
-				break;
-
-			//
-			// System.Activator
-			//
-			// static CreateInstance (string assemblyName, string typeName)
-			// static CreateInstance (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture, object?[]? activationAttributes)
-			// static CreateInstance (string assemblyName, string typeName, object?[]? activationAttributes)
-			//
-			case IntrinsicId.Activator_CreateInstance_AssemblyName_TypeName:
-				ProcessCreateInstanceByName (diagnosticContext, calledMethodDefinition, methodParams);
-				break;
-
-			//
-			// System.Activator
-			//
-			// static CreateInstanceFrom (string assemblyFile, string typeName)
-			// static CreateInstanceFrom (string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
-			// static CreateInstanceFrom (string assemblyFile, string typeName, object? []? activationAttributes)
-			//
-			case IntrinsicId.Activator_CreateInstanceFrom:
-				ProcessCreateInstanceByName (diagnosticContext, calledMethodDefinition, methodParams);
-				break;
-
-			//
-			// System.Activator
-			//
-			// static T CreateInstance<T> ()
-			//
-			// Note: If the when condition returns false it would be an overload which we don't recognize, so just fall through to the default case
-			case IntrinsicId.Activator_CreateInstanceOfT when
-				calledMethod is GenericInstanceMethod genericCalledMethod && genericCalledMethod.GenericArguments.Count == 1: {
-
-					if (genericCalledMethod.GenericArguments[0] is GenericParameter genericParameter &&
-						genericParameter.HasDefaultConstructorConstraint) {
-						// This is safe, the linker would have marked the default .ctor already
-						break;
-					}
-
-					var targetValue = new GenericParameterValue (calledMethodDefinition.GenericParameters[0], DynamicallyAccessedMemberTypes.PublicParameterlessConstructor);
-					RequireDynamicallyAccessedMembers (
-						diagnosticContext,
-						GetTypeValueNodeFromGenericArgument (genericCalledMethod.GenericArguments[0]),
-						targetValue);
-				}
-				break;
-
-			//
-			// System.AppDomain
-			//
-			// CreateInstance (string assemblyName, string typeName)
-			// CreateInstance (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
-			// CreateInstance (string assemblyName, string typeName, object? []? activationAttributes)
-			//
-			// CreateInstanceAndUnwrap (string assemblyName, string typeName)
-			// CreateInstanceAndUnwrap (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
-			// CreateInstanceAndUnwrap (string assemblyName, string typeName, object? []? activationAttributes)
-			//
-			// CreateInstanceFrom (string assemblyFile, string typeName)
-			// CreateInstanceFrom (string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
-			// CreateInstanceFrom (string assemblyFile, string typeName, object? []? activationAttributes)
-			//
-			// CreateInstanceFromAndUnwrap (string assemblyFile, string typeName)
-			// CreateInstanceFromAndUnwrap (string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
-			// CreateInstanceFromAndUnwrap (string assemblyFile, string typeName, object? []? activationAttributes)
-			//
-			case var appDomainCreateInstance when appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstance
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceAndUnwrap
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFrom
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
-				ProcessCreateInstanceByName (diagnosticContext, calledMethodDefinition, methodParams);
-				break;
-
-			//
-			// System.Reflection.Assembly
-			//
-			// CreateInstance (string typeName)
-			// CreateInstance (string typeName, bool ignoreCase)
-			// CreateInstance (string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder? binder, object []? args, CultureInfo? culture, object []? activationAttributes)
-			//
-			case IntrinsicId.Assembly_CreateInstance:
-				// For now always fail since we don't track assemblies (dotnet/linker/issues/1947)
-				diagnosticContext.AddDiagnostic (DiagnosticId.ParametersOfAssemblyCreateInstanceCannotBeAnalyzed, calledMethodDefinition.GetDisplayName ());
-				break;
+			// Note about Activator.CreateInstance<T>
+			// There are 2 interesting cases:
+			//  - The generic argument for T is either specific type or annotated - in that case generic instantiation will handle this
+			//    since from .NET 6+ the T is annotated with PublicParameterlessConstructor annotation, so the linker would apply this as for any other method.
+			//  - The generic argument for T is unannotated type - the generic instantiantion handling has a special case for handling PublicParameterlessConstructor requirement
+			//    in such that if the generic argument type has the "new" constraint it will not warn (as it is effectively the same thing semantically).
+			//    For all other cases, the linker would have already produced a warning.
 
 			default:
 				throw new NotImplementedException ("Unhandled instrinsic");
@@ -644,69 +497,10 @@ namespace Mono.Linker.Dataflow
 			return false;
 		}
 
-		void ProcessCreateInstanceByName (in DiagnosticContext diagnosticContext, MethodDefinition calledMethod, ValueNodeList methodParams)
-		{
-			BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
-			bool parameterlessConstructor = true;
-			if (calledMethod.Parameters.Count == 8 && calledMethod.Parameters[2].ParameterType.MetadataType == MetadataType.Boolean) {
-				parameterlessConstructor = false;
-				bindingFlags = BindingFlags.Instance;
-				if (methodParams[3].AsConstInt () is int bindingFlagsInt)
-					bindingFlags |= (BindingFlags) bindingFlagsInt;
-				else
-					bindingFlags |= BindingFlags.Public | BindingFlags.NonPublic;
-			}
-
-			int methodParamsOffset = calledMethod.HasImplicitThis () ? 1 : 0;
-
-			foreach (var assemblyNameValue in methodParams[methodParamsOffset]) {
-				if (assemblyNameValue is KnownStringValue assemblyNameStringValue) {
-					if (assemblyNameStringValue.Contents is string assemblyName && assemblyName.Length == 0) {
-						// Throws exception for zero-length assembly name.
-						continue;
-					}
-					foreach (var typeNameValue in methodParams[methodParamsOffset + 1]) {
-						if (typeNameValue is NullValue) {
-							// Throws exception for null type name.
-							continue;
-						}
-						if (typeNameValue is KnownStringValue typeNameStringValue) {
-							var resolvedAssembly = _context.TryResolve (assemblyNameStringValue.Contents);
-							if (resolvedAssembly == null) {
-								diagnosticContext.AddDiagnostic (DiagnosticId.UnresolvedAssemblyInCreateInstance,
-									assemblyNameStringValue.Contents,
-									calledMethod.GetDisplayName ());
-								continue;
-							}
-
-							if (!_context.TypeNameResolver.TryResolveTypeName (resolvedAssembly, typeNameStringValue.Contents, out TypeReference? typeRef)
-								|| _context.TryResolve (typeRef) is not TypeDefinition resolvedType
-								|| typeRef is ArrayType) {
-								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
-								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
-								// but linker can't know that. In case a user tries to create an array using System.Activator we should simply ignore it, the user
-								// might expect an exception to be thrown.
-								continue;
-							}
-
-							_reflectionMarker.MarkConstructorsOnType (diagnosticContext.Origin, resolvedType, parameterlessConstructor ? m => m.Parameters.Count == 0 : null, bindingFlags);
-						} else {
-							diagnosticContext.AddDiagnostic (DiagnosticId.UnrecognizedParameterInMethodCreateInstance, calledMethod.Parameters[1].Name, calledMethod.GetDisplayName ());
-						}
-					}
-				} else {
-					diagnosticContext.AddDiagnostic (DiagnosticId.UnrecognizedParameterInMethodCreateInstance, calledMethod.Parameters[0].Name, calledMethod.GetDisplayName ());
-				}
-			}
-		}
-
 		void RequireDynamicallyAccessedMembers (in DiagnosticContext diagnosticContext, in MultiValue value, ValueWithDynamicallyAccessedMembers targetValue)
 		{
 			var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction (_context, _reflectionMarker, diagnosticContext);
 			requireDynamicallyAccessedMembersAction.Invoke (value, targetValue);
 		}
-
-		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (BindingFlags? bindingFlags) =>
-			HandleCallAction.GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags);
 	}
 }

--- a/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
@@ -24,9 +24,9 @@ namespace ILLink.Shared.TrimAnalysis
 			_diagnosticContext = diagnosticContext;
 		}
 
-		private partial bool TryResolveTypeNameAndMark (string typeName, out TypeProxy type)
+		public partial bool TryResolveTypeNameAndMark (string typeName, bool needsAssemblyName, out TypeProxy type)
 		{
-			if (_reflectionMarker.TryResolveTypeNameAndMark (typeName, _diagnosticContext.Origin, out TypeDefinition? foundType)) {
+			if (_reflectionMarker.TryResolveTypeNameAndMark (typeName, _diagnosticContext.Origin, needsAssemblyName, out TypeDefinition? foundType)) {
 				type = new (foundType);
 				return true;
 			} else {

--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -111,8 +111,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task GetTypeDataFlow ()
 		{
-			// https://github.com/dotnet/linker/issues/2273
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -13,7 +13,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task ActivatorCreateInstance ()
 		{
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -67,7 +67,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task ExpressionNewType ()
 		{
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -196,13 +196,43 @@ namespace ILLink.RoslynAnalyzer.Tests
 		[Fact]
 		public Task TypeUsedViaReflection ()
 		{
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task TypeUsedViaReflectionAssemblyDoesntExist ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task TypeUsedViaReflectionInDifferentAssembly ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task TypeUsedViaReflectionLdstrIncomplete ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task TypeUsedViaReflectionLdstrValidButChanged ()
+		{
+			return RunTest ();
 		}
 
 		[Fact]
 		public Task TypeUsedViaReflectionTypeDoesntExist ()
 		{
-			return RunTest (allowMissingWarnings: true);
+			return RunTest ();
+		}
+
+		[Fact]
+		public Task TypeUsedViaReflectionTypeNameIsSymbol ()
+		{
+			return RunTest ();
 		}
 	}
 }

--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReflectionTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReflectionTests.g.cs
@@ -62,36 +62,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task TypeUsedViaReflectionAssemblyDoesntExist ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task TypeUsedViaReflectionInDifferentAssembly ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task TypeUsedViaReflectionLdstrIncomplete ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task TypeUsedViaReflectionLdstrValidButChanged ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task TypeUsedViaReflectionTypeNameIsSymbol ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
 		public Task UnderlyingSystemType ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionNewType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionNewType.cs
@@ -53,11 +53,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Expression.New (T);
 		}
 
-		[ExpectedWarning ("IL2072", nameof (Expression) + "." + nameof (Expression.New), "'System." + nameof (Type) + "." + nameof (Type.GetType))]
 		[ExpectedWarning ("IL2072", nameof (Expression) + "." + nameof (Expression.New), nameof (ExpressionNewType) + "." + nameof (ExpressionNewType.GetType))]
 		[Kept]
 		static void Branch_UnrecognizedPatterns ()
 		{
+			// Note that "RemovedType" will not resolve here since the type declared below with the same name is nested type and so its real name is "ExpressionNewType+RemovedType"
+			// This should not warn - we choose to not warn if we can't resolve a type (and anything which it's used for)
 			Expression.New (Type.GetType ("RemovedType"));
 			Expression.New (GetType ());
 		}

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
@@ -268,6 +269,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			const string reflectionTypeKeptString = "mono.linker.tests.cases.reflection.TypeUsedViaReflection+CaseInsensitive, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false, true);
+			typeKept.RequiresPublicMethods (); // Validate that we don't track the value anymore since the above already warned about the problem
 		}
 
 		public class CaseUnknown { }

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -324,7 +324,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		public class OverloadWith5ParametersWithIgnoreCase { }
 
 		[Kept]
-		[ExpectedWarning ("IL2096", "'System.Type.GetType(String, Func<AssemblyName,Assembly>, Func<Assembly,String,Boolean,Type>, Boolean, Boolean)'")]
+		// Small difference in formatting between analyzer/linker
+		[ExpectedWarning ("IL2096", "'System.Type.GetType(String, Func<AssemblyName,Assembly>, Func<Assembly,String,Boolean,Type>, Boolean, Boolean)'", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2096", "'System.Type.GetType(String, Func<AssemblyName, Assembly>, Func<Assembly, String, Boolean, Type>, Boolean, Boolean)'", ProducedBy = ProducedBy.Analyzer)]
 		static void TestTypeOverloadWith5ParametersWithIgnoreCase ()
 		{
 			const string reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+OverloadWith5ParametersWithIgnoreCase";
@@ -374,7 +376,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
-		[ExpectedWarning ("IL2096", "'System.Type.GetType(String, Func<AssemblyName,Assembly>, Func<Assembly,String,Boolean,Type>, Boolean, Boolean)'")]
+		// Small difference in formatting between analyzer/linker
+		[ExpectedWarning ("IL2096", "'System.Type.GetType(String, Func<AssemblyName,Assembly>, Func<Assembly,String,Boolean,Type>, Boolean, Boolean)'", ProducedBy = ProducedBy.Trimmer)]
+		[ExpectedWarning ("IL2096", "'System.Type.GetType(String, Func<AssemblyName, Assembly>, Func<Assembly, String, Boolean, Type>, Boolean, Boolean)'", ProducedBy = ProducedBy.Analyzer)]
 		static void TestUnkownIgnoreCase5Params (int num)
 		{
 			const string reflectionTypeKeptString = "mono.linker.tests.cases.reflection.TypeUsedViaReflection+CaseUnknown2, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";


### PR DESCRIPTION
This shared pretty much all of the remaining intrinsics except for `object.GetType` (type hierarchy marking).

The linker move is straightforward and the only functional changes are:
* `Type.GetType()` with unsupported case insensitive search will not produce warnings from its return value
* Removed intrinsics handling of `Activator.CreateInstance<T>` - it's not needed, annotations do the same thing, and avoid generating duplicate warnings. This fixes: https://github.com/dotnet/linker/issues/1483

In the analyzer there are two behavioral differences from linker:
* Searching for assembly name + type name is completely disabled (no warnings, ignored) - see the comment added, but there's no good way to do it in most cases and probably not common. We can improve if really necessary.
* `Type.GetType` doesn't actually resolve any types since we don't have a type resolver implementation in the analyzer. This change makes all the rest work as appropriate, so once we do have a type resolver, it should all just light up.

I added test to cover at least basic type resolver cases in a way that it shows that analyzer doesn't handle it.

Other small things:
* Analyzer's ability to handle boolean constants
* Minor cleanup