### PR TITLE
Adjust ref param kind check for IL offset

### DIFF
--- a/src/linker/Linker.Dataflow/MethodProxy.cs
+++ b/src/linker/Linker.Dataflow/MethodProxy.cs
@@ -53,7 +53,7 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		public override string ToString () => Method.ToString ();
 
-		public ReferenceKind ParameterReferenceKind (int index) => Method.ParameterReferenceKind (index);
+		public ReferenceKind ParameterReferenceKind (int index) => Method.HasImplicitThis () ? Method.ParameterReferenceKind (index + 1) : Method.ParameterReferenceKind (index);
 
 		public bool Equals (MethodProxy other) => Method.Equals (other.Method);
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
@@ -34,6 +36,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestAssigningToRefParameter (nullType3, ref nullType3);
 			Type nullType4 = null;
 			TestAssigningToRefParameter_Mismatch (nullType4, ref nullType4);
+			TestPassingRefsWithImplicitThis ();
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
@@ -169,11 +172,201 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			return false;
 		}
 
+		static void TestPassingRefsWithImplicitThis ()
+		{
+			var x = new InheritsFromType ();
+			var param1 = typeof (int);
+			var param2 = typeof (string);
+			x.MethodWithRefAndImplicitThis (ref param1, in param2, out var param3);
+			param1.RequiresPublicMethods ();
+			param2.RequiresAll ();
+			param3.RequiresPublicFields ();
+		}
+
 		[return: DynamicallyAccessedMembersAttribute (DynamicallyAccessedMemberTypes.PublicFields)]
 		static Type GetTypeWithFields () => null;
 
 		class TestType
 		{
+		}
+
+		class InheritsFromType : Type
+		{
+			public void MethodWithRefAndImplicitThis ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] ref Type type1,
+				in Type type2,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] out Type type3)
+			{
+				type3 = typeof (int);
+			}
+			public override Assembly Assembly => throw new NotImplementedException ();
+
+			public override string AssemblyQualifiedName => throw new NotImplementedException ();
+
+			public override Type BaseType => throw new NotImplementedException ();
+
+			public override string FullName => throw new NotImplementedException ();
+
+			public override Guid GUID => throw new NotImplementedException ();
+
+			public override Module Module => throw new NotImplementedException ();
+
+			public override string Namespace => throw new NotImplementedException ();
+
+			public override Type UnderlyingSystemType => throw new NotImplementedException ();
+
+			public override string Name => throw new NotImplementedException ();
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			public override ConstructorInfo[] GetConstructors (BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			public override object[] GetCustomAttributes (bool inherit)
+			{
+				throw new NotImplementedException ();
+			}
+
+			public override object[] GetCustomAttributes (Type attributeType, bool inherit)
+			{
+				throw new NotImplementedException ();
+			}
+
+			public override Type GetElementType ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
+			public override EventInfo GetEvent (string name, BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
+			public override EventInfo[] GetEvents (BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+			public override FieldInfo GetField (string name, BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+			public override FieldInfo[] GetFields (BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+			public override Type GetInterface (string name, bool ignoreCase)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+			public override Type[] GetInterfaces ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
+			public override MemberInfo[] GetMembers (BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+			public override MethodInfo[] GetMethods (BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes | DynamicallyAccessedMemberTypes.PublicNestedTypes)]
+			public override Type GetNestedType (string name, BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes | DynamicallyAccessedMemberTypes.PublicNestedTypes)]
+			public override Type[] GetNestedTypes (BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicProperties)]
+			public override PropertyInfo[] GetProperties (BindingFlags bindingAttr)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+			public override object InvokeMember (string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+			{
+				throw new NotImplementedException ();
+			}
+
+			public override bool IsDefined (Type attributeType, bool inherit)
+			{
+				throw new NotImplementedException ();
+			}
+
+			protected override TypeAttributes GetAttributeFlagsImpl ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			protected override ConstructorInfo GetConstructorImpl (BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+			protected override MethodInfo GetMethodImpl (string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+			{
+				throw new NotImplementedException ();
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+			protected override PropertyInfo GetPropertyImpl (string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+			{
+				throw new NotImplementedException ();
+			}
+
+			protected override bool HasElementTypeImpl ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			protected override bool IsArrayImpl ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			protected override bool IsByRefImpl ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			protected override bool IsCOMObjectImpl ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			protected override bool IsPointerImpl ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			protected override bool IsPrimitiveImpl ()
+			{
+				throw new NotImplementedException ();
+			}
 		}
 	}
 }


### PR DESCRIPTION
In the linker, ParameterReferenceKind expects the IL parameter index (with `this` as 0), but MethodProxy would pass the index without this. This fix adds a test that failed with the incorrect order, but works after accounting for the offset.