### PR TITLE
Mark all type forwarders used during string->Type resolution

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
@@ -67,7 +67,7 @@ namespace ILLink.Shared.TrimAnalysis
 			return false;
 		}
 
-		private partial bool TryResolveTypeNameForCreateInstance (in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType)
+		private partial bool TryResolveTypeNameForCreateInstanceAndMark (in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType)
 		{
 			// Intentionally never resolve anything. Analyzer can really only see types from the current compilation unit. For other assemblies
 			// it typically only sees reference assemblies and thus just public API. It's not worth (at least for now) to try to resolve

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -1325,7 +1325,7 @@ namespace ILLink.Shared.TrimAnalysis
 							continue;
 						}
 						if (typeNameValue is KnownStringValue typeNameStringValue) {
-							if (!TryResolveTypeNameForCreateInstance (calledMethod, assemblyNameStringValue.Contents, typeNameStringValue.Contents, out TypeProxy resolvedType)) {
+							if (!TryResolveTypeNameForCreateInstanceAndMark (calledMethod, assemblyNameStringValue.Contents, typeNameStringValue.Contents, out TypeProxy resolvedType)) {
 								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
 								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
 								// but linker can't know that. In case a user tries to create an array using System.Activator we should simply ignore it, the user
@@ -1425,7 +1425,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 		private partial bool TryGetBaseType (TypeProxy type, [NotNullWhen (true)] out TypeProxy? baseType);
 
-		private partial bool TryResolveTypeNameForCreateInstance (in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType);
+		private partial bool TryResolveTypeNameForCreateInstanceAndMark (in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType);
 
 		private partial void MarkStaticConstructor (TypeProxy type);
 

--- a/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -68,7 +68,7 @@ namespace ILLink.Shared.TrimAnalysis
 			return false;
 		}
 
-		private partial bool TryResolveTypeNameForCreateInstance (in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType)
+		private partial bool TryResolveTypeNameForCreateInstanceAndMark (in MethodProxy calledMethod, string assemblyName, string typeName, out TypeProxy resolvedType)
 		{
 			var resolvedAssembly = _context.TryResolve (assemblyName);
 			if (resolvedAssembly == null) {
@@ -79,9 +79,8 @@ namespace ILLink.Shared.TrimAnalysis
 				return false;
 			}
 
-			if (!_context.TypeNameResolver.TryResolveTypeName (resolvedAssembly, typeName, out TypeReference? typeRef)
-				|| _context.TryResolve (typeRef) is not TypeDefinition resolvedTypeDefinition
-				|| typeRef is ArrayType) {
+			if (!_reflectionMarker.TryResolveTypeNameAndMark (resolvedAssembly, typeName, _diagnosticContext, out TypeDefinition? resolvedTypeDefinition)
+				|| resolvedTypeDefinition.IsTypeOf (WellKnownType.System_Array)) {
 				// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
 				// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
 				// but linker can't know that. In case a user tries to create an array using System.Activator we should simply ignore it, the user

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -880,7 +880,7 @@ namespace Mono.Linker
 		public TypeDefinition? TryResolve (AssemblyDefinition assembly, string typeNameString)
 		{
 			// It could be cached if it shows up on fast path
-			return _typeNameResolver.TryResolveTypeName (assembly, typeNameString, out TypeReference? typeReference)
+			return _typeNameResolver.TryResolveTypeName (assembly, typeNameString, out TypeReference? typeReference, out _)
 				? TryResolve (typeReference)
 				: null;
 		}

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Runtime.TypeParsing;
@@ -15,6 +16,8 @@ namespace Mono.Linker
 	{
 		readonly LinkContext _context;
 
+		public readonly record struct TypeResolutionRecord (AssemblyDefinition ReferringAssembly, TypeDefinition ResolvedType);
+
 		public TypeNameResolver (LinkContext context)
 		{
 			_context = context;
@@ -24,11 +27,11 @@ namespace Mono.Linker
 			string typeNameString,
 			in DiagnosticContext diagnosticContext,
 			[NotNullWhen (true)] out TypeReference? typeReference,
-			[NotNullWhen (true)] out AssemblyDefinition? typeAssembly,
+			[NotNullWhen (true)] out List<TypeResolutionRecord>? typeResolutionRecords,
 			bool needsAssemblyName = true)
 		{
 			typeReference = null;
-			typeAssembly = null;
+			typeResolutionRecords = null;
 			if (string.IsNullOrEmpty (typeNameString))
 				return false;
 
@@ -41,12 +44,20 @@ namespace Mono.Linker
 				return false;
 			}
 
+			typeResolutionRecords = new List<TypeResolutionRecord> ();
+			AssemblyDefinition? typeAssembly;
 			if (parsedTypeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
 				typeAssembly = _context.TryResolve (assemblyQualifiedTypeName.AssemblyName.Name);
-				if (typeAssembly == null)
+				if (typeAssembly == null) {
+					typeResolutionRecords = null;
 					return false;
+				}
 
-				typeReference = ResolveTypeName (typeAssembly, assemblyQualifiedTypeName.TypeName);
+				typeReference = ResolveTypeName (typeAssembly, assemblyQualifiedTypeName.TypeName, typeResolutionRecords);
+				if (typeReference == null) {
+					typeResolutionRecords = null;
+				}
+
 				return typeReference != null;
 			}
 
@@ -62,12 +73,12 @@ namespace Mono.Linker
 				_ => throw new NotSupportedException ()
 			};
 
-			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, out typeReference))
+			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, typeResolutionRecords, out typeReference))
 				return true;
 
 			// If type is not found in the caller's assembly, try in core assembly.
 			typeAssembly = _context.TryResolve (PlatformAssemblies.CoreLib);
-			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, out typeReference))
+			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, typeResolutionRecords, out typeReference))
 				return true;
 
 			// It is common to use Type.GetType for looking if a type is available.
