### PR TITLE
Add more trimming options to TrimMode and change defaults

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -33,11 +33,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="sdk/Sdk.props" PackagePath="Sdk/" />
-    <Content Include="build/$(PackageId).props" PackagePath="build/" />
+    <Content Include="sdk/Sdk.props" PackagePath="Sdk/">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="build/$(PackageId).props" PackagePath="build/">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <!-- Note: this should not match the package name, because we don't want the targets
          to be imported by nuget. The SDK will import them in the right order. -->
-    <Content Include="build/Microsoft.NET.ILLink.targets" PackagePath="build/" />
+    <Content Include="build/Microsoft.NET.ILLink.targets" PackagePath="build/">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -51,8 +51,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(PublishTrimmed)' == 'true' And '$(EnableTrimAnalyzer)' != 'true'">
     <!-- Trim analysis warnings are suppressed for .NET < 6. -->
     <SuppressTrimAnalysisWarnings Condition="$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0'))">true</SuppressTrimAnalysisWarnings>
-    <!-- Suppress for WPF/WinForms (unless linking everything) -->
-    <SuppressTrimAnalysisWarnings Condition="'$(TrimmerDefaultAction)' != 'link' And ('$(UseWpf)' == 'true' Or '$(UseWindowsForms)' == 'true')">true</SuppressTrimAnalysisWarnings>
+    <!-- Suppress for WPF/WinForms -->
+    <SuppressTrimAnalysisWarnings Condition="'$(UseWpf)' == 'true' Or '$(UseWindowsForms)' == 'true'">true</SuppressTrimAnalysisWarnings>
     <!-- Otherwise, for .NET 6+, warnings are on by default -->
     <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == ''">false</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
@@ -154,12 +154,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_DotNetHostFileName Condition="$([MSBuild]::IsOSPlatform(`Windows`))">dotnet.exe</_DotNetHostFileName>
     </PropertyGroup>
 
+    <!-- Define a LinkVersion to support different options behavior based on TFM. -->
+    <PropertyGroup>
+      <_LinkVersion Condition="$([MSBuild]::VersionGreaterThan('$(TargetFrameworkVersion)', '6.0'))">7</_LinkVersion>
+      <_LinkVersion Condition="$([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '6.0'))">6</_LinkVersion>
+      <_LinkVersion Condition="$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0'))">5</_LinkVersion>
+      <_LinkVersion Condition="$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '5.0'))">3</_LinkVersion>
+    </PropertyGroup>
+
     <Delete Files="@(_LinkedResolvedFileToPublishCandidate)" />
     <ILLink AssemblyPaths="@(ManagedAssemblyToLink)"
             ReferenceAssemblyPaths="@(ReferencePath)"
             RootAssemblyNames="@(TrimmerRootAssembly)"
+            LinkVersion="$(_LinkVersion)"
             TrimMode="$(TrimMode)"
-            DefaultAction="$(TrimmerDefaultAction)"
+            DefaultAction="$(_TrimmerDefaultAction)"
             RemoveSymbols="$(TrimmerRemoveSymbols)"
             FeatureSettings="@(_TrimmerFeatureSettings)"
             CustomData="@(_TrimmerCustomData)"
@@ -212,6 +221,10 @@ Copyright (c) .NET Foundation. All rights reserved.
          potentially problematic when warnings are suppressed. -->
     <NETSdkInformation Condition="'$(PublishTrimmed)' == 'true' And '$(SuppressTrimAnalysisWarnings)' == 'true'" ResourceName="ILLinkOptimizedAssemblies" />
 
+    <!-- In .NET 7, TrimmerDefaultAction is deprecated. TrimMode can be used for the supported configurations. -->
+    <Warning Condition="'$(TrimmerDefaultAction)' != '' And $([MSBuild]::VersionGreaterThan('$(TargetFrameworkVersion)', '6.0'))"
+             Text="Property 'TrimmerDefaultAction' is deprecated in .NET 7." />
+
     <!-- The defaults currently root non-framework assemblies, which
          is a no-op for portable apps. If we later support more ways
          to customize the behavior we can allow linking portable apps
@@ -225,16 +238,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ILLinkWarningLevel Condition=" '$(ILLinkWarningLevel)' == '' ">0</ILLinkWarningLevel>
     </PropertyGroup>
 
-    <!-- Defaults for .NET < 6 -->
-    <PropertyGroup Condition=" $([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0')) ">
-      <TrimMode Condition=" '$(TrimMode)' == '' ">copyused</TrimMode>
-      <!-- Action is the same regardless of whether the assembly has an IsTrimmable attribute. (The attribute didn't exist until .NET 6.) -->
-      <TrimmerDefaultAction>$(TrimMode)</TrimmerDefaultAction>
-    </PropertyGroup>
     <PropertyGroup>
-      <TrimMode Condition=" '$(TrimMode)' == '' ">link</TrimMode>
-      <!-- For .NET 6+, assemblies without IsTrimmable attribute get the "copy" action. -->
-      <TrimmerDefaultAction Condition=" '$(TrimmerDefaultAction)' == '' ">copy</TrimmerDefaultAction>
+      <!-- Set TrimmerDefaultAction for compat -->
+      <_TrimmerDefaultAction>$(TrimmerDefaultAction)</_TrimmerDefaultAction>
       <ILLinkTreatWarningsAsErrors Condition=" '$(ILLinkTreatWarningsAsErrors)' == '' ">$(TreatWarningsAsErrors)</ILLinkTreatWarningsAsErrors>
       <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimmerSingleWarn Condition=" '$(TrimmerSingleWarn)' == '' ">true</TrimmerSingleWarn>

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -55,6 +55,86 @@ namespace ILLink.Tasks.Tests
 				}
 			}
 		};
