### PR TITLE
Don't warn on enum switch if named values are exhaustive

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -116,6 +116,9 @@ dotnet_diagnostic.IDE0082.severity = warning
 # IDE0110: Remove unnecessary discard
 dotnet_diagnostic.IDE0110.severity = warning
 
+# CS8524: Switch doesn't handle unnamed enum values
+dotnet_diagnostic.CS8524.severity = none
+
 ## CA analyzer rules
 dotnet_analyzer_diagnostic.category-performance.severity = warning
 dotnet_analyzer_diagnostic.category-maintainability.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -116,9 +116,6 @@ dotnet_diagnostic.IDE0082.severity = warning
 # IDE0110: Remove unnecessary discard
 dotnet_diagnostic.IDE0110.severity = warning
 
-# CS8524: Switch doesn't handle unnamed enum values
-dotnet_diagnostic.CS8524.severity = none
-
 ## CA analyzer rules
 dotnet_analyzer_diagnostic.category-performance.severity = warning
 dotnet_analyzer_diagnostic.category-maintainability.severity = warning

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,6 +28,7 @@
          when we build the cecil submodule. The reference assembly package will depend on this version of cecil.
          Keep this in sync with ProjectInfo.cs in the submodule. -->
     <MonoCecilVersion>0.11.4</MonoCecilVersion>
+    <StaticCsVersion>0.1.0</StaticCsVersion>
     <UseVSTestRunner>true</UseVSTestRunner>
   </PropertyGroup>
 </Project>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -15,7 +15,9 @@
   <ItemGroup>
     <None Include="Microsoft.NET.ILLink.Analyzers.props" CopyToOutputDirectory="PreserveNewest" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
-    <PackageReference Include="StaticCs" Version="$(StaticCsVersion)" />
+    <PackageReference Include="StaticCs" Version="$(StaticCsVersion)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <Import Project="..\ILLink.Shared\ILLink.Shared.projitems" Label="Shared" />

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <None Include="Microsoft.NET.ILLink.Analyzers.props" CopyToOutputDirectory="PreserveNewest" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
+    <PackageReference Include="StaticCs" Version="$(StaticCsVersion)" />
   </ItemGroup>
 
   <Import Project="..\ILLink.Shared\ILLink.Shared.projitems" Label="Shared" />

--- a/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
+++ b/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
@@ -3,6 +3,7 @@
 
 namespace ILLink.Shared.TrimAnalysis
 {
+	[StaticCs.Closed]
 	enum IntrinsicId
 	{
 		None = 0,

--- a/src/ILLink.Shared/TypeSystemProxy/WellKnownType.cs
+++ b/src/ILLink.Shared/TypeSystemProxy/WellKnownType.cs
@@ -34,7 +34,6 @@ namespace ILLink.Shared.TypeSystemProxy
 				WellKnownType.System_NotSupportedException => ("System", "NotSupportedException"),
 				WellKnownType.System_Runtime_CompilerServices_DisablePrivateReflectionAttribute => ("System.Runtime.CompilerServices", "DisablePrivateReflectionAttribute"),
 				WellKnownType.System_Void => ("System", "Void"),
-				_ => throw new ArgumentException ($"{nameof (type)} is not a well-known type."),
 			};
 		}
 		public static string GetNamespace (this WellKnownType type) => GetNamespaceAndName (type).Namespace;

--- a/src/ILLink.Shared/TypeSystemProxy/WellKnownType.cs
+++ b/src/ILLink.Shared/TypeSystemProxy/WellKnownType.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ILLink.Shared.TypeSystemProxy
 {
 	public enum WellKnownType

--- a/src/ILLink.Shared/TypeSystemProxy/WellKnownType.cs
+++ b/src/ILLink.Shared/TypeSystemProxy/WellKnownType.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using StaticCs;
+
 namespace ILLink.Shared.TypeSystemProxy
 {
+	[Closed]
 	public enum WellKnownType
 	{
 		System_String,

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -25,7 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StaticCs" Version="$(StaticCsVersion)" />
+    <PackageReference Include="StaticCs" Version="$(StaticCsVersion)">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\Mono.Cecil.csproj" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" PrivateAssets="all" />

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="StaticCs" Version="$(StaticCsVersion)" />
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\Mono.Cecil.csproj" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" PrivateAssets="all" />


### PR DESCRIPTION
In some cases, it is helpful to only cover named values of enums in a switch without a catch-all at the bottom. Since the warning code is different for named and unnamed variants we can disable the unnamed variants warning. This way, if all named variants are accounted for without the catch-all and a new variant is added it will warn in that location rather than only showing up at runtime.