@@ -75,46 +86,51 @@ namespace Mono.Linker
 			if (needsAssemblyName && provider != null)
 				diagnosticContext.AddDiagnostic (DiagnosticId.TypeWasNotFoundInAssemblyNorBaseLibrary, typeNameString);
 
-			typeAssembly = null;
+			typeResolutionRecords = null;
 			return false;
 
-			bool TryResolveTypeName (AssemblyDefinition assemblyDefinition, TypeName typeName, [NotNullWhen (true)] out TypeReference? typeReference)
+			bool TryResolveTypeName (AssemblyDefinition assemblyDefinition, TypeName typeName, List<TypeResolutionRecord> typeResolutionRecords, [NotNullWhen (true)] out TypeReference? typeReference)
 			{
 				typeReference = null;
 				if (assemblyDefinition == null)
 					return false;
 
-				typeReference = ResolveTypeName (assemblyDefinition, typeName);
+				typeReference = ResolveTypeName (assemblyDefinition, typeName, typeResolutionRecords);
 				return typeReference != null;
 			}
 		}
 
-		public bool TryResolveTypeName (AssemblyDefinition assembly, string typeNameString, [NotNullWhen (true)] out TypeReference? typeReference)
+		public bool TryResolveTypeName (
+			AssemblyDefinition assembly,
+			string typeNameString,
+			[NotNullWhen (true)] out TypeReference? typeReference,
+			[NotNullWhen (true)] out List<TypeResolutionRecord> typeResolutionRecords)
 		{
-			typeReference = ResolveTypeName (assembly, TypeParser.ParseTypeName (typeNameString));
+			typeResolutionRecords = new List<TypeResolutionRecord> ();
+			typeReference = ResolveTypeName (assembly, TypeParser.ParseTypeName (typeNameString), typeResolutionRecords);
 			return typeReference != null;
 		}
 
-		TypeReference? ResolveTypeName (AssemblyDefinition assembly, TypeName typeName)
+		TypeReference? ResolveTypeName (AssemblyDefinition assembly, TypeName typeName, List<TypeResolutionRecord> typeResolutionRecords)
 		{
 			if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
 				// In this case we ignore the assembly parameter since the type name has assembly in it
 				var assemblyFromName = _context.TryResolve (assemblyQualifiedTypeName.AssemblyName.Name);
-				return assemblyFromName == null ? null : ResolveTypeName (assemblyFromName, assemblyQualifiedTypeName.TypeName);
+				return assemblyFromName == null ? null : ResolveTypeName (assemblyFromName, assemblyQualifiedTypeName.TypeName, typeResolutionRecords);
 			}
 
 			if (assembly == null || typeName == null)
 				return null;
 
 			if (typeName is ConstructedGenericTypeName constructedGenericTypeName) {
-				var genericTypeRef = ResolveTypeName (assembly, constructedGenericTypeName.GenericType);
+				var genericTypeRef = ResolveTypeName (assembly, constructedGenericTypeName.GenericType, typeResolutionRecords);
 				if (genericTypeRef == null)
 					return null;
 
 				Debug.Assert (genericTypeRef is TypeDefinition);
 				var genericInstanceType = new GenericInstanceType (genericTypeRef);
 				foreach (var arg in constructedGenericTypeName.GenericArguments) {
-					var genericArgument = ResolveTypeName (assembly, arg);
+					var genericArgument = ResolveTypeName (assembly, arg, typeResolutionRecords);
 					if (genericArgument == null)
 						return null;
 
@@ -123,7 +139,7 @@ namespace Mono.Linker
 
 				return genericInstanceType;
 			} else if (typeName is HasElementTypeName elementTypeName) {
-				var elementType = ResolveTypeName (assembly, elementTypeName.ElementTypeName);
+				var elementType = ResolveTypeName (assembly, elementTypeName.ElementTypeName, typeResolutionRecords);
 				if (elementType == null)
 					return null;
 
@@ -136,7 +152,15 @@ namespace Mono.Linker
 				};
 			}
 
