### PR TITLE
Display init properties as ".init" in GetDisplayName

### DIFF
--- a/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -103,7 +103,7 @@ namespace Mono.Linker
 		public static bool IsInit (this MethodDefinition methodDefinition)
 		{
 			return methodDefinition.IsSetter && methodDefinition.ReturnType.IsRequiredModifier
-				&& ((RequiredModifierType)methodDefinition.ReturnType).ModifierType.IsTypeOf ("System.Runtime.CompilerServices.IsExternalInit");
+				&& ((RequiredModifierType) methodDefinition.ReturnType).ModifierType.IsTypeOf ("System.Runtime.CompilerServices.IsExternalInit");
 		}
 	}
 }

--- a/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Mono.Cecil;
 
 namespace Mono.Linker
@@ -97,6 +98,12 @@ namespace Mono.Linker
 				di.Scope.Constants.Clear ();
 				di.Scope = null;
 			}
+		}
+
+		public static bool IsInit (this MethodDefinition methodDefinition)
+		{
+			return methodDefinition.IsSetter && methodDefinition.ReturnType.IsRequiredModifier
+				&& ((RequiredModifierType)methodDefinition.ReturnType).ModifierType.IsTypeOf ("System.Runtime.CompilerServices.IsExternalInit");
 		}
 	}
 }

--- a/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Cecil;
 
 namespace Mono.Linker

--- a/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/linker/Linker/MethodReferenceExtensions.cs
@@ -18,13 +18,14 @@ namespace Mono.Linker
 			if (methodDefinition != null && (methodDefinition.IsSetter || methodDefinition.IsGetter)) {
 				// Append property name
 				string name;
-				// Remove set_/get_ from beginning and add .get/.set/.init to end
+				// Remove set_/get_ prefix from method to get property name
+				var propertyName = methodDefinition.Name.AsSpan (4);
 				if (methodDefinition.IsGetter)
-					name = string.Concat (methodDefinition.Name.AsSpan (4), ".get");
+					name = string.Concat (propertyName, ".get");
 				else if (methodDefinition.IsInit ())
-					name = string.Concat (methodDefinition.Name.AsSpan (4), ".init");
+					name = string.Concat (propertyName, ".init");
 				else
-					name = string.Concat (methodDefinition.Name.AsSpan (4), ".set");
+					name = string.Concat (propertyName, ".set");
 
 				sb.Append (name);
 				// Insert declaring type name and namespace

--- a/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/linker/Linker/MethodReferenceExtensions.cs
@@ -14,10 +14,18 @@ namespace Mono.Linker
 			var sb = new System.Text.StringBuilder ();
 
 			// Match C# syntaxis name if setter or getter
-			var methodDefinition = method.Resolve ();
+			MethodDefinition methodDefinition = method.Resolve ();
 			if (methodDefinition != null && (methodDefinition.IsSetter || methodDefinition.IsGetter)) {
 				// Append property name
-				string name = methodDefinition.IsSetter ? string.Concat (methodDefinition.Name.AsSpan (4), ".set") : string.Concat (methodDefinition.Name.AsSpan (4), ".get");
+				string name;
+				// Remove set_/get_ from beginning and add .get/.set/.init to end
+				if (methodDefinition.IsGetter)
+					name = string.Concat (methodDefinition.Name.AsSpan (4), ".get");
+				else if (methodDefinition.IsInit ())
+					name = string.Concat (methodDefinition.Name.AsSpan (4), ".init");
+				else
+					name = string.Concat (methodDefinition.Name.AsSpan (4), ".set");
+
 				sb.Append (name);
 				// Insert declaring type name and namespace
 				sb.Insert (0, '.').Insert (0, method.DeclaringType.GetDisplayName ());

--- a/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
+++ b/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
@@ -212,6 +212,18 @@ namespace Mono.Linker.Tests
 			GenericClassMultipleParameters<MethodT, string>.NestedGenericClassMultipleParameters<int, MethodV> p)
 		{
 		}
+		public string Property {
+			[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.Property.get")]
+			get;
+			[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.Property.init")]
+			init;
+		}
+		public string Property2 {
+			[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.Property2.get")]
+			get;
+			[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.Property2.set")]
+			set;
+		}
 	}
 }
 

--- a/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
+++ b/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
@@ -212,12 +212,14 @@ namespace Mono.Linker.Tests
 			GenericClassMultipleParameters<MethodT, string>.NestedGenericClassMultipleParameters<int, MethodV> p)
 		{
 		}
+
 		public string Property {
 			[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.Property.get")]
 			get;
 			[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.Property.init")]
 			init;
 		}
+
 		public string Property2 {
 			[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.Property2.get")]
 			get;


### PR DESCRIPTION
Shows `init` properties as `Property.init` instead of `Property.set` in GetDisplayName and adds an `IsInit` extension to MethodDefinition.

Fixes https://github.com/dotnet/linker/issues/2816, but may want to wait until NativeAOT has the same changes to merge.