### PR TITLE
Better tests for attribute dataflow

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -18,6 +18,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
 		[KeepsPublicConstructor (typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods ("Mono.Linker.Tests.Cases.DataFlow.AttributeConstructorDataflow+ClassWithKeptPublicMethods")]
+		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
+		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()
 		{
 			typeof (AttributeConstructorDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorAttribute));
@@ -66,6 +68,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class ClassWithKeptPublicMethods
 		{
 			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--ClassWithKeptPublicMethods--")]
 			public static void KeptMethod () { }
 			static void Method () { }
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
@@ -18,6 +18,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods ("Mono.Linker.Tests.Cases.DataFlow.AttributeFieldDataflow+ClassWithKeptPublicMethods")]
+		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
+		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()
 		{
 			typeof (AttributeFieldDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
@@ -67,6 +69,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class ClassWithKeptPublicMethods
 		{
 			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--ClassWithKeptPublicMethods--")]
 			public static void KeptMethod () { }
 			static void Method () { }
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -70,8 +70,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class ClassWithKeptPublicMethods
 		{
 			[Kept]
-			[KeptAttributeAttribute(typeof(RequiresUnreferencedCodeAttribute))]
-			[RequiresUnreferencedCode("--ClassWithKeptPublicMethods--")]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--ClassWithKeptPublicMethods--")]
 			public static void KeptMethod () { }
 			static void Method () { }
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -18,6 +18,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods ("Mono.Linker.Tests.Cases.DataFlow.AttributePropertyDataflow+ClassWithKeptPublicMethods")]
+		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
+		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()
 		{
 			typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
@@ -68,6 +70,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class ClassWithKeptPublicMethods
 		{
 			[Kept]
+			[KeptAttributeAttribute(typeof(RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode("--ClassWithKeptPublicMethods--")]
 			public static void KeptMethod () { }
 			static void Method () { }
 		}


### PR DESCRIPTION
Use RUC warnings to validate correct marking caused by attribute data flow.
The analyzer side of these tests doesn't work yet as they use string->type marking and the analyzer is missing a type name parser for now.