### PR TITLE
Add ValueHolder to represent places where a value can be stored and referenced

### DIFF
--- a/src/ILLink.Shared/ILLink.Shared.projitems
+++ b/src/ILLink.Shared/ILLink.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/**/*.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TrimAnalysis\MemorySlot.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)SharedStrings.resx">

--- a/src/ILLink.Shared/ILLink.Shared.projitems
+++ b/src/ILLink.Shared/ILLink.Shared.projitems
@@ -10,7 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/**/*.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)TrimAnalysis\MemorySlot.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)SharedStrings.resx">

--- a/src/ILLink.Shared/TrimAnalysis/ValueHolder.cs
+++ b/src/ILLink.Shared/TrimAnalysis/ValueHolder.cs
@@ -1,0 +1,60 @@
+﻿using System.Diagnostics;
+using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
+
+namespace ILLink.Shared.TrimAnalysis
+{
+	internal partial class ValueHolder : IValueHolder
+    {
+		public MultiValue Value { get; private set; }
+		internal ValueHolderKind Kind { get; init; }
+		internal ValueHolder (MultiValue value, ValueHolderKind kind)
+		{
+			Value = value;
+			Kind = kind;
+		}
+		internal partial class ValueHolderReference<TKey> : IValueHolder
+		{
+			readonly ValueHolder Holder;
+			public readonly TKey Key;
+			internal ValueHolderReference (ValueHolder slot, TKey key)
+			{
+				Holder = slot;
+				Key = key;
+			}
+			public  MultiValue Value => Holder.Value;
+			internal ValueHolderKind Kind => Holder.Kind;
+			internal void SetValue (MultiValue value)
+			{
+				Debug.Assert (IsMutable);
+				Holder.Value = value;
+			}
+			public bool IsMutable { get => IsMutableKind (Kind); }
+		}
+
+
+		public static bool IsMutableKind (ValueHolderKind kind)
+		{
+			return kind switch {
+				ValueHolderKind.LocalVariable => true,
+				ValueHolderKind.Field => true,
+				ValueHolderKind.Parameter => false,
+				ValueHolderKind.ArrayElement => true,
+				ValueHolderKind.Stack => false
+			};
+		}
+    }
+
+	internal enum ValueHolderKind
+	{
+		LocalVariable,
+		Field,
+		Parameter,
+		ArrayElement,
+		Stack
+	}
+
+	internal interface IValueHolder
+	{
+		MultiValue Value { get; }
+	}
+}

--- a/src/ILLink.Shared/TrimAnalysis/ValueHolder.cs
+++ b/src/ILLink.Shared/TrimAnalysis/ValueHolder.cs
@@ -16,9 +16,9 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			readonly ValueHolder Holder;
 			public readonly TKey Key;
-			internal ValueHolderReference (ValueHolder slot, TKey key)
+			internal ValueHolderReference (ValueHolder holder, TKey key)
 			{
-				Holder = slot;
+				Holder = holder;
 				Key = key;
 			}
 			public  MultiValue Value => Holder.Value;
@@ -36,10 +36,11 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			return kind switch {
 				ValueHolderKind.LocalVariable => true,
-				ValueHolderKind.Field => true,
+				ValueHolderKind.Field => false,
 				ValueHolderKind.Parameter => false,
 				ValueHolderKind.ArrayElement => true,
-				ValueHolderKind.Stack => false
+				ValueHolderKind.Stack => false,
+				_ => false
 			};
 		}
     }

--- a/src/ILLink.Shared/TrimAnalysis/ValueHolder.cs
+++ b/src/ILLink.Shared/TrimAnalysis/ValueHolder.cs
@@ -1,36 +1,78 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using ILLink.Shared.DataFlow;
 using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	internal partial class ValueHolder : IValueHolder
