### PR TITLE
Fix linker crash in generated type analysis

### DIFF
--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -110,7 +110,7 @@ namespace Mono.Linker
 							CompilerGeneratedNames.IsLambdaDisplayClass (generatedType.Name)) {
 							// fill in null for now, attribute providers will be filled in later
 							if (!_generatedTypeToTypeArgumentInfo.TryAdd (generatedType, new TypeArgumentInfo (method, null))) {
-								var alreadyAssociatedMethod = _compilerGeneratedTypeToUserCodeMethod[generatedType];
+								var alreadyAssociatedMethod = _generatedTypeToTypeArgumentInfo[generatedType].CreatingMethod;
 								_context.LogWarning (new MessageOrigin (method), DiagnosticId.MethodsAreAssociatedWithUserMethod, method.GetDisplayName (), alreadyAssociatedMethod.GetDisplayName (), generatedType.GetDisplayName ());
 							}
 							continue;
@@ -235,7 +235,15 @@ namespace Mono.Linker
 			{
 				Debug.Assert (CompilerGeneratedNames.IsGeneratedType (generatedType.Name));
 
-				var typeInfo = _generatedTypeToTypeArgumentInfo[generatedType];
+				if (!_generatedTypeToTypeArgumentInfo.TryGetValue(generatedType, out var typeInfo))
+				{
+					// This can happen for static (non-capturing) closure environments, where more than
+					// nested function can map to the same closure environment. Since the current functionality
+					// is based on a one-to-one relationship between environments (types) and methods, this is
+					// not supported.
+					return;
+				}
+
 				if (typeInfo.OriginalAttributes is not null) {
 					return;
 				}
@@ -265,10 +273,9 @@ namespace Mono.Linker
 									userAttrs = param;
 								} else if (_context.TryResolve ((TypeReference) param.Owner) is { } owningType) {
 									MapGeneratedTypeTypeParameters (owningType);
-									if (_generatedTypeToTypeArgumentInfo[owningType].OriginalAttributes is { } owningAttrs) {
+									if (_generatedTypeToTypeArgumentInfo.TryGetValue(owningType, out var owningInfo) &&
+										owningInfo.OriginalAttributes is { } owningAttrs) {
 										userAttrs = owningAttrs[param.Position];
-									} else {
-										Debug.Assert (false, "This should be impossible in valid code");
 									}
 								}
 							}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
@@ -31,6 +31,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			AsyncTypeMismatch ();
 			AsyncInsideClosure ();
 			AsyncInsideClosureMismatch ();
+
+			// Closures
+			GlobalClosures ();
 		}
 
 		private static void UseIterator ()
@@ -227,6 +230,36 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					_ = typeof (T1).GetMethods ();
 					_ = typeof (T2).GetProperties ();
 				}
+			}
+		}
+
+		private static void GlobalClosures ()
+		{
+			GlobalClosureClass<int>.M1<int> ();
+			GlobalClosureClass<int>.M2<int> ();
+		}
+
+		private sealed class GlobalClosureClass<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>
+		{
+			public static void M1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] U>()
+			{
+				Func<string, Action> a = (string s) => () => Console.WriteLine(s + typeof(T).GetMethods());
+				Func<string, Action> b = (string s) =>
+					// https://github.com/dotnet/linker/issues/2826
+					[ExpectedWarning ("IL2090", "U", "PublicProperties")]
+					() => Console.WriteLine(s + typeof(U).GetProperties());
+				a("");
+				b("");
+			}
+			public static void M2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] U>()
+			{
+				Func<string, Action> a = (string s) => () => Console.WriteLine(s + typeof(T).GetMethods());
+				Func<string, Action> b = (string s) =>
+					// https://github.com/dotnet/linker/issues/2826
+					[ExpectedWarning ("IL2090", "U", "PublicProperties")]
+					() => Console.WriteLine(s + typeof(U).GetProperties());
+				a("");
+				b("");
 			}
 		}
 	}


### PR DESCRIPTION
The generated type analysis works by trying to create a type mapping,
where type parameters from generated types (state machine types) are
mapped back to the original method type parameter they were created
from. This isn't possible for the type parameters of "static" closures,
where there is a single closure environment created for multiple lambdas
which don't capture any values.

This change works around the problem by avoiding remapping those type
parameters. They will be left as the original type parameter (and may
leave warnings about generated code).