### PR TITLE
Match analyzer and linker requires methods

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -183,7 +183,7 @@ namespace ILLink.RoslynAnalyzer
 							if (instanceCtor.Arity > 0)
 								continue;
 
-							if (instanceCtor.DoesMemberRequires (RequiresAttributeName, out var requiresAttribute) &&
+							if (instanceCtor.DoesMemberRequire (RequiresAttributeName, out var requiresAttribute) &&
 								VerifyAttributeArguments (requiresAttribute)) {
 								syntaxNodeAnalysisContext.ReportDiagnostic (Diagnostic.Create (RequiresDiagnosticRule,
 									syntaxNodeAnalysisContext.Node.GetLocation (),
@@ -213,7 +213,7 @@ namespace ILLink.RoslynAnalyzer
 						return;
 
 					foreach (var attr in symbol.GetAttributes ()) {
-						if (attr.AttributeConstructor?.DoesMemberRequires (RequiresAttributeName, out var requiresAttribute) == true) {
+						if (attr.AttributeConstructor?.DoesMemberRequire (RequiresAttributeName, out var requiresAttribute) == true) {
 							symbolAnalysisContext.ReportDiagnostic (Diagnostic.Create (RequiresDiagnosticRule,
 								symbol.Locations[0], attr.AttributeConstructor.GetDisplayName (), GetMessageFromAttribute (requiresAttribute), GetUrlFromAttribute (requiresAttribute)));
 						}
@@ -242,7 +242,7 @@ namespace ILLink.RoslynAnalyzer
 					while (member is IMethodSymbol method && method.OverriddenMethod != null && SymbolEqualityComparer.Default.Equals (method.ReturnType, method.OverriddenMethod.ReturnType))
 						member = method.OverriddenMethod;
 
-					if (!member.DoesMemberRequires (RequiresAttributeName, out var requiresAttribute))
+					if (!member.DoesMemberRequire (RequiresAttributeName, out var requiresAttribute))
 						return;
 
 					if (!VerifyAttributeArguments (requiresAttribute))
@@ -353,8 +353,8 @@ namespace ILLink.RoslynAnalyzer
 
 		private bool HasMismatchingAttributes (ISymbol member1, ISymbol member2)
 		{
-			bool member1CreatesRequirement = member1.DoesMemberRequires (RequiresAttributeName, out _);
-			bool member2CreatesRequirement = member2.DoesMemberRequires (RequiresAttributeName, out _);
+			bool member1CreatesRequirement = member1.DoesMemberRequire (RequiresAttributeName, out _);
+			bool member2CreatesRequirement = member2.DoesMemberRequire (RequiresAttributeName, out _);
 			bool member1FulfillsRequirement = member1.IsOverrideInRequiresScope (RequiresAttributeName);
 			bool member2FulfillsRequirement = member2.IsOverrideInRequiresScope (RequiresAttributeName);
 			return (member1CreatesRequirement && !member2FulfillsRequirement) || (member2CreatesRequirement && !member1FulfillsRequirement);

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -183,7 +183,7 @@ namespace ILLink.RoslynAnalyzer
 							if (instanceCtor.Arity > 0)
 								continue;
 
-							if (instanceCtor.TargetHasRequiresAttribute (RequiresAttributeName, out var requiresAttribute) &&
+							if (instanceCtor.DoesMemberRequires (RequiresAttributeName, out var requiresAttribute) &&
 								VerifyAttributeArguments (requiresAttribute)) {
 								syntaxNodeAnalysisContext.ReportDiagnostic (Diagnostic.Create (RequiresDiagnosticRule,
 									syntaxNodeAnalysisContext.Node.GetLocation (),
@@ -213,7 +213,7 @@ namespace ILLink.RoslynAnalyzer
 						return;
 
 					foreach (var attr in symbol.GetAttributes ()) {
-						if (attr.AttributeConstructor?.TargetHasRequiresAttribute (RequiresAttributeName, out var requiresAttribute) == true) {
+						if (attr.AttributeConstructor?.DoesMemberRequires (RequiresAttributeName, out var requiresAttribute) == true) {
 							symbolAnalysisContext.ReportDiagnostic (Diagnostic.Create (RequiresDiagnosticRule,
 								symbol.Locations[0], attr.AttributeConstructor.GetDisplayName (), GetMessageFromAttribute (requiresAttribute), GetUrlFromAttribute (requiresAttribute)));
 						}
@@ -242,7 +242,7 @@ namespace ILLink.RoslynAnalyzer
 					while (member is IMethodSymbol method && method.OverriddenMethod != null && SymbolEqualityComparer.Default.Equals (method.ReturnType, method.OverriddenMethod.ReturnType))
 						member = method.OverriddenMethod;
 
-					if (!member.TargetHasRequiresAttribute (RequiresAttributeName, out var requiresAttribute))
+					if (!member.DoesMemberRequires (RequiresAttributeName, out var requiresAttribute))
 						return;
 
 					if (!VerifyAttributeArguments (requiresAttribute))
@@ -353,8 +353,8 @@ namespace ILLink.RoslynAnalyzer
 
 		private bool HasMismatchingAttributes (ISymbol member1, ISymbol member2)
 		{
-			bool member1CreatesRequirement = member1.TargetHasRequiresAttribute (RequiresAttributeName, out _);
-			bool member2CreatesRequirement = member2.TargetHasRequiresAttribute (RequiresAttributeName, out _);
+			bool member1CreatesRequirement = member1.DoesMemberRequires (RequiresAttributeName, out _);
+			bool member2CreatesRequirement = member2.DoesMemberRequires (RequiresAttributeName, out _);
 			bool member1FulfillsRequirement = member1.IsOverrideInRequiresScope (RequiresAttributeName);
 			bool member2FulfillsRequirement = member2.IsOverrideInRequiresScope (RequiresAttributeName);
 			return (member1CreatesRequirement && !member2FulfillsRequirement) || (member2CreatesRequirement && !member1FulfillsRequirement);

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -12,7 +12,7 @@ namespace ILLink.RoslynAnalyzer
 		/// <summary>
 		/// True if the target of a call is considered to be annotated with the Requires... attribute
 		/// </summary>
-		public static bool DoesMemberRequires (this ISymbol member, string requiresAttribute, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData)
+		public static bool DoesMemberRequire (this ISymbol member, string requiresAttribute, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData)
 		{
 			requiresAttributeData = null;
 			if (member.IsStaticConstructor ())
@@ -41,7 +41,7 @@ namespace ILLink.RoslynAnalyzer
 		/// True if member of a call is considered to be annotated with the Requires... attribute.
 		/// Doesn't check the associated symbol for overrides and virtual methods because the analyzer should warn on mismatched between the property AND the accessors
 		/// </summary>
-		/// <param name="containingSymbol">
+		/// <param name="member">
 		///	Symbol that is either an overriding member or an overriden/virtual member
 		/// </param>
 		public static bool IsOverrideInRequiresScope (this ISymbol member, string requiresAttribute)

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -8,7 +8,7 @@ namespace ILLink.RoslynAnalyzer
 {
 	public static class RequiresISymbolExtensions
 	{
-		// TODO: Consider sharing with linker DoesMemberRequires method
+		// TODO: Consider sharing with linker DoesMemberRequire method
 		/// <summary>
 		/// True if the target of a call is considered to be annotated with the Requires... attribute
 		/// </summary>

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -8,11 +8,11 @@ namespace ILLink.RoslynAnalyzer
 {
 	public static class RequiresISymbolExtensions
 	{
-		// TODO: Consider sharing with linker DoesMethodRequireUnreferencedCode method
+		// TODO: Consider sharing with linker DoesMemberRequires method
 		/// <summary>
 		/// True if the target of a call is considered to be annotated with the Requires... attribute
 		/// </summary>
-		public static bool TargetHasRequiresAttribute (this ISymbol member, string requiresAttribute, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData)
+		public static bool DoesMemberRequires (this ISymbol member, string requiresAttribute, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData)
 		{
 			requiresAttributeData = null;
 			if (member.IsStaticConstructor ())
@@ -28,7 +28,7 @@ namespace ILLink.RoslynAnalyzer
 			return false;
 		}
 
-		// TODO: Consider sharing with linker IsMethodInRequiresUnreferencedCodeScope method
+		// TODO: Consider sharing with linker IsInRequiresScope method
 		/// <summary>
 		/// True if the source of a call is considered to be annotated with the Requires... attribute
 		/// </summary>

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeUtils.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeUtils.cs
@@ -12,14 +12,14 @@ namespace ILLink.RoslynAnalyzer
 		private const string RequiresUnreferencedCodeAttribute = nameof (RequiresUnreferencedCodeAttribute);
 
 		public static bool TryGetRequiresUnreferencedCodeAttribute (this ISymbol member, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData) =>
-			member.DoesMemberRequiresUnreferencedCodeAttribute (out requiresAttributeData) && VerifyRequiresUnreferencedCodeAttributeArguments (requiresAttributeData);
+			member.DoesMemberRequireUnreferencedCodeAttribute (out requiresAttributeData) && VerifyRequiresUnreferencedCodeAttributeArguments (requiresAttributeData);
 
 		// TODO: Consider sharing with linker DoesMethodRequireUnreferencedCode method
 		/// <summary>
 		/// True if the target of a call is considered to be annotated with the RequiresUnreferencedCode attribute
 		/// </summary>
-		public static bool DoesMemberRequiresUnreferencedCodeAttribute (this ISymbol member, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData)
-			=> member.DoesMemberRequires (RequiresUnreferencedCodeAttribute, out requiresAttributeData);
+		public static bool DoesMemberRequireUnreferencedCodeAttribute (this ISymbol member, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData)
+			=> member.DoesMemberRequire (RequiresUnreferencedCodeAttribute, out requiresAttributeData);
 
 		// TODO: Consider sharing with linker IsMethodInRequiresUnreferencedCodeScope method
 		/// <summary>

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeUtils.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeUtils.cs
@@ -12,14 +12,14 @@ namespace ILLink.RoslynAnalyzer
 		private const string RequiresUnreferencedCodeAttribute = nameof (RequiresUnreferencedCodeAttribute);
 
 		public static bool TryGetRequiresUnreferencedCodeAttribute (this ISymbol member, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData) =>
-			member.TargetHasRequiresUnreferencedCodeAttribute (out requiresAttributeData) && VerifyRequiresUnreferencedCodeAttributeArguments (requiresAttributeData);
+			member.DoesMemberRequiresUnreferencedCodeAttribute (out requiresAttributeData) && VerifyRequiresUnreferencedCodeAttributeArguments (requiresAttributeData);
 
 		// TODO: Consider sharing with linker DoesMethodRequireUnreferencedCode method
 		/// <summary>
 		/// True if the target of a call is considered to be annotated with the RequiresUnreferencedCode attribute
 		/// </summary>
-		public static bool TargetHasRequiresUnreferencedCodeAttribute (this ISymbol member, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData)
-			=> member.TargetHasRequiresAttribute (RequiresUnreferencedCodeAttribute, out requiresAttributeData);
+		public static bool DoesMemberRequiresUnreferencedCodeAttribute (this ISymbol member, [NotNullWhen (returnValue: true)] out AttributeData? requiresAttributeData)
+			=> member.DoesMemberRequires (RequiresUnreferencedCodeAttribute, out requiresAttributeData);
 
 		// TODO: Consider sharing with linker IsMethodInRequiresUnreferencedCodeScope method
 		/// <summary>

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -187,7 +187,11 @@ namespace ILLink.Shared
 		// Dynamic code diagnostic ids.
 		RequiresDynamicCode = 3050,
 		RequiresDynamicCodeAttributeMismatch = 3051,
-		RequiresDynamicCodeOnStaticConstructor = 3052
+		RequiresDynamicCodeOnStaticConstructor = 3052,
+		COMInteropNotSupportedInFullAOT = 3052,
+		AssemblyProducedAOTWarnings = 3053,
+		GenericRecursionCycle = 3054,
+		CorrectnessOfAbstractDelegatesCannotBeGuaranteed = 3055,
 	}
 
 	public static class DiagnosticIdExtensions
@@ -204,11 +208,13 @@ namespace ILLink.Shared
 				2045 => MessageSubCategory.TrimAnalysis,
 				2046 => MessageSubCategory.TrimAnalysis,
 				2050 => MessageSubCategory.TrimAnalysis,
-				var x when x >= 2055 && x <= 2099 => MessageSubCategory.TrimAnalysis,
+				>= 2055 and <= 2099 => MessageSubCategory.TrimAnalysis,
 				2103 => MessageSubCategory.TrimAnalysis,
 				2106 => MessageSubCategory.TrimAnalysis,
 				2107 => MessageSubCategory.TrimAnalysis,
-				var x when x >= 2109 && x <= 2116 => MessageSubCategory.TrimAnalysis,
+				>= 2109 and <= 2116 => MessageSubCategory.TrimAnalysis,
+				>= 3050 and <= 3052 => MessageSubCategory.AotAnalysis,
+				>= 3054 and <= 3055 => MessageSubCategory.AotAnalysis,
 				_ => MessageSubCategory.None,
 			};
 	}

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -187,11 +187,11 @@ namespace ILLink.Shared
 		// Dynamic code diagnostic ids.
 		RequiresDynamicCode = 3050,
 		RequiresDynamicCodeAttributeMismatch = 3051,
-		RequiresDynamicCodeOnStaticConstructor = 3052,
 		COMInteropNotSupportedInFullAOT = 3052,
 		AssemblyProducedAOTWarnings = 3053,
 		GenericRecursionCycle = 3054,
 		CorrectnessOfAbstractDelegatesCannotBeGuaranteed = 3055,
+		RequiresDynamicCodeOnStaticConstructor = 3056,
 	}
 
 	public static class DiagnosticIdExtensions

--- a/src/ILLink.Shared/ILLink.Shared.projitems
+++ b/src/ILLink.Shared/ILLink.Shared.projitems
@@ -22,6 +22,5 @@
     <None Include="$(MSBuildThisFileDirectory)ILLink.LinkAttributes.xsd">
       <SubType>Designer</SubType>
     </None>
-    <None Include="$(MSBuildThisFileDirectory)ILLink.xsd" />
   </ItemGroup>
 </Project>

--- a/src/ILLink.Shared/MessageSubCategory.cs
+++ b/src/ILLink.Shared/MessageSubCategory.cs
@@ -8,5 +8,6 @@ namespace ILLink.Shared
 		public const string None = "";
 		public const string TrimAnalysis = "Trim analysis";
 		public const string UnresolvedAssembly = "Unresolved assembly";
+		public const string AotAnalysis = "AOT analysis";
 	}
 }

--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -1107,6 +1107,30 @@
   <data name="RequiresDynamicCodeAttributeMismatchMessage" xml:space="preserve">
     <value>{0}. 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.</value>
   </data>
+  <data name="COMInteropNotSupportedInFullAOTTitle" xml:space="preserve">
+    <value>COM interop is not supported with full ahead of time compilation.</value>
+  </data>
+  <data name="COMInteropNotSupportedInFullAOTMessage" xml:space="preserve">
+    <value>COM interop is not supported with full ahead of time compilation.</value>
+  </data>
+  <data name="AssemblyProducedAOTWarningsTitle" xml:space="preserve">
+    <value>Assembly produced AOT analysis warnings.</value>
+  </data>
+  <data name="AssemblyProducedAOTWarningsMessage" xml:space="preserve">
+    <value>Assembly '{0}' produced AOT analysis warnings.</value>
+  </data>
+  <data name="GenericRecursionCycleTitle" xml:space="preserve">
+    <value>Generic expansion to was aborted due to generic recursion. An exception will be thrown at runtime if this codepath is ever reached.</value>
+  </data>
+  <data name="GenericRecursionCycleMessage" xml:space="preserve">
+    <value>Generic expansion to '{0}' was aborted due to generic recursion. An exception will be thrown at runtime if this codepath is ever reached. Generic recursion also negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: {1}</value>
+  </data>
+  <data name="CorrectnessOfAbstractDelegatesCannotBeGuaranteedTitle" xml:space="preserve">
+    <value>P/invoke method declares a parameter with an abstract delegate. Correctness of interop for abstract delegates cannot be guaranteed after native compilation.</value>
+  </data>
+  <data name="CorrectnessOfAbstractDelegatesCannotBeGuaranteedMessage" xml:space="preserve">
+    <value>P/invoke method '{0}' declares a parameter with an abstract delegate. Correctness of interop for abstract delegates cannot be guaranteed after native compilation: the marshalling code for the delegate might not be available. Use a non-abstract delegate type or ensure any delegate instance passed as parameter is marked with `UnmanagedFunctionPointerAttribute`.</value>
+  </data>
   <data name="BaseRequiresMismatchMessage" xml:space="preserve">
     <value>Base member '{2}' with '{0}' has a derived member '{1}' without '{0}'</value>
   </data>

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -33,7 +33,7 @@ namespace Mono.Linker.Dataflow
 
 			return Intrinsics.GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
 				context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
-				context.Annotations.DoesMethodRequireUnreferencedCode (methodDefinition, out _) ||
+				context.Annotations.DoesMethodRequiresUnreferencedCode (methodDefinition, out _) ||
 				methodDefinition.IsPInvokeImpl;
 		}
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -33,7 +33,7 @@ namespace Mono.Linker.Dataflow
 
 			return Intrinsics.GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
 				context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
-				context.Annotations.DoesMethodRequiresUnreferencedCode (methodDefinition, out _) ||
+				context.Annotations.DoesMethodRequireUnreferencedCode (methodDefinition, out _) ||
 				methodDefinition.IsPInvokeImpl;
 		}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1654,7 +1654,7 @@ namespace Mono.Linker.Steps
 			}
 
 			if (reason.Kind != DependencyKind.DynamicallyAccessedMemberOnType &&
-				Annotations.DoesFieldRequiresUnreferencedCode (field, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCodeAttribute) &&
+				Annotations.DoesFieldRequireUnreferencedCode (field, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCodeAttribute) &&
 				!ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode (origin.Provider))
 				ReportRequiresUnreferencedCode (field.GetDisplayName (), requiresUnreferencedCodeAttribute, origin);
 
@@ -2943,7 +2943,7 @@ namespace Mono.Linker.Steps
 			if (ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode (origin.Provider))
 				return;
 
-			if (!Annotations.DoesMethodRequiresUnreferencedCode (method, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCode))
+			if (!Annotations.DoesMethodRequireUnreferencedCode (method, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCode))
 				return;
 
 			ReportRequiresUnreferencedCode (method.GetDisplayName (), requiresUnreferencedCode, origin);

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2919,7 +2919,7 @@ namespace Mono.Linker.Steps
 				return false;
 
 			if (originMember is MethodDefinition &&
-				Annotations.IsInRequiresScope ((MethodDefinition) originMember))
+				Annotations.IsInRequiresUnreferencedCodeScope ((MethodDefinition) originMember))
 				return true;
 
 			if (originMember is not IMemberDefinition member)
@@ -2928,7 +2928,7 @@ namespace Mono.Linker.Steps
 			MethodDefinition? owningMethod;
 			while (Context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (member, out owningMethod)) {
 				Debug.Assert (owningMethod != member);
-				if (Annotations.IsInRequiresScope (owningMethod))
+				if (Annotations.IsInRequiresUnreferencedCodeScope (owningMethod))
 					return true;
 				member = owningMethod;
 			}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1626,7 +1626,7 @@ namespace Mono.Linker.Steps
 			if (reportOnMember)
 				origin = new MessageOrigin (member);
 
-			if (Annotations.DoesMemberRequiresUnreferencedCode (member, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCodeAttribute)) {
+			if (Annotations.DoesMemberRequireUnreferencedCode (member, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCodeAttribute)) {
 				var id = reportOnMember ? DiagnosticId.DynamicallyAccessedMembersOnTypeReferencesMemberWithRequiresUnreferencedCode : DiagnosticId.DynamicallyAccessedMembersOnTypeReferencesMemberOnBaseWithRequiresUnreferencedCode;
 				Context.LogWarning (origin, id, type.GetDisplayName (),
 					((MemberReference) member).GetDisplayName (), // The cast is valid since it has to be a method or field

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1626,7 +1626,7 @@ namespace Mono.Linker.Steps
 			if (reportOnMember)
 				origin = new MessageOrigin (member);
 
-			if (Annotations.DoesMemberRequireUnreferencedCode (member, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCodeAttribute)) {
+			if (Annotations.DoesMemberRequiresUnreferencedCode (member, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCodeAttribute)) {
 				var id = reportOnMember ? DiagnosticId.DynamicallyAccessedMembersOnTypeReferencesMemberWithRequiresUnreferencedCode : DiagnosticId.DynamicallyAccessedMembersOnTypeReferencesMemberOnBaseWithRequiresUnreferencedCode;
 				Context.LogWarning (origin, id, type.GetDisplayName (),
 					((MemberReference) member).GetDisplayName (), // The cast is valid since it has to be a method or field
@@ -1654,7 +1654,7 @@ namespace Mono.Linker.Steps
 			}
 
 			if (reason.Kind != DependencyKind.DynamicallyAccessedMemberOnType &&
-				Annotations.DoesFieldRequireUnreferencedCode (field, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCodeAttribute) &&
+				Annotations.DoesFieldRequiresUnreferencedCode (field, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCodeAttribute) &&
 				!ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode (origin.Provider))
 				ReportRequiresUnreferencedCode (field.GetDisplayName (), requiresUnreferencedCodeAttribute, origin);
 
@@ -2919,7 +2919,7 @@ namespace Mono.Linker.Steps
 				return false;
 
 			if (originMember is MethodDefinition &&
-				Annotations.IsMethodInRequiresUnreferencedCodeScope ((MethodDefinition) originMember))
+				Annotations.IsInRequiresScope ((MethodDefinition) originMember))
 				return true;
 
 			if (originMember is not IMemberDefinition member)
@@ -2928,7 +2928,7 @@ namespace Mono.Linker.Steps
 			MethodDefinition? owningMethod;
 			while (Context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (member, out owningMethod)) {
 				Debug.Assert (owningMethod != member);
-				if (Annotations.IsMethodInRequiresUnreferencedCodeScope (owningMethod))
+				if (Annotations.IsInRequiresScope (owningMethod))
 					return true;
 				member = owningMethod;
 			}
@@ -2943,7 +2943,7 @@ namespace Mono.Linker.Steps
 			if (ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode (origin.Provider))
 				return;
 
-			if (!Annotations.DoesMethodRequireUnreferencedCode (method, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCode))
+			if (!Annotations.DoesMethodRequiresUnreferencedCode (method, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCode))
 				return;
 
 			ReportRequiresUnreferencedCode (method.GetDisplayName (), requiresUnreferencedCode, origin);

--- a/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
+++ b/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
@@ -40,8 +40,8 @@ namespace Mono.Linker.Steps
 		void ValidateMethodRequiresUnreferencedCodeAreSame (MethodDefinition method, MethodDefinition baseMethod)
 		{
 			var annotations = Context.Annotations;
-			bool methodHasAttribute = annotations.IsInRequiresScope (method);
-			if (methodHasAttribute != annotations.IsInRequiresScope (baseMethod)) {
+			bool methodHasAttribute = annotations.IsInRequiresUnreferencedCodeScope (method);
+			if (methodHasAttribute != annotations.IsInRequiresUnreferencedCodeScope (baseMethod)) {
 				string message = MessageFormat.FormatRequiresAttributeMismatch (methodHasAttribute,
 					baseMethod.DeclaringType.IsInterface, nameof (RequiresUnreferencedCodeAttribute), method.GetDisplayName (), baseMethod.GetDisplayName ());
 				Context.LogWarning (method, DiagnosticId.RequiresUnreferencedCodeAttributeMismatch, message);

--- a/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
+++ b/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
@@ -40,8 +40,8 @@ namespace Mono.Linker.Steps
 		void ValidateMethodRequiresUnreferencedCodeAreSame (MethodDefinition method, MethodDefinition baseMethod)
 		{
 			var annotations = Context.Annotations;
-			bool methodHasAttribute = annotations.IsMethodInRequiresUnreferencedCodeScope (method);
-			if (methodHasAttribute != annotations.IsMethodInRequiresUnreferencedCodeScope (baseMethod)) {
+			bool methodHasAttribute = annotations.IsInRequiresScope (method);
+			if (methodHasAttribute != annotations.IsInRequiresScope (baseMethod)) {
 				string message = MessageFormat.FormatRequiresAttributeMismatch (methodHasAttribute,
 					baseMethod.DeclaringType.IsInterface, nameof (RequiresUnreferencedCodeAttribute), method.GetDisplayName (), baseMethod.GetDisplayName ());
 				Context.LogWarning (method, DiagnosticId.RequiresUnreferencedCodeAttributeMismatch, message);

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -591,10 +591,10 @@ namespace Mono.Linker
 		/// Determines if method is within a declared RUC scope - this typically means that trim analysis
 		/// warnings should be suppressed in such a method.
 		/// </summary>
-		/// <remarks>Unlike <see cref="DoesMethodRequireUnreferencedCode(MethodDefinition, out RequiresUnreferencedCodeAttribute)"/>
+		/// <remarks>Unlike <see cref="DoesMemberRequireUnreferencedCode(IMemberDefinition, out RequiresUnreferencedCodeAttribute?)"/>
 		/// if a declaring type has RUC, all methods in that type are considered "in scope" of that RUC. So this includes also
 		/// instance methods (not just statics and .ctors).</remarks>
-		internal bool IsInRequiresScope (MethodDefinition method)
+		internal bool IsInRequiresUnreferencedCodeScope (MethodDefinition method)
 		{
 			if (HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method) && !method.IsStaticConstructor ())
 				return true;
@@ -608,7 +608,7 @@ namespace Mono.Linker
 		/// <summary>
 		/// Determines if a member requires unreferenced code (and thus any usage of such method should be warned about).
 		/// </summary>
-		/// <remarks>Unlike <see cref="IsInRequiresScope(MethodDefinition)"/> only static methods 
+		/// <remarks>Unlike <see cref="IsInRequiresUnreferencedCodeScope(MethodDefinition)"/> only static methods 
 		/// and .ctors are reported as requiring unreferenced code when the declaring type has RUC on it.</remarks>
 		internal bool DoesMemberRequireUnreferencedCode (IMemberDefinition member, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -591,7 +591,7 @@ namespace Mono.Linker
 		/// Determines if method is within a declared RUC scope - this typically means that trim analysis
 		/// warnings should be suppressed in such a method.
 		/// </summary>
-		/// <remarks>Unlike <see cref="DoesMethodRequiresUnreferencedCode(MethodDefinition, out RequiresUnreferencedCodeAttribute)"/>
+		/// <remarks>Unlike <see cref="DoesMethodRequireUnreferencedCode(MethodDefinition, out RequiresUnreferencedCodeAttribute)"/>
 		/// if a declaring type has RUC, all methods in that type are considered "in scope" of that RUC. So this includes also
 		/// instance methods (not just statics and .ctors).</remarks>
 		internal bool IsInRequiresScope (MethodDefinition method)
@@ -610,17 +610,17 @@ namespace Mono.Linker
 		/// </summary>
 		/// <remarks>Unlike <see cref="IsInRequiresScope(MethodDefinition)"/> only static methods 
 		/// and .ctors are reported as requiring unreferenced code when the declaring type has RUC on it.</remarks>
-		internal bool DoesMemberRequiresUnreferencedCode (IMemberDefinition member, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
+		internal bool DoesMemberRequireUnreferencedCode (IMemberDefinition member, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
 			attribute = null;
 			return member switch {
-				MethodDefinition method => DoesMethodRequiresUnreferencedCode (method, out attribute),
-				FieldDefinition field => DoesFieldRequiresUnreferencedCode (field, out attribute),
+				MethodDefinition method => DoesMethodRequireUnreferencedCode (method, out attribute),
+				FieldDefinition field => DoesFieldRequireUnreferencedCode (field, out attribute),
 				_ => false
 			};
 		}
 
-		internal bool DoesMethodRequiresUnreferencedCode (MethodDefinition originalMethod, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
+		internal bool DoesMethodRequireUnreferencedCode (MethodDefinition originalMethod, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
 			MethodDefinition? method = originalMethod;
 			do {
@@ -639,7 +639,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		internal bool DoesFieldRequiresUnreferencedCode (FieldDefinition field, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
+		internal bool DoesFieldRequireUnreferencedCode (FieldDefinition field, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
 			if (!field.IsStatic || field.DeclaringType is null) {
 				attribute = null;

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -588,11 +588,39 @@ namespace Mono.Linker
 		}
 
 		/// <summary>
-		/// Determines if method requires unreferenced code (and thus any usage of such method should be warned about).
+		/// Determines if method is within a declared RUC scope - this typically means that trim analysis
+		/// warnings should be suppressed in such a method.
 		/// </summary>
-		/// <remarks>Unlike <see cref="IsMethodInRequiresUnreferencedCodeScope(MethodDefinition)"/> only static methods 
+		/// <remarks>Unlike <see cref="DoesMethodRequiresUnreferencedCode(MethodDefinition, out RequiresUnreferencedCodeAttribute)"/>
+		/// if a declaring type has RUC, all methods in that type are considered "in scope" of that RUC. So this includes also
+		/// instance methods (not just statics and .ctors).</remarks>
+		internal bool IsInRequiresScope (MethodDefinition method)
+		{
+			if (HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method) && !method.IsStaticConstructor ())
+				return true;
+
+			if (method.DeclaringType is not null && HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method.DeclaringType))
+				return true;
+
+			return false;
+		}
+
+		/// <summary>
+		/// Determines if a member requires unreferenced code (and thus any usage of such method should be warned about).
+		/// </summary>
+		/// <remarks>Unlike <see cref="IsInRequiresScope(MethodDefinition)"/> only static methods 
 		/// and .ctors are reported as requiring unreferenced code when the declaring type has RUC on it.</remarks>
-		internal bool DoesMethodRequireUnreferencedCode (MethodDefinition originalMethod, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
+		internal bool DoesMemberRequiresUnreferencedCode (IMemberDefinition member, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
+		{
+			attribute = null;
+			return member switch {
+				MethodDefinition method => DoesMethodRequiresUnreferencedCode (method, out attribute),
+				FieldDefinition field => DoesFieldRequiresUnreferencedCode (field, out attribute),
+				_ => false
+			};
+		}
+
+		internal bool DoesMethodRequiresUnreferencedCode (MethodDefinition originalMethod, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
 			MethodDefinition? method = originalMethod;
 			do {
@@ -611,25 +639,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		/// <summary>
-		/// Determines if method is within a declared RUC scope - this typically means that trim analysis
-		/// warnings should be suppressed in such a method.
-		/// </summary>
-		/// <remarks>Unlike <see cref="DoesMethodRequireUnreferencedCode(MethodDefinition, out RequiresUnreferencedCodeAttribute)"/>
-		/// if a declaring type has RUC, all methods in that type are considered "in scope" of that RUC. So this includes also
-		/// instance methods (not just statics and .ctors).</remarks>
-		internal bool IsMethodInRequiresUnreferencedCodeScope (MethodDefinition method)
-		{
-			if (HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method) && !method.IsStaticConstructor ())
-				return true;
-
-			if (method.DeclaringType is not null && HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method.DeclaringType))
-				return true;
-
-			return false;
-		}
-
-		internal bool DoesFieldRequireUnreferencedCode (FieldDefinition field, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
+		internal bool DoesFieldRequiresUnreferencedCode (FieldDefinition field, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
 		{
 			if (!field.IsStatic || field.DeclaringType is null) {
 				attribute = null;
@@ -637,16 +647,6 @@ namespace Mono.Linker
 			}
 
 			return TryGetLinkerAttribute (field.DeclaringType, out attribute);
-		}
-
-		internal bool DoesMemberRequireUnreferencedCode (IMemberDefinition member, [NotNullWhen (returnValue: true)] out RequiresUnreferencedCodeAttribute? attribute)
-		{
-			attribute = null;
-			return member switch {
-				MethodDefinition method => DoesMethodRequireUnreferencedCode (method, out attribute),
-				FieldDefinition field => DoesFieldRequireUnreferencedCode (field, out attribute),
-				_ => false
-			};
 		}
 
 		public void EnqueueVirtualMethod (MethodDefinition method)

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnStaticConstructor.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnStaticConstructor.cs
@@ -79,7 +79,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		{
 			[ExpectedWarning ("IL2116", "StaticCtorTriggeredByMethodCall..cctor()")]
 			[ExpectedWarning ("IL3004", "StaticCtorTriggeredByMethodCall..cctor()", ProducedBy = ProducedBy.Analyzer)]
-			[ExpectedWarning ("IL3052", "StaticCtorTriggeredByMethodCall..cctor()", ProducedBy = ProducedBy.Analyzer)]
+			[ExpectedWarning ("IL3056", "StaticCtorTriggeredByMethodCall..cctor()", ProducedBy = ProducedBy.Analyzer)]
 			[RequiresUnreferencedCode ("Message for --StaticCtorTriggeredByMethodCall.Cctor--")]
 			[RequiresAssemblyFiles ("Message for --StaticCtorTriggeredByMethodCall.Cctor--")]
 			[RequiresDynamicCode ("Message for --StaticCtorTriggeredByMethodCall.Cctor--")]


### PR DESCRIPTION
Match analyzer and linker requires methods to be more similar according to their behavior
Sync diagnostic Id in NativeAOT with the information in linker