### PR TITLE
Move the ILLink targets from the SDK repo to the linker repo

### DIFF
--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
@@ -12,7 +12,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project>
 
   <PropertyGroup>
-    <UsingILLinkTasksSdk>true</UsingILLinkTasksSdk>
+    <!-- N.B. The ILLinkTargetsPath is used as a sentinel to indicate a version of this file has already been imported. -->
+    <ILLinkTargetsPath>$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.targets</ILLinkTargetsPath>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net6.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
   </PropertyGroup>

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -1,0 +1,365 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.ILLink.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- These properties should be set even if PublishTrimmed != true, to allow SDK components to
+       set PublishTrimmed in targets which are imported after these targets. -->
+  <PropertyGroup>
+    <IntermediateLinkDir Condition=" '$(IntermediateLinkDir)' == '' ">$(IntermediateOutputPath)linked\</IntermediateLinkDir>
+    <IntermediateLinkDir Condition=" !HasTrailingSlash('$(IntermediateLinkDir)') ">$(IntermediateLinkDir)\</IntermediateLinkDir>
+    <!-- Used to enable incremental build for the linker target. -->
+    <_LinkSemaphore>$(IntermediateLinkDir)Link.semaphore</_LinkSemaphore>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Condition="'$(IsTrimmable)' == 'true'" Include="System.Reflection.AssemblyMetadata">
+      <_Parameter1>IsTrimmable</_Parameter1>
+      <_Parameter2>True</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <!-- We disable features for trimmed apps here so that the feature
+      switches can flow to the runtimeconfig.json. Features are disabled
+      by default since they may require assemblies, types or members that
+      could be removed by the linker, causing a trimmed app to crash. -->
+  <PropertyGroup Condition="'$(PublishTrimmed)' == 'true' And
+                            $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
+    <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
+    <CustomResourceTypesSupport Condition="'$(CustomResourceTypesSupport)' == ''">false</CustomResourceTypesSupport>
+    <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' == ''">false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
+    <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
+    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
+    <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
+    <AutoreleasePoolSupport Condition="'$(AutoreleasePoolSupport)' == ''">false</AutoreleasePoolSupport>
+    <EnableCppCLIHostActivation Condition="'$(EnableCppCLIHostActivation)' == ''">false</EnableCppCLIHostActivation>
+    <!-- C++/CLI activation requires native hosting -->
+    <_EnableConsumingManagedCodeFromNativeHosting Condition="'$(EnableCppCLIHostActivation)' == 'true'">true</_EnableConsumingManagedCodeFromNativeHosting>
+    <_EnableConsumingManagedCodeFromNativeHosting Condition="'$(_EnableConsumingManagedCodeFromNativeHosting)' == ''">false</_EnableConsumingManagedCodeFromNativeHosting>
+    <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
+  </PropertyGroup>
+
+
+  <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(PublishTrimmed)' == 'true' And '$(EnableTrimAnalyzer)' != 'true'">
+    <!-- Trim analysis warnings are suppressed for .NET < 6. -->
+    <SuppressTrimAnalysisWarnings Condition="$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0'))">true</SuppressTrimAnalysisWarnings>
+    <!-- Suppress for WPF/WinForms (unless linking everything) -->
+    <SuppressTrimAnalysisWarnings Condition="'$(TrimmerDefaultAction)' != 'link' And ('$(UseWpf)' == 'true' Or '$(UseWindowsForms)' == 'true')">true</SuppressTrimAnalysisWarnings>
+    <!-- Otherwise, for .NET 6+, warnings are on by default -->
+    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == ''">false</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+
+  <!-- Suppress warnings produced by the linker or by the ILLink Roslyn analyzer. -->
+  <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == 'true'">
+    <!-- RequiresUnreferenceCodeAttribute method called -->
+    <NoWarn>$(NoWarn);IL2026;IL2116</NoWarn>
+    <!-- Invalid use of DynamicallyAccessedMembersAttribute -->
+    <NoWarn>$(NoWarn);IL2041;IL2042;IL2043;IL2056</NoWarn>
+    <!-- Reference to removed attribute type -->
+    <NoWarn>$(NoWarn);IL2045</NoWarn>
+    <!-- RequiresUnreferencedCodeAttribute mismatch on virtual override -->
+    <NoWarn>$(NoWarn);IL2046</NoWarn>
+    <!-- COM marshalling warning -->
+    <NoWarn>$(NoWarn);IL2050</NoWarn>
+    <!-- Reflection intrinsics with unknown arguments -->
+    <NoWarn>$(NoWarn);IL2032;IL2055;IL2057;IL2058;IL2059;IL2060;IL2061;IL2096</NoWarn>
+    <!-- Unknown values passed to locations with DynamicallyAccessedMemberTypes -->
+    <NoWarn>$(NoWarn);IL2062;IL2063;IL2064;IL2065;IL2066</NoWarn>
+    <!-- Unsatisfied DynamicallyAccessedMembers requirements -->
+    <NoWarn>$(NoWarn);IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;IL2087;IL2088;IL2089;IL2090;IL2091</NoWarn>
+    <!-- DynamicallyAccessedMembersAttribute mismatch on virtual override -->
+    <NoWarn>$(NoWarn);IL2092;IL2093;IL2094;IL2095</NoWarn>
+    <!-- DynamicallyAccessedMembersAttribute used on unsupported member -->
+    <NoWarn>$(NoWarn);IL2097;IL2098;IL2099;IL2106</NoWarn>
+    <!-- Unknown value passed to Expression.Property -->
+    <NoWarn>$(NoWarn);IL2103</NoWarn>
+    <!-- Multiple methods associated with state machine type or user method -->
+    <NoWarn>$(NoWarn);IL2107;IL2117</NoWarn>
+    <!-- Unannotated type derived from base type with RequiresUnreferencedCode -->
+    <NoWarn>$(NoWarn);IL2109</NoWarn>
+    <!-- Reflection access to members with DynamicallyAccessedMembers requirements -->
+    <NoWarn>$(NoWarn);IL2110;IL2111;IL2114;IL2115</NoWarn>
+    <!-- Reflection access to members with RequiresUnreferencedCode -->
+    <NoWarn>$(NoWarn);IL2112;IL2113</NoWarn>
+    <!-- Reflection access to compiler-generated code -->
+    <NoWarn>$(NoWarn);IL2118;IL2119;IL2120</NoWarn>
+  </PropertyGroup>
+
+  <!--
+    ============================================================
+                     ILLink
+
+    Replace the files to be published with versions that have been
+    passed through the linker. Also prevent removed files from being
+    included in the generated deps.json.
+    ============================================================
+    -->
+  <Target Name="ILLink"
+          Condition=" '$(PublishTrimmed)' == 'true' And
+                      '$(RunILLink)' != 'false' And
+                      '$(_TargetFrameworkVersionWithoutV)' >= '3.0' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' "
+          DependsOnTargets="_RunILLink">
+
+    <NETSdkError Condition="'$(_ILLinkExitCode)' != '' And '$(_ILLinkExitCode)' != '0'" ResourceName="ILLinkFailed" />
+
+    <ItemGroup>
+      <_LinkedResolvedFileToPublish Include="@(_LinkedResolvedFileToPublishCandidate)" Condition="Exists('%(Identity)')" />
+      <ResolvedFileToPublish Remove="@(ManagedAssemblyToLink)" />
+      <ResolvedFileToPublish Remove="@(_PDBToLink)" />
+      <ResolvedFileToPublish Include="@(_LinkedResolvedFileToPublish)" />
+    </ItemGroup>
+
+    <!-- Remove assemblies from inputs to GenerateDepsFile. See
+         https://github.com/dotnet/sdk/pull/3086 -->
+    <ItemGroup>
+      <_RemovedManagedAssembly Include="@(ManagedAssemblyToLink)" Condition="!Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" />
+
+      <ResolvedCompileFileDefinitions Remove="@(_RemovedManagedAssembly)" />
+      <RuntimeCopyLocalItems Remove="@(_RemovedManagedAssembly)" />
+      <RuntimeTargetsCopyLocalItems Remove="@(_RemovedManagedAssembly)" />
+      <UserRuntimeAssembly Remove="@(_RemovedManagedAssembly)" />
+      <RuntimePackAsset Remove="@(_RemovedManagedAssembly)" />
+    </ItemGroup>
+
+  </Target>
+
+
+  <!--
+    ============================================================
+                     _RunILLink
+
+    Execute the linker. This target runs incrementally, only executing
+    if the output semaphore file is out of date with respect to the inputs.
+    ============================================================
+    -->
+  <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" Condition="'$(ILLinkTasksAssembly)' != ''" />
+  <Target Name="_RunILLink"
+          DependsOnTargets="_ComputeManagedAssemblyToLink;PrepareForILLink"
+          Inputs="$(MSBuildAllProjects);@(ManagedAssemblyToLink);@(TrimmerRootDescriptor);@(ReferencePath)"
+          Outputs="$(_LinkSemaphore)">
+    <NETSdkInformation ResourceName="ILLinkRunning" />
+    <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
+         In this case, explicitly specify the path to the dotnet host. -->
+    <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
+      <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
+      <_DotNetHostFileName>dotnet</_DotNetHostFileName>
+      <_DotNetHostFileName Condition="$([MSBuild]::IsOSPlatform(`Windows`))">dotnet.exe</_DotNetHostFileName>
+    </PropertyGroup>
+
+    <Delete Files="@(_LinkedResolvedFileToPublishCandidate)" />
+    <ILLink AssemblyPaths="@(ManagedAssemblyToLink)"
+            ReferenceAssemblyPaths="@(ReferencePath)"
+            RootAssemblyNames="@(TrimmerRootAssembly)"
+            TrimMode="$(TrimMode)"
+            DefaultAction="$(TrimmerDefaultAction)"
+            RemoveSymbols="$(TrimmerRemoveSymbols)"
+            FeatureSettings="@(_TrimmerFeatureSettings)"
+            CustomData="@(_TrimmerCustomData)"
+
+            BeforeFieldInit="$(_TrimmerBeforeFieldInit)"
+            OverrideRemoval="$(_TrimmerOverrideRemoval)"
+            UnreachableBodies="$(_TrimmerUnreachableBodies)"
+            UnusedInterfaces="$(_TrimmerUnusedInterfaces)"
+            IPConstProp="$(_TrimmerIPConstProp)"
+            Sealer="$(_TrimmerSealer)"
+
+            Warn="$(ILLinkWarningLevel)"
+            NoWarn="$(NoWarn)"
+            TreatWarningsAsErrors="$(ILLinkTreatWarningsAsErrors)"
+            WarningsAsErrors="$(WarningsAsErrors)"
+            WarningsNotAsErrors="$(WarningsNotAsErrors)"
+            SingleWarn="$(TrimmerSingleWarn)"
+
+            CustomSteps="@(_TrimmerCustomSteps)"
+            RootDescriptorFiles="@(TrimmerRootDescriptor)"
+            OutputDirectory="$(IntermediateLinkDir)"
+            DumpDependencies="$(_TrimmerDumpDependencies)"
+            ExtraArgs="$(_ExtraTrimmerArgs)"
+            ToolExe="$(_DotNetHostFileName)"
+            ToolPath="$(_DotNetHostDirectory)"
+            ContinueOnError="ErrorAndContinue">
+        <Output TaskParameter="ExitCode" PropertyName="_ILLinkExitCode" />
+      </ILLink>
+
+     <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" Condition=" '$(_ILLinkExitCode)' == '0' " />
+
+  </Target>
+
+  <!--
+    ============================================================
+                     PrepareForILLink
+
+    Set up the default options and inputs to ILLink. Other targets are expected to hook into
+    this extension point via BeforeTargets/AfterTargets to opt assemblies into or out of trimming
+    using global ILLink options, or per-assembly IsTrimmable and TrimMode metadata.
+
+    Note that adding items to or removing items from ManagedAssemblyToLink is unsupported. To change
+    the set of inputs to the linker, instead use a different extension point to
+    set PostprocessAssembly metadata on ResolvedFileToPublish.
+   -->
+   <Target Name="PrepareForILLink"
+           DependsOnTargets="_ComputeManagedAssemblyToLink">
+
+    <!-- We print a message to the user to explain that trimming is
+         potentially problematic when warnings are suppressed. -->
+    <NETSdkInformation Condition="'$(PublishTrimmed)' == 'true' And '$(SuppressTrimAnalysisWarnings)' == 'true'" ResourceName="ILLinkOptimizedAssemblies" />
+
+    <!-- The defaults currently root non-framework assemblies, which
+         is a no-op for portable apps. If we later support more ways
+         to customize the behavior we can allow linking portable apps
+         in some cases. If we're not running ILLink because e.g. this
+         is a NativeAOT app, value of SelfContained doesn't matter. -->
+    <NETSdkError Condition="'$(RunILLink)' != 'false' And '$(SelfContained)' != 'true'" ResourceName="ILLinkNotSupportedError" />
+
+    <PropertyGroup Condition=" '$(ILLinkWarningLevel)' == '' ">
+      <ILLinkWarningLevel Condition=" '$(EffectiveAnalysisLevel)' != '' And
+                                       $([MSBuild]::VersionGreaterThanOrEquals($(EffectiveAnalysisLevel), '5.0')) ">5</ILLinkWarningLevel>
+      <ILLinkWarningLevel Condition=" '$(ILLinkWarningLevel)' == '' ">0</ILLinkWarningLevel>
+    </PropertyGroup>
+
+    <!-- Defaults for .NET < 6 -->
+    <PropertyGroup Condition=" $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0')) ">
+      <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
+      <!-- Action is the same regardless of whether the assembly has an IsTrimmable attribute. (The attribute didn't exist until .NET 6.) -->
+      <TrimmerDefaultAction>$(TrimMode)</TrimmerDefaultAction>
+    </PropertyGroup>
+    <PropertyGroup>
+      <TrimMode Condition=" '$(TrimMode)' == '' ">link</TrimMode>
+      <!-- For .NET 6+, assemblies without IsTrimmable attribute get the "copy" action. -->
+      <TrimmerDefaultAction Condition=" '$(TrimmerDefaultAction)' == '' ">copy</TrimmerDefaultAction>
+      <ILLinkTreatWarningsAsErrors Condition=" '$(ILLinkTreatWarningsAsErrors)' == '' ">$(TreatWarningsAsErrors)</ILLinkTreatWarningsAsErrors>
+      <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
+      <TrimmerSingleWarn Condition=" '$(TrimmerSingleWarn)' == '' ">true</TrimmerSingleWarn>
+    </PropertyGroup>
+
+    <!-- Suppressions to work around issues in previous versions of the framework. See https://github.com/dotnet/runtime/issues/40336 -->
+    <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == 'true' And $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0'))">
+      <!-- Framework embedded XML descriptors reference windows-only members. -->
+      <NoWarn Condition=" !$(RuntimeIdentifier.StartsWith('win')) ">$(NoWarn);IL2008</NoWarn> <!-- Unresolved type referenced in XML. -->
+      <NoWarn Condition=" !$(RuntimeIdentifier.StartsWith('win')) ">$(NoWarn);IL2009</NoWarn> <!-- Unresolved member on type referenced in XML. -->
+      <!-- Framework has DynamicDependencyAttributes that reference windows-only members. -->
+      <NoWarn Condition=" !$(RuntimeIdentifier.StartsWith('win')) ">$(NoWarn);IL2037</NoWarn> <!-- Unresolved member for DynamicDependencyAttribute -->
+      <!-- Framework embedded XML descriptors reference 32-bit-only members. -->
+      <NoWarn Condition=" '$(PlatformTarget)' != 'x64' AND '$(PlatformTarget)' != 'arm64'">$(NoWarn);IL2009;IL2012</NoWarn> <!-- Unresolved field referenced in XML -->
+    </PropertyGroup>
+
+    <!-- Set a default value for TrimmerRemoveSymbols unless set explicitly. -->
+    <PropertyGroup Condition=" '$(TrimmerRemoveSymbols)' == '' ">
+      <!-- The default is to remove symbols when debugger support is disabled, and keep them otherwise. -->
+      <TrimmerRemoveSymbols Condition=" '$(DebuggerSupport)' == 'false' ">true</TrimmerRemoveSymbols>
+      <TrimmerRemoveSymbols Condition=" '$(DebuggerSupport)' != 'false' ">false</TrimmerRemoveSymbols>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_TrimmerUnreachableBodies)' == '' And
+                              '$(PublishTrimmed)' == 'true' And
+                              $([MSBuild]::VersionLessThan($(_TargetFrameworkVersionWithoutV), '6.0'))">
+      <_TrimmerUnreachableBodies>false</_TrimmerUnreachableBodies>
+    </PropertyGroup>
+
+    <!-- Set IsTrimmable for any assemblies that already have customized TrimMode. -->
+    <ItemGroup>
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.TrimMode)' != '' ">
+        <IsTrimmable>true</IsTrimmable>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+
+    <!-- SetIsTrimmable for any assemblies listed in TrimmableAssembly. -->
+    <JoinItems Left="@(ManagedAssemblyToLink)" LeftKey="FileName" LeftMetadata="*"
+               Right="@(TrimmableAssembly)"
+               ItemSpecToUse="Left">
+      <Output TaskParameter="JoinResult" ItemName="_TrimmableManagedAssemblyToLink" />
+    </JoinItems>
+    <ItemGroup>
+      <ManagedAssemblyToLink Remove="@(_TrimmableManagedAssemblyToLink)" />
+      <ManagedAssemblyToLink Include="@(_TrimmableManagedAssemblyToLink)" IsTrimmable="true" />
+    </ItemGroup>
+
+    <!-- Root the main assembly, whether or not it has IsTrimmable set. -->
+    <ItemGroup>
+      <TrimmerRootAssembly Include="@(IntermediateAssembly)" />
+    </ItemGroup>
+
+    <!-- For .NET < 6, root and copy assemblies without IsTrimmable=true MSBuild metadata. -->
+    <ItemGroup Condition=" $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0')) ">
+      <TrimmerRootAssembly Include="@(ManagedAssemblyToLink)" Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' != 'true' " />
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' != 'true' ">
+        <TrimMode>copy</TrimMode>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+
+    <!-- In .NET6+, set the action explicitly for any with IsTrimmable MSBuild metadata -->
+    <ItemGroup Condition=" $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '6.0')) ">
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' == 'true' And '%(ManagedAssemblyToLink.TrimMode)' == '' ">
+        <TrimMode>$(TrimMode)</TrimMode>
+      </ManagedAssemblyToLink>
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.IsTrimmable)' == 'false' And '%(ManagedAssemblyToLink.TrimMode)' == '' ">
+        <TrimMode>$(TrimmerDefaultAction)</TrimMode>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Don't collapse to a single warning for the intermediate assembly.
+           This just sets metadata on the items in ManagedAssemblyToLink that came from IntermediateAssembly. -->
+      <!-- Find ManagedAssemblyToLink _except_ IntermediateAssembly -->
+      <__SingleWarnIntermediateAssembly Include="@(ManagedAssemblyToLink)" />
+      <__SingleWarnIntermediateAssembly Remove="@(IntermediateAssembly)" />
+      <!-- Subtract these from ManagedAssemblyToLink, to get the intersection. -->
+      <_SingleWarnIntermediateAssembly Include="@(ManagedAssemblyToLink)" />
+      <_SingleWarnIntermediateAssembly Remove="@(__SingleWarnIntermediateAssembly)" />
+      <!-- Set metadata on the intersection. -->
+      <_SingleWarnIntermediateAssembly>
+        <TrimmerSingleWarn Condition=" '%(_SingleWarnIntermediateAssembly.TrimmerSingleWarn)' == '' ">false</TrimmerSingleWarn>
+      </_SingleWarnIntermediateAssembly>
+      <!-- Replace these items in ManagedAssemblyToLink. -->
+      <ManagedAssemblyToLink Remove="@(_SingleWarnIntermediateAssembly)" />
+      <ManagedAssemblyToLink Include="@(_SingleWarnIntermediateAssembly)" />
+
+      <!-- Don't collapse to a single warning for project references -->
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.ProjectReferenceOriginalItemSpec)' != '' ">
+        <TrimmerSingleWarn Condition=" '%(ManagedAssemblyToLink.TrimmerSingleWarn)' == '' ">false</TrimmerSingleWarn>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+
+    <ItemGroup>
+      <_TrimmerFeatureSettings Include="@(RuntimeHostConfigurationOption)" Condition="'%(RuntimeHostConfigurationOption.Trim)' == 'true'" />
+    </ItemGroup>
+
+   </Target>
+
+  <!--
+    ============================================================
+                     _ComputeManagedAssemblyToLink
+
+    Compute the set of inputs to the linker.
+    ============================================================
+    -->
+  <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(ILLinkTasksAssembly)" Condition="'$(ILLinkTasksAssembly)' != ''" />
+  <Target Name="_ComputeManagedAssemblyToLink" DependsOnTargets="_ComputeAssembliesToPostprocessOnPublish">
+
+    <!-- NB: There should not be non-managed assemblies in this list, but we still give the linker a chance to
+         further refine this list. It currently drops C++/CLI assemblies in ComputeManageAssemblies. -->
+    <ComputeManagedAssemblies Assemblies="@(ResolvedFileToPublish->WithMetadataValue('PostprocessAssembly', 'true'))">
+      <Output TaskParameter="ManagedAssemblies" ItemName="ManagedAssemblyToLink" />
+    </ComputeManagedAssemblies>
+
+    <ItemGroup>
+      <!-- The linker implicitly picks up PDBs next to input assemblies. We will filter these out of the publish set. -->
+      <__PDBToLink Include="@(ResolvedFileToPublish)" Exclude="@(ManagedAssemblyToLink->'%(RelativeDir)%(Filename).pdb')" />
+      <_PDBToLink Include="@(ResolvedFileToPublish)" Exclude="@(__PDBToLink)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_LinkedResolvedFileToPublishCandidate Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
+      <_LinkedResolvedFileToPublishCandidate Include="@(_PDBToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/ILLink.Tasks/sdk/Sdk.props
+++ b/src/ILLink.Tasks/sdk/Sdk.props
@@ -12,6 +12,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project>
 
   <!-- Only import the build props if the ILLink.Tasks package isn't referenced via NuGet. -->
-  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.ILLink.Tasks.props" Condition="'$(UsingILLinkTasksSdk)' != 'true'" />
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.ILLink.Tasks.props" Condition="'$(ILLinkTargetsPath)' == ''" />
 
 </Project>


### PR DESCRIPTION
In general, a task invocation in MSBuild and the task definition are
inseparable. Adding parameters to the task will either result in errors
if the target is updated and too new, or silently skipping the parameter
if the target is too old.

Best practice is to ship both as a pair to prevent this problem. Testing is
harder, but we can add some limited testing if necessary to the linker repo.