### PR TITLE
Update ref package used by analyzer tests to Preview 5

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -25,9 +25,9 @@ namespace ILLink.RoslynAnalyzer.Tests
 		private static readonly string MonoLinkerTestsCases = "Mono.Linker.Tests.Cases";
 
 		public static readonly ReferenceAssemblies Net6PreviewAssemblies =
-			new ReferenceAssemblies (
+		new ReferenceAssemblies (
 				"net7.0",
-				new PackageIdentity ("Microsoft.NETCore.App.Ref", "7.0.0-preview.2.22152.2"),
+				new PackageIdentity ("Microsoft.NETCore.App.Ref", "7.0.0-preview.5.22301.12"),
 				Path.Combine ("ref", "net7.0"))
 			.WithNuGetConfigFilePath (Path.Combine (TestCaseUtils.GetRepoRoot (), "NuGet.config"));
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -20,6 +20,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[SkipKeptItemsValidation]
 	[ExpectedNoWarnings]
+	[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "These tests are not targetted at AOT scenarios")]
 	class AnnotatedMembersAccessedViaReflection
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -20,7 +20,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[SkipKeptItemsValidation]
 	[ExpectedNoWarnings]
-	[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "These tests are not targetted at AOT scenarios")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targetted at AOT scenarios")]
 	class AnnotatedMembersAccessedViaReflection
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
@@ -9,6 +9,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[SkipKeptItemsValidation]
 	[ExpectedNoWarnings]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targetted at AOT scenarios")]
 	public class MakeGenericDataFlow
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/NullableAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/NullableAnnotations.cs
@@ -12,6 +12,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[ExpectedNoWarnings]
 	[KeptPrivateImplementationDetails ("ThrowSwitchExpressionException")]
+	[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targetted at AOT scenarios")]
 	class NullableAnnotations
 	{
 		[Kept]


### PR DESCRIPTION
This brings in some of the AOT annotations in the framework and thus requires suppressions in some tests.
(For example MakeGenericType now produces IL3050 in the analyzer).