+	/// <summary>
+	/// Represents a single location in memory
+	/// </summary>
+	public partial class ValueHolder
     {
 		public MultiValue Value { get; private set; }
-		internal ValueHolderKind Kind { get; init; }
-		internal ValueHolder (MultiValue value, ValueHolderKind kind)
+		internal ValueHolder (MultiValue value)
 		{
 			Value = value;
-			Kind = kind;
 		}
-		internal partial class ValueHolderReference<TKey> : IValueHolder
+		/// <summary>
+		/// Represents a reference to a location that can hold a value. Exposes the ability to mutate the value held at a location.
+		/// </summary>
+		public partial record Reference : SingleValue
 		{
-			readonly ValueHolder Holder;
-			public readonly TKey Key;
-			internal ValueHolderReference (ValueHolder holder, TKey key)
+			internal Reference (ValueHolder holder, ValueHolderKind kind)
 			{
 				Holder = holder;
-				Key = key;
+				Kind = kind;
 			}
-			public  MultiValue Value => Holder.Value;
-			internal ValueHolderKind Kind => Holder.Kind;
+
+			private Reference (SingleValue value, ValueHolderKind kind)
+			{
+				_value = value;
+				Kind = kind;
+				Holder = null;
+			}
+			public static Reference FieldReference (MultiValue value)
+			{
+				return new Reference (value, ValueHolderKind.Field);
+			}
+
+			public static Reference ParameterReference (MultiValue value)
+			{
+				return new Reference (value, ValueHolderKind.Parameter);
+			}
+
+			public readonly ValueHolderKind Kind;
+
+			readonly ValueHolder? Holder;
+
+			readonly SingleValue? _value;
+
+			public MultiValue Value { get => _value ?? Holder!.Value; }
+
 			internal void SetValue (MultiValue value)
 			{
-				Debug.Assert (IsMutable);
-				Holder.Value = value;
+				if (!IsMutable)
+					throw new InvalidOperationException ($"Cannot assign new value to value location type {Enum.GetName(typeof(ValueHolderKind), Kind)}");
+				Holder!.Value = value;
+			}
+
+			internal void SetToMeetValue (MultiValue value)
+			{
+				if (!IsMutable)
+					throw new InvalidOperationException ($"Cannot assign new value to value location type {Enum.GetName(typeof(ValueHolderKind), Kind)}");
+				Holder!.Value = MultiValue.Meet (Holder.Value, value);
 			}
 			public bool IsMutable { get => IsMutableKind (Kind); }
-		}
 
+			public override SingleValue DeepCopy ()
+			{
+				if (Holder is not null)
+					return new Reference (Holder, Kind);
+				return new Reference (_value!, Kind);
+			}
+		}
 
 		public static bool IsMutableKind (ValueHolderKind kind)
 		{
@@ -39,23 +81,60 @@ namespace ILLink.Shared.TrimAnalysis
 				ValueHolderKind.Field => false,
 				ValueHolderKind.Parameter => false,
 				ValueHolderKind.ArrayElement => true,
-				ValueHolderKind.Stack => false,
 				_ => false
 			};
 		}
     }
 
-	internal enum ValueHolderKind
+	/// <summary>
+	/// Represents a reference type with fields, indices, or other members that hold values
+	/// </summary>
+	/// <typeparam name="TKey">The type that is used to find the values of fields / indices stored in the object. e.g. int or ConstIntValue for arrays or indexable types</typeparam>
+	/// <typeparam name="TValue">The type of the values stored in the reference type</typeparam>
+	/// <remarks>This is just a prototype for a potential value we could use</remarks>
+	internal record ReferenceTypeValueHolder<TKey, TValue> : SingleValue
+		where TKey : notnull
+	{
+		public ReferenceTypeValueHolder (Dictionary<TKey, TValue> values)
+		{
+			_values = values;
+		}
+		private Dictionary<TKey, TValue> _values;
+
+		public virtual bool TryGetValue (TKey key, out TValue value) => _values.TryGetValue (key, out value);
+
+		public virtual void SetValue (TKey key, TValue value) => _values.Add (key, value);
+
+		public virtual void SetToReferenceOf(ReferenceTypeValueHolder<TKey, TValue> other)
+		{
+			_values = other._values;
+		}
+
+		public virtual void CopyFrom (ReferenceTypeValueHolder<TKey, TValue> other)
+		{
+			_values.Clear ();
+			foreach (TKey key in other._values.Keys) {
+				TValue value = other._values[key];
+				_values[key] = value;
+			}
+		}
+
+		public override SingleValue DeepCopy ()
+		{
+			var newVals = new Dictionary<TKey, TValue> ();
+			foreach (TKey key in _values.Keys) {
+				TValue value = _values[key];
+				newVals.Add (key, value);
+			}
+			return new ReferenceTypeValueHolder<TKey, TValue> (newVals);
+		}
+	}
+
+	public enum ValueHolderKind
 	{
 		LocalVariable,
 		Field,
 		Parameter,
-		ArrayElement,
-		Stack
-	}
-
-	internal interface IValueHolder
-	{
-		MultiValue Value { get; }
+		ArrayElement
 	}
 }

