### PR TITLE
Add ability for the analyzer to recognize const fields

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
@@ -34,6 +34,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestStringEmpty ();
 
 			TypeWithWarnings.Test ();
+			OverConstTypeName.Test ();
 
 			// TODO:
 			// Test multi-value returns
@@ -163,7 +164,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class TypeWithWarnings
 		{
-
 			[RequiresUnreferencedCode ("--Method1--")]
 			public void Method1 () { }
 
@@ -176,6 +176,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public static void Test ()
 			{
 				Type.GetType ("Mono.Linker.Tests.Cases.DataFlow." + nameof (GetTypeDataFlow) + "+" + nameof (TypeWithWarnings)).RequiresPublicMethods ();
+			}
+		}
+
+		class OverConstTypeName
+		{
+			private const string s_ConstTypeName = "Mono.Linker.Tests.Cases.DataFlow." + nameof (GetTypeDataFlow) + "+" + nameof (OverConstTypeName);
+
+			[RequiresUnreferencedCode ("--Method1--")]
+			public void Method1 () { }
+
+			// https://github.com/dotnet/linker/issues/2273
+			[ExpectedWarning ("IL2026", "--Method1--", ProducedBy = ProducedBy.Trimmer)]
+			public static void Test ()
+			{
+				Type.GetType (s_ConstTypeName).RequiresPublicMethods ();
 			}
 		}
 


### PR DESCRIPTION
This means the value of the fields is tracked as a const value instead of a field reference.
This is to support some additional code patterns as well as align the behavior with the linker. Compiler will inline the const fields into the IL effectively removing the field reference in these cases and linker only sees the constant. So ideally the analyzer should have a similar behavior.

This is currently blocking runtime integration: https://github.com/dotnet/runtime/pull/68650