+		
+		[Theory]
+		[InlineData(3, AssemblyAction.CopyUsed)]
+		[InlineData(5, AssemblyAction.CopyUsed)]
+		[InlineData(6, AssemblyAction.Copy)]
+		[InlineData(7, AssemblyAction.Link)]
+		public void DefaultDefaultAction(int linkVersion, AssemblyAction expectedDefault)
+		{
+			var task = new MockTask() {
+				LinkVersion = linkVersion
+			};
+			using (var driver = task.CreateDriver()) {
+				Assert.Equal (expectedDefault, driver.Context.DefaultAction);
+			}
+		}
+
+		[Theory]
+		[InlineData(3, "copyused", AssemblyAction.CopyUsed)]
+		[InlineData(3, "copy", AssemblyAction.Copy)]
+		[InlineData(3, "link", AssemblyAction.Link)]
+		[InlineData(5, "copyused", AssemblyAction.CopyUsed)]
+		[InlineData(5, "copy", AssemblyAction.Copy)]
+		[InlineData(5, "link", AssemblyAction.Link)]
+		// Trim Mode settings don't affect DefaultAction after 5, unless 'full' or 'partial'
+		[InlineData(6, "copyused", AssemblyAction.Copy)]
+		[InlineData(6, "copy", AssemblyAction.Copy)]
+		[InlineData(6, "link", AssemblyAction.Copy)]
+		[InlineData(7, "copyused", AssemblyAction.Link)]
+		[InlineData(7, "copy", AssemblyAction.Link)]
+		[InlineData(7, "link", AssemblyAction.Link)]
+		// 'Full' and 'partial' are always respected
+		[InlineData(3, "full", AssemblyAction.Link)]
+		[InlineData(5, "full", AssemblyAction.Link)]
+		[InlineData(6, "full", AssemblyAction.Link)]
+		[InlineData(7, "full", AssemblyAction.Link)]
+		[InlineData(3, "partial", AssemblyAction.Copy)]
+		[InlineData(5, "partial", AssemblyAction.Copy)]
+		[InlineData(6, "partial", AssemblyAction.Copy)]
+		[InlineData(7, "partial", AssemblyAction.Copy)]
+		public void DefaultActionWithTrimMode(int linkVersion, string trimMode, AssemblyAction expectedDefault)
+		{
+			var task = new MockTask () {
+				LinkVersion = linkVersion,
+				TrimMode = trimMode
+			};
+			using var driver = task.CreateDriver();
+			Assert.Equal (expectedDefault, driver.Context.DefaultAction);
+		}
+
+		[Theory]
+		[InlineData(3, "copyused", AssemblyAction.CopyUsed)]
+		[InlineData(3, "copy", AssemblyAction.Copy)]
+		[InlineData(3, "link", AssemblyAction.Link)]
+		[InlineData(5, "copyused", AssemblyAction.CopyUsed)]
+		[InlineData(5, "copy", AssemblyAction.Copy)]
+		[InlineData(5, "link", AssemblyAction.Link)]
+		[InlineData(6, "copyused", AssemblyAction.CopyUsed)]
+		[InlineData(6, "copy", AssemblyAction.Copy)]
+		[InlineData(6, "link", AssemblyAction.Link)]
+		[InlineData(7, "copyused", AssemblyAction.CopyUsed)]
+		[InlineData(7, "copy", AssemblyAction.Copy)]
+		[InlineData(7, "link", AssemblyAction.Link)]
+		// 'Full' and 'partial' are always respected
+		[InlineData(3, "full", AssemblyAction.Link)]
+		[InlineData(5, "full", AssemblyAction.Link)]
+		[InlineData(6, "full", AssemblyAction.Link)]
+		[InlineData(7, "full", AssemblyAction.Link)]
+		[InlineData(3, "partial", AssemblyAction.Link)]
+		[InlineData(5, "partial", AssemblyAction.Link)]
+		[InlineData(6, "partial", AssemblyAction.Link)]
+		[InlineData(7, "partial", AssemblyAction.Link)]
+		public void TrimActionWithTrimMode(int linkVersion, string trimMode, AssemblyAction expectedDefault)
+		{
+			var task = new MockTask () {
+				LinkVersion = linkVersion,
+				TrimMode = trimMode
+			};
+			using var driver = task.CreateDriver();
+			Assert.Equal (expectedDefault, driver.Context.TrimAction);
+		}
 
 		[Theory]
 		[MemberData (nameof (AssemblyPathsCases))]

--- a/test/ILLink.Tasks.Tests/Mock.cs
+++ b/test/ILLink.Tasks.Tests/Mock.cs
@@ -71,8 +71,13 @@ namespace ILLink.Tasks.Tests
 
 	public class MockBuildEngine : IBuildEngine
 	{
+		public readonly List<BuildWarningEventArgs> Warnings = new List<BuildWarningEventArgs>();
+
 		public void LogErrorEvent (BuildErrorEventArgs e) { }
-		public void LogWarningEvent (BuildWarningEventArgs e) { }
+		public void LogWarningEvent (BuildWarningEventArgs e)
+		{ 
+			Warnings.Add(e);
+		}
 		public void LogMessageEvent (BuildMessageEventArgs e) { }
 		public void LogCustomEvent (CustomBuildEventArgs e) { }
 		public bool BuildProjectFile (string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => false;


### PR DESCRIPTION
The new default for trimming is equivalent to TrimmerDefaultAction=link.
Since we're trying to stay away from the term link and TrimmerDefaultAction
isn't a very clear name, this change repurposes TrimMode.

The two new TrimModes are 'full' and 'partial'. The new default is equivalent
to 'TrimMode=full'. These new modes are also recognized for earlier TFMs, but
the defaults are only changed for net7.0+