--- a/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -36,11 +36,11 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			Size = size;
 			ElementType = elementType;
-			IndexValues = new Dictionary<int, ValueBasicBlockPair> ();
+			IndexValues = new Dictionary<int, MemorySlotBasicBlockPair> ();
 		}
 
 		public TypeReference ElementType { get; }
-		public Dictionary<int, ValueBasicBlockPair> IndexValues { get; }
+		public Dictionary<int, MemorySlotBasicBlockPair> IndexValues { get; }
 
 		public partial bool TryGetValueByIndex (int index, out MultiValue value)
 		{
@@ -69,8 +69,8 @@ namespace ILLink.Shared.TrimAnalysis
 				return false;
 
 			// If both sets T and O are the same size and "T intersect O" is empty, then T == O.
-			HashSet<KeyValuePair<int, ValueBasicBlockPair>> thisValueSet = new (IndexValues);
-			HashSet<KeyValuePair<int, ValueBasicBlockPair>> otherValueSet = new (otherArr.IndexValues);
+			HashSet<KeyValuePair<int, MemorySlotBasicBlockPair>> thisValueSet = new (IndexValues);
+			HashSet<KeyValuePair<int, MemorySlotBasicBlockPair>> otherValueSet = new (otherArr.IndexValues);
 			thisValueSet.ExceptWith (otherValueSet);
 			return thisValueSet.Count == 0;
 		}
@@ -79,7 +79,7 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			var newValue = new ArrayValue (Size.DeepCopy (), ElementType);
 			foreach (var kvp in IndexValues) {
-				newValue.IndexValues.Add (kvp.Key, new ValueBasicBlockPair (kvp.Value.Value.Clone (), kvp.Value.BasicBlockIndex));
+				newValue.IndexValues.Add (kvp.Key, new MemorySlotBasicBlockPair (kvp.Value.Value.Clone (), kvp.Value.BasicBlockIndex));
 			}
 
 			return newValue;

--- a/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -79,7 +79,7 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			var newValue = new ArrayValue (Size.DeepCopy (), ElementType);
 			foreach (var kvp in IndexValues) {
-				newValue.IndexValues.Add (kvp.Key, new MemorySlotBasicBlockPair (kvp.Value.Value.Clone (), kvp.Value.BasicBlockIndex));
+				newValue.IndexValues.Add (kvp.Key, new ValueHolderBasicBlockPair (kvp.Value.Value, kvp.Value.BasicBlockIndex));
 			}
 
 			return newValue;
@@ -103,7 +103,7 @@ namespace ILLink.Shared.TrimAnalysis
 				result.Append (element.Key);
 				result.Append (",(");
 				bool firstValue = true;
