### PR TITLE
Seal classes to silence warnings in Preview 5

### DIFF
--- a/src/ILLink.RoslynAnalyzer/ImmutableArrayOperations.cs
+++ b/src/ILLink.RoslynAnalyzer/ImmutableArrayOperations.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.RoslynAnalyzer
 {
-	class ImmutableArrayOperations
+	sealed class ImmutableArrayOperations
 	{
 		internal static bool Contains<T, TComp> (ImmutableArray<T> list, T elem, TComp comparer)
 					where TComp : IEqualityComparer<T>

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial class FlowAnnotations
+	sealed partial class FlowAnnotations
 	{
 		// In the analyzer there's no stateful data the flow annotations need to store
 		// so we just create a singleton on demand.

--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -51,7 +51,7 @@ namespace ILLink.Tasks
 		[Required]
 		public ITaskItem RuntimeRootDescriptorFilePath { get; set; }
 
-		class ClassMembers
+		sealed class ClassMembers
 		{
 			public bool keepAllFields;
 			public HashSet<string> methods;
@@ -483,7 +483,7 @@ namespace ILLink.Tasks
 				defineConstants.Add (item.ItemSpec.Trim ());
 		}
 
-		class DefineTracker
+		sealed class DefineTracker
 		{
 			readonly HashSet<string> defineConstants;
 			readonly TaskLoggingHelper log;

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -10,7 +10,7 @@ using Mono.Linker.Steps;
 
 namespace Mono.Linker.Dataflow
 {
-	class DynamicallyAccessedMembersTypeHierarchy
+	sealed class DynamicallyAccessedMembersTypeHierarchy
 	{
 		readonly LinkContext _context;
 		readonly MarkStep _markStep;

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -15,7 +15,7 @@ using Mono.Linker.Dataflow;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial class FlowAnnotations
+	sealed partial class FlowAnnotations
 	{
 		readonly LinkContext _context;
 		readonly Dictionary<TypeDefinition, TypeAnnotations> _annotations = new Dictionary<TypeDefinition, TypeAnnotations> ();

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -17,7 +17,7 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 
 namespace Mono.Linker.Dataflow
 {
-	class ReflectionMethodBodyScanner : MethodBodyScanner
+	sealed class ReflectionMethodBodyScanner : MethodBodyScanner
 	{
 		readonly MarkStep _markStep;
 		MessageOrigin _origin;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1421,7 +1421,7 @@ namespace Mono.Linker.Steps
 			TypeReferenceMarker.MarkTypeReferences (assembly, MarkingHelpers);
 		}
 
-		class TypeReferenceMarker : TypeReferenceWalker
+		sealed class TypeReferenceMarker : TypeReferenceWalker
 		{
 
 			readonly MarkingHelpers markingHelpers;

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -555,7 +555,7 @@ namespace Mono.Linker.Steps
 		{
 		}
 
-		class AssemblyReferencesCorrector : TypeReferenceWalker
+		sealed class AssemblyReferencesCorrector : TypeReferenceWalker
 		{
 			readonly DefaultMetadataImporter importer;
 

--- a/src/linker/Linker/CompilerGeneratedCallGraph.cs
+++ b/src/linker/Linker/CompilerGeneratedCallGraph.cs
@@ -7,7 +7,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-	class CompilerGeneratedCallGraph
+	sealed class CompilerGeneratedCallGraph
 	{
 		readonly Dictionary<IMemberDefinition, HashSet<IMemberDefinition>> callGraph;
 

--- a/src/linker/Linker/CompilerGeneratedNames.cs
+++ b/src/linker/Linker/CompilerGeneratedNames.cs
@@ -3,7 +3,7 @@
 
 namespace Mono.Linker
 {
-	class CompilerGeneratedNames
+	sealed class CompilerGeneratedNames
 	{
 		internal static bool IsGeneratedMemberName (string memberName)
 		{

--- a/src/linker/Linker/DynamicDependency.cs
+++ b/src/linker/Linker/DynamicDependency.cs
@@ -14,7 +14,7 @@ namespace Mono.Linker
 	/// CustomAttribute for dependency tracing. It is also a place for helper
 	/// methods related to the attribute.
 	[System.AttributeUsage (System.AttributeTargets.Constructor | System.AttributeTargets.Field | System.AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
-	internal class DynamicDependency : Attribute
+	sealed internal class DynamicDependency : Attribute
 	{
 		public CustomAttribute? OriginalAttribute { get; private set; }
 		public DynamicDependency (string memberSignature)

--- a/src/linker/Linker/DynamicDependency.cs
+++ b/src/linker/Linker/DynamicDependency.cs
@@ -14,7 +14,7 @@ namespace Mono.Linker
 	/// CustomAttribute for dependency tracing. It is also a place for helper
 	/// methods related to the attribute.
 	[System.AttributeUsage (System.AttributeTargets.Constructor | System.AttributeTargets.Field | System.AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
-	sealed internal class DynamicDependency : Attribute
+	internal sealed class DynamicDependency : Attribute
 	{
 		public CustomAttribute? OriginalAttribute { get; private set; }
 		public DynamicDependency (string memberSignature)

--- a/src/linker/Linker/LinkerILProcessor.cs
+++ b/src/linker/Linker/LinkerILProcessor.cs
@@ -8,7 +8,7 @@ using Mono.Cecil.Cil;
 namespace Mono.Linker
 {
 #pragma warning disable RS0030
-	class LinkerILProcessor
+	sealed class LinkerILProcessor
 	{
 		readonly ILProcessor _ilProcessor;
 

--- a/src/linker/Linker/TypeHierarchyCache.cs
+++ b/src/linker/Linker/TypeHierarchyCache.cs
@@ -8,7 +8,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-	class TypeHierarchyCache
+	sealed class TypeHierarchyCache
 	{
 		[Flags]
 		private enum HierarchyFlags

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -12,7 +12,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-	internal class TypeNameResolver
+	sealed internal class TypeNameResolver
 	{
 		readonly LinkContext _context;
 

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -12,7 +12,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-	sealed internal class TypeNameResolver
+	internal sealed class TypeNameResolver
 	{
 		readonly LinkContext _context;
 

--- a/src/tlens/TLens.Analyzers/DuplicatedCodeAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/DuplicatedCodeAnalyzer.cs
@@ -9,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class DuplicatedCodeAnalyzer : Analyzer
+	sealed class DuplicatedCodeAnalyzer : Analyzer
 	{
 		readonly Dictionary<string, List<MethodDefinition>> strings = new Dictionary<string, List<MethodDefinition>> ();
 

--- a/src/tlens/TLens.Analyzers/InterfaceDispatchAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/InterfaceDispatchAnalyzer.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace TLens.Analyzers
 {
-	class InterfaceDispatchAnalyzer : InterfacesAnalyzer
+	sealed class InterfaceDispatchAnalyzer : InterfacesAnalyzer
 	{
 		public override void PrintResults (int maxCount)
 		{

--- a/src/tlens/TLens.Analyzers/InterfaceTypeCheckAnalyzers.cs
+++ b/src/tlens/TLens.Analyzers/InterfaceTypeCheckAnalyzers.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace TLens.Analyzers
 {
-	class InterfaceTypeCheckAnalyzers : InterfacesAnalyzer
+	sealed class InterfaceTypeCheckAnalyzers : InterfacesAnalyzer
 	{
 		public override void PrintResults (int maxCount)
 		{

--- a/src/tlens/TLens.Analyzers/InverterCtorsChainAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/InverterCtorsChainAnalyzer.cs
@@ -9,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class InverterCtorsChainAnalyzer : Analyzer
+	sealed class InverterCtorsChainAnalyzer : Analyzer
 	{
 		readonly List<(MethodDefinition, MethodDefinition)> ctors = new List<(MethodDefinition, MethodDefinition)> ();
 

--- a/src/tlens/TLens.Analyzers/LargeStaticArraysAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/LargeStaticArraysAnalyzer.cs
@@ -9,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class LargeStaticArraysAnalyzer : Analyzer
+	sealed class LargeStaticArraysAnalyzer : Analyzer
 	{
 		readonly List<(int, MethodDefinition)> methods = new List<(int, MethodDefinition)> ();
 

--- a/src/tlens/TLens.Analyzers/LargeStaticCtorAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/LargeStaticCtorAnalyzer.cs
@@ -8,7 +8,7 @@ using Mono.Cecil;
 
 namespace TLens.Analyzers
 {
-	class LargeStaticCtorAnalyzer : Analyzer
+	sealed class LargeStaticCtorAnalyzer : Analyzer
 	{
 		readonly List<MethodDefinition> cctors = new List<MethodDefinition> ();
 

--- a/src/tlens/TLens.Analyzers/LargeStringsAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/LargeStringsAnalyzer.cs
@@ -9,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class LargeStringsAnalyzer : Analyzer
+	sealed class LargeStringsAnalyzer : Analyzer
 	{
 		readonly List<(int, MethodDefinition)> ldstrs = new List<(int, MethodDefinition)> ();
 

--- a/src/tlens/TLens.Analyzers/LimitedMethodCalls.cs
+++ b/src/tlens/TLens.Analyzers/LimitedMethodCalls.cs
@@ -9,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class LimitedMethodCalls : Analyzer
+	sealed class LimitedMethodCalls : Analyzer
 	{
 		readonly Dictionary<MethodDefinition, List<MethodDefinition>> methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 

--- a/src/tlens/TLens.Analyzers/RedundantFieldInitializationAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/RedundantFieldInitializationAnalyzer.cs
@@ -9,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class RedundantFieldInitializationAnalyzer : Analyzer
+	sealed class RedundantFieldInitializationAnalyzer : Analyzer
 	{
 		readonly Dictionary<MethodDefinition, List<FieldDefinition>> ctors = new Dictionary<MethodDefinition, List<FieldDefinition>> ();
 

--- a/src/tlens/TLens.Analyzers/TypeInstatiationAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/TypeInstatiationAnalyzer.cs
@@ -9,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class TypeInstatiationAnalyzer : Analyzer
+	sealed class TypeInstatiationAnalyzer : Analyzer
 	{
 		readonly Dictionary<TypeDefinition, List<MethodDefinition>> types = new Dictionary<TypeDefinition, List<MethodDefinition>> ();
 

--- a/src/tlens/TLens.Analyzers/UnnecessaryFieldsAssignmentAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/UnnecessaryFieldsAssignmentAnalyzer.cs
@@ -9,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class UnnecessaryFieldsAssignmentAnalyzer : Analyzer
+	sealed class UnnecessaryFieldsAssignmentAnalyzer : Analyzer
 	{
 		[Flags]
 		enum Access

--- a/src/tlens/TLens.Analyzers/UnusedParametersAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/UnusedParametersAnalyzer.cs
@@ -10,7 +10,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class UnusedParametersAnalyzer : Analyzer
+	sealed class UnusedParametersAnalyzer : Analyzer
 	{
 		readonly List<(MethodDefinition, int)> methods = new List<(MethodDefinition, int)> ();
 

--- a/src/tlens/TLens.Analyzers/UserOperatorCalledForNullCheckAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/UserOperatorCalledForNullCheckAnalyzer.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	class UserOperatorCalledForNullCheckAnalyzer : Analyzer
+	sealed class UserOperatorCalledForNullCheckAnalyzer : Analyzer
 	{
-		class Counters
+		sealed class Counters
 		{
 			public int Total;
 			public int Redundant;

--- a/src/tlens/TLens/AssemlyReferenceResolver.cs
+++ b/src/tlens/TLens/AssemlyReferenceResolver.cs
@@ -8,7 +8,7 @@ using Mono.Cecil;
 
 namespace TLens
 {
-	class AssemlyReferenceResolver : IAssemblyResolver
+	sealed class AssemlyReferenceResolver : IAssemblyResolver
 	{
 		readonly string[] additionalFolders;
 		readonly Dictionary<string, AssemblyDefinition> resolved = new ();

--- a/src/tlens/TLens/Driver.cs
+++ b/src/tlens/TLens/Driver.cs
@@ -11,7 +11,7 @@ using TLens.Analyzers;
 
 namespace TLens
 {
-	class Driver
+	sealed class Driver
 	{
 		static int Main (string[] args)
 		{

--- a/src/tlens/TLens/LensesCollection.cs
+++ b/src/tlens/TLens/LensesCollection.cs
@@ -10,7 +10,7 @@ namespace TLens
 {
 	static class LensesCollection
 	{
-		public class LensAnalyzerDetails
+		sealed public class LensAnalyzerDetails
 		{
 			public LensAnalyzerDetails (string name, string description, Type analyzerType)
 			{

--- a/src/tlens/TLens/LensesCollection.cs
+++ b/src/tlens/TLens/LensesCollection.cs
@@ -10,7 +10,7 @@ namespace TLens
 {
 	static class LensesCollection
 	{
-		sealed public class LensAnalyzerDetails
+		public sealed class LensAnalyzerDetails
 		{
 			public LensAnalyzerDetails (string name, string description, Type analyzerType)
 			{

--- a/src/tlens/TLens/Runner.cs
+++ b/src/tlens/TLens/Runner.cs
@@ -8,7 +8,7 @@ using TLens.Analyzers;
 
 namespace TLens
 {
-	class Runner
+	sealed class Runner
 	{
 		readonly List<Analyzer> analyzers = new List<Analyzer> ();
 


### PR DESCRIPTION
After updating to SDK Preview 5, there are new warnings about being able to seal classes that breaks the build (CA1852). This PR adds the `sealed` modifier to classes to silence the warnings.