-			return assembly.MainModule.ResolveType (typeName.ToString (), _context);
+			TypeDefinition? resolvedType = assembly.MainModule.ResolveType (typeName.ToString (), _context);
+
+			// True type references (like generics and arrays) don't count as actually resolved types, they're just wrappers
+			// so only record type resolutions for types which are actually resolved.
+			if (resolvedType != null) {
+				typeResolutionRecords.Add (new (assembly, resolvedType));
+			}
+
+			return resolvedType;
 		}
 	}
 }

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -73,12 +73,12 @@ namespace Mono.Linker
 				_ => throw new NotSupportedException ()
 			};
 
-			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, typeResolutionRecords, out typeReference))
+			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, out typeReference, typeResolutionRecords))
 				return true;
 
 			// If type is not found in the caller's assembly, try in core assembly.
 			typeAssembly = _context.TryResolve (PlatformAssemblies.CoreLib);
-			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, typeResolutionRecords, out typeReference))
+			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, out typeReference, typeResolutionRecords))
 				return true;
 
 			// It is common to use Type.GetType for looking if a type is available.
@@ -89,7 +89,7 @@ namespace Mono.Linker
 			typeResolutionRecords = null;
 			return false;
 
-			bool TryResolveTypeName (AssemblyDefinition assemblyDefinition, TypeName typeName, List<TypeResolutionRecord> typeResolutionRecords, [NotNullWhen (true)] out TypeReference? typeReference)
+			bool TryResolveTypeName (AssemblyDefinition assemblyDefinition, TypeName typeName, [NotNullWhen (true)] out TypeReference? typeReference, List<TypeResolutionRecord> typeResolutionRecords)
 			{
 				typeReference = null;
 				if (assemblyDefinition == null)
@@ -104,10 +104,14 @@ namespace Mono.Linker
 			AssemblyDefinition assembly,
 			string typeNameString,
 			[NotNullWhen (true)] out TypeReference? typeReference,
-			[NotNullWhen (true)] out List<TypeResolutionRecord> typeResolutionRecords)
+			[NotNullWhen (true)] out List<TypeResolutionRecord>? typeResolutionRecords)
 		{
 			typeResolutionRecords = new List<TypeResolutionRecord> ();
 			typeReference = ResolveTypeName (assembly, TypeParser.ParseTypeName (typeNameString), typeResolutionRecords);
+
+			if (typeReference == null)
+				typeResolutionRecords = null;
+
 			return typeReference != null;
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -139,7 +139,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicMethods (Type.GetType ("Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayTypeGetTypeElement[]"));
 		}
 
-		// Nothing should be marked as CreateInstance doesn't work on arrays
+		// Technically there's no reason to mark this type since it's only used as an array element type and CreateInstance
+		// doesn't work on arrays, but the currently implementation will preserve it anyway due to how it processes
+		// string -> Type resolution. This will only impact code which would have failed at runtime, so very unlikely to
+		// actually occur in real apps (and even if it does happen, it just increases size, doesn't break behavior).
+		[Kept]
 		class ArrayCreateInstanceByNameElement
 		{
 			public ArrayCreateInstanceByNameElement ()

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInGenericIsDynamicallyAccessedWithAssemblyCopyUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInGenericIsDynamicallyAccessedWithAssemblyCopyUsed.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
@@ -18,14 +19,18 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/ImplementationLibrary.cs" })]
 	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "Implementation.dll" })]
 
-	// https://github.com/dotnet/linker/issues/1536
-	//[KeptMemberInAssembly ("Forwarder.dll", typeof (ImplementationLibrary))]
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (ImplementationLibrary))]
 	[KeptTypeInAssembly ("Implementation.dll", typeof (ImplementationLibrary))]