-				foreach (var v in element.Value.Value) {
+				foreach (var v in element.Value.Value.Value) {
 					if (firstValue) {
 						result.Append (",");
 						firstValue = false;

--- a/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -36,11 +36,11 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			Size = size;
 			ElementType = elementType;
-			IndexValues = new Dictionary<int, MemorySlotBasicBlockPair> ();
+			IndexValues = new Dictionary<int, ValueHolderBasicBlockPair> ();
 		}
 
 		public TypeReference ElementType { get; }
-		public Dictionary<int, MemorySlotBasicBlockPair> IndexValues { get; }
+		public Dictionary<int, ValueHolderBasicBlockPair> IndexValues { get; }
 
 		public partial bool TryGetValueByIndex (int index, out MultiValue value)
 		{
@@ -69,8 +69,8 @@ namespace ILLink.Shared.TrimAnalysis
 				return false;
 
 			// If both sets T and O are the same size and "T intersect O" is empty, then T == O.
-			HashSet<KeyValuePair<int, MemorySlotBasicBlockPair>> thisValueSet = new (IndexValues);
-			HashSet<KeyValuePair<int, MemorySlotBasicBlockPair>> otherValueSet = new (otherArr.IndexValues);
+			HashSet<KeyValuePair<int, ValueHolderBasicBlockPair>> thisValueSet = new (IndexValues);
+			HashSet<KeyValuePair<int, ValueHolderBasicBlockPair>> otherValueSet = new (otherArr.IndexValues);
 			thisValueSet.ExceptWith (otherValueSet);
 			return thisValueSet.Count == 0;
 		}

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -890,7 +890,7 @@ namespace Mono.Linker.Dataflow
 			ValueNodeList methodParams = new ValueNodeList (countToPop);
 			for (int iParam = 0; iParam < countToPop; ++iParam) {
 				StackSlot slot = PopUnknown (currentStack, 1, containingMethodBody, ilOffset);
-				methodParams.Add (slot.ValueHolder);
+				methodParams.Add (slot.ValueHolder.Value);
 			}
 
 			if (isNewObj) {
@@ -942,7 +942,7 @@ namespace Mono.Linker.Dataflow
 					new StackSlot (
 						calledMethod.ReturnType.IsByRefOrPointer () ? 
 						new ValueHolder.ValueHolderReference<VariableReference> (new ValueHolder (methodReturnValue, ValueHolderKind.Stack), null)
-						: new ValueHolder (methodReturnValue, ValueHolderKind.Stack));
+						: new ValueHolder (methodReturnValue, ValueHolderKind.Stack)));
 
 			foreach (var param in methodParams) {
 				foreach (var v in param) {

--- a/src/linker/Linker.Dataflow/SingleValueExtensions.cs
+++ b/src/linker/Linker.Dataflow/SingleValueExtensions.cs
@@ -61,7 +61,7 @@ namespace ILLink.Shared.TrimAnalysis
 			case ArrayValue:
 				ArrayValue av = (ArrayValue) node;
 				foundCycle = av.Size.DetectCycle (seenNodes, allNodesSeen);
-				foreach (ValueBasicBlockPair pair in av.IndexValues.Values) {
+				foreach (MemorySlotBasicBlockPair pair in av.IndexValues.Values) {
 					foreach (var v in pair.Value) {
 						foundCycle |= v.DetectCycle (seenNodes, allNodesSeen);
 					}

--- a/src/linker/Linker.Dataflow/SingleValueExtensions.cs
+++ b/src/linker/Linker.Dataflow/SingleValueExtensions.cs
@@ -61,7 +61,7 @@ namespace ILLink.Shared.TrimAnalysis
 			case ArrayValue:
 				ArrayValue av = (ArrayValue) node;
 				foundCycle = av.Size.DetectCycle (seenNodes, allNodesSeen);
-				foreach (MemorySlotBasicBlockPair pair in av.IndexValues.Values) {
+				foreach (ValueHolderBasicBlockPair pair in av.IndexValues.Values) {
 					foreach (var v in pair.Value) {
 						foundCycle |= v.DetectCycle (seenNodes, allNodesSeen);
 					}

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using ILLink.Shared.TrimAnalysis;
 using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
 namespace Mono.Linker.Dataflow
@@ -47,15 +48,15 @@ namespace Mono.Linker.Dataflow
 		}
 	}
 
-	public struct ValueBasicBlockPair
+	internal struct MemorySlotBasicBlockPair
 	{
-		public ValueBasicBlockPair (MultiValue value, int basicBlockIndex)
+		internal MemorySlotBasicBlockPair (MemorySlot slot, int basicBlockIndex)
 		{
-			Value = value;
+			Value = slot;
 			BasicBlockIndex = basicBlockIndex;
 		}
 
-		public MultiValue Value { get; }
+		public MemorySlot Value { get; }
 		public int BasicBlockIndex { get; }
 	}
 }

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -50,13 +50,13 @@ namespace Mono.Linker.Dataflow
 
 	internal struct ValueHolderBasicBlockPair
 	{
-		internal ValueHolderBasicBlockPair (MemorySlot slot, int basicBlockIndex)
+		internal ValueHolderBasicBlockPair (ValueHolder holder, int basicBlockIndex)
 		{
-			Value = slot;
+			Value = holder;
 			BasicBlockIndex = basicBlockIndex;
 		}
 
-		public MemorySlot Value { get; }
+		public ValueHolder Value { get; }
 		public int BasicBlockIndex { get; }
 	}
 }

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -48,9 +48,9 @@ namespace Mono.Linker.Dataflow
 		}
 	}
 
-	internal struct MemorySlotBasicBlockPair
+	internal struct ValueHolderBasicBlockPair
 	{
-		internal MemorySlotBasicBlockPair (MemorySlot slot, int basicBlockIndex)
+		internal ValueHolderBasicBlockPair (MemorySlot slot, int basicBlockIndex)
 		{
 			Value = slot;
 			BasicBlockIndex = basicBlockIndex;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/RefLocal.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/RefLocal.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.LinkXml.PreserveNamespace;
+using DAM = System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute;
+using DAMT = System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	class RefLocal
+	{
+		static void Main ()
+		{
+
+		}
+
+		static void TestMeetRefVariations
+			<[DAM (DAMT.PublicMethods)] TPublicMethods,
+			 [DAM (DAMT.PublicFields)] TPublicFields,
+			 [DAM (DAMT.PublicNestedTypes)] TPublicNestedTypes> (int condition)
+		{
+			var t1 = typeof (TPublicMethods);
+			var t2 = typeof (TPublicFields);
+			var t3 = typeof (TPublicNestedTypes);
+
+			ref Type r1 = ref t1;
+			ref Type r2 = ref t2;
+			ref Type r3 = ref t3;
+
+			switch (condition) {
+			case 1:
+				r1 = r2; // A
+				break;
+			case 2:
+				r1 = r3; // B
+				r1 = typeof (TPublicFields); // C
+				break;
+			case 3:
+				r1 = typeof (TPublicNestedTypes); // D
+				break;
+			default:
+				break;
+			}
+			// r1: {
+			//	-> t1,
+			//	-> t3,
+			// }
+			// r2: {
+			//	-> t2
+			// }
+			// r3: {
+			//	-> t3
+			// }
+			// t1: {
+			//	TPublicMethods
+			//	TPublicNestedTypes (D)
+			// }
+			// t2: {
+			//	TPublicFields
+			// }
+			// t3: {
+			//	TPublicNestedTypes
+			//	TPublicFields (B -> C)
+
+			r2 = r1;
+			// r2: {
+			//	-> t1
+			//	-> t2
+			//	-> t3
+			// }
+
+
+		}
+	}
+}


### PR DESCRIPTION
Related to https://github.com/dotnet/linker/pull/2769

In order to fully support `ref` parameters and locals, we need to be able to (1) know what kind of variable the value comes from (parameter, local, or array), and (2) mutate the value in place (or share to all other references that the value has changed). The current dataflow tracking doesn't make a real distinction between a value and an entity that can hold a value, and I think that it might be a good idea to fully separate those concepts into something like Values and ValueHolders.

This PR is a prototype for what the ValueHolder might look like in the Linker, and some of the changes necessary in MethodBodyScanner. There would be much more changes necessary to integrate ValueHolder completely (I'm expecting ValueHolder to replace MultiValue in most places), and it won't pass CI, I just wanted to get feedback and alternative ideas early on, and discuss if this is a direction we should go in.

Alternatively, we could use a struct that has a reference to a MultiValue, and a ValueHolderKind as a special case for references. This may be a simpler change, but it seems like it would involve lots of special casing and doesn't separate the concept of Values and ThingsThatCanHoldValues.