### PR TITLE
Add two specific tests for type hierarchy marking

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -49,7 +49,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			// for some non-reflection access.
 			var f = AnnotatedPublicMethods.DAMField;
 
-			RUCOnVirtualMethodDerivedAnnotated.Test ();
+			RUCOnNewSlotVirtualMethodDerivedAnnotated.Test ();
 
 			CompilerGeneratedBackingField.Test ();
 		}
@@ -598,7 +598,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
-		class RUCOnVirtualMethodDerivedAnnotated
+		class RUCOnNewSlotVirtualMethodDerivedAnnotated
 		{
 			[Kept]
 			[KeptMember (".ctor()")]
@@ -616,6 +616,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptBaseType (typeof (Base))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			[ExpectedWarning ("IL2113", "--RUCOnVirtualMethodDerivedAnnotated.Base.RUCVirtualMethod--")]
+			// https://github.com/dotnet/linker/issues/2815
+			// [ExpectedWarning ("IL2112", "--RUCOnVirtualMethodDerivedAnnotated.Derived.RUCVirtualMethod--")]
 			public class Derived : Base
 			{
 				[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -49,6 +49,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			// for some non-reflection access.
 			var f = AnnotatedPublicMethods.DAMField;
 
+			RUCOnVirtualMethodDerivedAnnotated.Test ();
+
 			CompilerGeneratedBackingField.Test ();
 		}
 
@@ -593,6 +595,44 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[ExpectedWarning ("IL2112", "--AnnotatedRUCPublicMethods--")]
 			public static void StaticMethod () { }
+		}
+
+		[Kept]
+		class RUCOnVirtualMethodDerivedAnnotated
+		{
+			[Kept]
+			[KeptMember (".ctor()")]
+			public class Base
+			{
+				[Kept]
+				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+				[RequiresUnreferencedCode ("--RUCOnVirtualMethodDerivedAnnotated.Base.RUCVirtualMethod--")]
+				public virtual void RUCVirtualMethod () { }
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[KeptBaseType (typeof (Base))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			[ExpectedWarning ("IL2113", "--RUCOnVirtualMethodDerivedAnnotated.Base.RUCVirtualMethod--")]
+			public class Derived : Base
+			{
+				[Kept]
+				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+				[RequiresUnreferencedCode ("--RUCOnVirtualMethodDerivedAnnotated.Derived.RUCVirtualMethod--")]
+				public virtual void RUCVirtualMethod () { }
+			}
+
+			[Kept]
+			static Derived _derivedInstance;
+
+			[Kept]
+			public static void Test ()
+			{
+				_derivedInstance = new Derived ();
+				_derivedInstance.GetType ().RequiresPublicMethods ();
+			}
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnVirtualsAndInterfaces.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnVirtualsAndInterfaces.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
@@ -24,6 +25,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestInterfaceMethodWithRequires ();
 			TestCovariantReturnCallOnDerived ();
 			CovariantReturnViaLdftn.Test ();
+			NewSlotVirtual.Test ();
 		}
 
 		class BaseType
@@ -193,6 +195,39 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				var tmp = new Derived ();
 				var _ = new Func<DerivedReturnType> (tmp.GetRequires);
+			}
+		}
+
+		class NewSlotVirtual
+		{
+			class Base
+			{
+				[RequiresUnreferencedCode ("Message for --NewSlotVirtual.Base.RUCMethod--")]
+				[RequiresAssemblyFiles ("Message for --NewSlotVirtual.Base.RUCMethod--")]
+				[RequiresDynamicCode ("Message for --NewSlotVirtual.Base.RUCMethod--")]
+				public virtual void RUCMethod () { }
+			}
+
+			class Derived : Base
+			{
+				[RequiresUnreferencedCode ("Message for --NewSlotVirtual.Derived.RUCMethod--")]
+				[RequiresAssemblyFiles ("Message for --NewSlotVirtual.Derived.RUCMethod--")]
+				[RequiresDynamicCode ("Message for --NewSlotVirtual.Derived.RUCMethod--")]
+				public virtual void RUCMethod () { }
+			}
+
+			[ExpectedWarning ("IL2026", "Message for --NewSlotVirtual.Base.RUCMethod--")]
+			// Reflection triggered warnings are not produced by analyzer for RDC/RAS
+			// [ExpectedWarning ("IL3002", "Message for --NewSlotVirtual.Base.RUCMethod--", ProducedBy = ProducedBy.Analyzer)]
+			// [ExpectedWarning ("IL3050", "Message for --NewSlotVirtual.Base.RUCMethod--", ProducedBy = ProducedBy.Analyzer)]
+			// https://github.com/dotnet/linker/issues/2815
+			[ExpectedWarning ("IL2026", "Message for --NewSlotVirtual.Derived.RUCMethod--", ProducedBy = ProducedBy.Analyzer)]
+			// Reflection triggered warnings are not produced by analyzer for RDC/RAS
+			// [ExpectedWarning ("IL3002", "Message for --NewSlotVirtual.Derived.RUCMethod--", ProducedBy = ProducedBy.Analyzer)]
+			// [ExpectedWarning ("IL3050", "Message for --NewSlotVirtual.Derived.RUCMethod--", ProducedBy = ProducedBy.Analyzer)]
+			public static void Test ()
+			{
+				typeof (Derived).RequiresPublicMethods ();
 			}
 		}
 	}


### PR DESCRIPTION
First one is for the case where Derived type is annotated and has a virtual RUC method (and the base type has that same method with RUC as well). The warning should be generated for the base RUC method.

Second one is for type hierarchy marking of non-public members on base types when the derived type has the annotation. This is a test for https://github.com/dotnet/linker/issues/2813