+
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (ImplementationLibraryImp))]
+	[KeptTypeInAssembly ("Implementation.dll", typeof (ImplementationLibraryImp))]
 	class UsedForwarderInGenericIsDynamicallyAccessedWithAssemblyCopyUsed
 	{
 		static void Main ()
 		{
 			PointToTypeInFacade ("Mono.Linker.Tests.Cases.TypeForwarding.OuterGeneric`1[[Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibrary, Forwarder]], test");
+
+			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.TypeForwarding.OuterGenericForCreateInstance`1[[Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibraryImp, Forwarder]]");
 		}
 
 		[Kept]
@@ -41,5 +46,12 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	{
 		[Kept]
 		public OuterGeneric () { }
+	}
+
+	[Kept]
+	class OuterGenericForCreateInstance<T>
+	{
+		[Kept]
+		public OuterGenericForCreateInstance () { }
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -245,21 +245,21 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						switch (attributeTypeName) {
 						case nameof (RemovedTypeInAssemblyAttribute):
 							if (linkedType != null)
-								Assert.Fail ($"Type `{expectedTypeName}' should have been removed");
+								Assert.Fail ($"Type `{expectedTypeName}' should have been removed from assembly {assemblyName}");
 							GetOriginalTypeFromInAssemblyAttribute (checkAttrInAssembly);
 							break;
 						case nameof (KeptTypeInAssemblyAttribute):
 							if (linkedType == null)
-								Assert.Fail ($"Type `{expectedTypeName}' should have been kept");
+								Assert.Fail ($"Type `{expectedTypeName}' should have been kept in assembly {assemblyName}");
 							break;
 						case nameof (RemovedInterfaceOnTypeInAssemblyAttribute):
 							if (linkedType == null)
-								Assert.Fail ($"Type `{expectedTypeName}' should have been kept");
+								Assert.Fail ($"Type `{expectedTypeName}' should have been kept in assembly {assemblyName}");
 							VerifyRemovedInterfaceOnTypeInAssembly (checkAttrInAssembly, linkedType);
 							break;
 						case nameof (KeptInterfaceOnTypeInAssemblyAttribute):
 							if (linkedType == null)
-								Assert.Fail ($"Type `{expectedTypeName}' should have been kept");
+								Assert.Fail ($"Type `{expectedTypeName}' should have been kept in assembly {assemblyName}");
 							VerifyKeptInterfaceOnTypeInAssembly (checkAttrInAssembly, linkedType);
 							break;
 						case nameof (RemovedMemberInAssemblyAttribute):
@@ -270,24 +270,24 @@ namespace Mono.Linker.Tests.TestCasesRunner
 							break;
 						case nameof (KeptBaseOnTypeInAssemblyAttribute):
 							if (linkedType == null)
-								Assert.Fail ($"Type `{expectedTypeName}' should have been kept");
+								Assert.Fail ($"Type `{expectedTypeName}' should have been kept in assembly {assemblyName}");
 							VerifyKeptBaseOnTypeInAssembly (checkAttrInAssembly, linkedType);
 							break;
 						case nameof (KeptMemberInAssemblyAttribute):
 							if (linkedType == null)
-								Assert.Fail ($"Type `{expectedTypeName}' should have been kept");
+								Assert.Fail ($"Type `{expectedTypeName}' should have been kept in assembly {assemblyName}");
 
 							VerifyKeptMemberInAssembly (checkAttrInAssembly, linkedType);
 							break;
 						case nameof (RemovedForwarderAttribute):
 							if (linkedAssembly.MainModule.ExportedTypes.Any (l => l.Name == expectedTypeName))
-								Assert.Fail ($"Forwarder `{expectedTypeName}' should have been removed");
+								Assert.Fail ($"Forwarder `{expectedTypeName}' should have been removed from assembly {assemblyName}");
 
 							break;
 
 						case nameof (RemovedAssemblyReferenceAttribute):
 							Assert.False (linkedAssembly.MainModule.AssemblyReferences.Any (l => l.Name == expectedTypeName),
-								$"AssemblyRef '{expectedTypeName}' should have been removed");
+								$"AssemblyRef '{expectedTypeName}' should have been removed from assembly {assemblyName}");
 							break;
 
 						case nameof (KeptResourceInAssemblyAttribute):
@@ -301,7 +301,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 							break;
 						case nameof (ExpectedInstructionSequenceOnMemberInAssemblyAttribute):
 							if (linkedType == null)
-								Assert.Fail ($"Type `{expectedTypeName}` should have been kept");
+								Assert.Fail ($"Type `{expectedTypeName}` should have been kept in assembly {assemblyName}");
 							VerifyExpectedInstructionSequenceOnMemberInAssembly (checkAttrInAssembly, linkedType);
 							break;
 						default:


### PR DESCRIPTION
Previously we only marked the type forwarder for the outer-most type (if any), but the same problem can happen with type names in generic arguments. If they are forwarder we need to mark those type forwarders as well.

This change records all type resolutions during the string->Type resolution and then makes sure that all type forwarders used get marked.

Renamed a method on HandleCallAction to make it more descriptive of what it actually does. Also unifies all string->Type resolution into the ReflectionMarker.

Enabled test which has been already added for the bug and added another variation (CreateInstance).

Improved ResultsChecker to include assembly names in validation messages.

Fixes https://github.com/dotnet/linker/issues/1536