### PR TITLE
Small updates to help with linker->aot port

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
+++ b/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using ILLink.Shared;
 using Microsoft.CodeAnalysis;
 
@@ -15,7 +14,7 @@ namespace ILLink.RoslynAnalyzer
 			return new DiagnosticDescriptor (diagnosticId.AsString (),
 				diagnosticString.GetTitleFormat (),
 				diagnosticString.GetMessageFormat (),
-				GetDiagnosticCategory (diagnosticId),
+				diagnosticId.GetDiagnosticCategory (),
 				DiagnosticSeverity.Warning,
 				true);
 		}
@@ -24,7 +23,7 @@ namespace ILLink.RoslynAnalyzer
 			=> new DiagnosticDescriptor (diagnosticId.AsString (),
 				diagnosticString.GetTitle (),
 				diagnosticString.GetMessage (),
-				GetDiagnosticCategory (diagnosticId),
+				diagnosticId.GetDiagnosticCategory (),
 				DiagnosticSeverity.Warning,
 				true);
 
@@ -41,7 +40,7 @@ namespace ILLink.RoslynAnalyzer
 				return new DiagnosticDescriptor (diagnosticId.AsString (),
 					diagnosticString.GetTitleFormat (),
 					diagnosticString.GetMessageFormat (),
-					diagnosticCategory ?? GetDiagnosticCategory (diagnosticId),
+					diagnosticCategory ?? diagnosticId.GetDiagnosticCategory (),
 					diagnosticSeverity,
 					isEnabledByDefault,
 					helpLinkUri);
@@ -50,29 +49,10 @@ namespace ILLink.RoslynAnalyzer
 			return new DiagnosticDescriptor (diagnosticId.AsString (),
 				lrsTitle!,
 				lrsMessage!,
-				diagnosticCategory ?? GetDiagnosticCategory (diagnosticId),
+				diagnosticCategory ?? diagnosticId.GetDiagnosticCategory (),
 				diagnosticSeverity,
 				isEnabledByDefault,
 				helpLinkUri);
-		}
-
-		static string GetDiagnosticCategory (DiagnosticId diagnosticId)
-		{
-			switch ((int) diagnosticId) {
-			case > 2000 and < 3000:
-				return DiagnosticCategory.Trimming;
-
-			case >= 3000 and < 3050:
-				return DiagnosticCategory.SingleFile;
-
-			case >= 3050 and <= 6000:
-				return DiagnosticCategory.AOT;
-
-			default:
-				break;
-			}
-
-			throw new ArgumentException ($"The provided diagnostic id '{diagnosticId}' does not fall into the range of supported warning codes 2001 to 6000 (inclusive).");
 		}
 	}
 }

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -226,23 +226,12 @@ namespace ILLink.Shared
 				_ => MessageSubCategory.None,
 			};
 
-		public static string GetDiagnosticCategory (this DiagnosticId diagnosticId)
-		{
-			switch ((int) diagnosticId) {
-			case > 2000 and < 3000:
-				return DiagnosticCategory.Trimming;
-
-			case >= 3000 and < 3050:
-				return DiagnosticCategory.SingleFile;
-
-			case >= 3050 and <= 6000:
-				return DiagnosticCategory.AOT;
-
-			default:
-				break;
-			}
-
-			throw new ArgumentException ($"The provided diagnostic id '{diagnosticId}' does not fall into the range of supported warning codes 2001 to 6000 (inclusive).");
-		}
+		public static string GetDiagnosticCategory (this DiagnosticId diagnosticId) =>
+			(int) diagnosticId switch {
+				> 2000 and < 3000 => DiagnosticCategory.Trimming,
+				>= 3000 and < 3050 => DiagnosticCategory.SingleFile,
+				>= 3050 and <= 6000 => DiagnosticCategory.AOT,
+				_ => throw new ArgumentException ($"The provided diagnostic id '{diagnosticId}' does not fall into the range of supported warning codes 2001 to 6000 (inclusive).")
+			};
 	}
 }

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -4,6 +4,8 @@
 // This is needed due to NativeAOT which doesn't enable nullable globally yet
 #nullable enable
 
+using System;
+
 namespace ILLink.Shared
 {
 	public enum DiagnosticId
@@ -223,5 +225,24 @@ namespace ILLink.Shared
 				>= 3054 and <= 3055 => MessageSubCategory.AotAnalysis,
 				_ => MessageSubCategory.None,
 			};
+
+		public static string GetDiagnosticCategory (this DiagnosticId diagnosticId)
+		{
+			switch ((int) diagnosticId) {
+			case > 2000 and < 3000:
+				return DiagnosticCategory.Trimming;
+
+			case >= 3000 and < 3050:
+				return DiagnosticCategory.SingleFile;
+
+			case >= 3050 and <= 6000:
+				return DiagnosticCategory.AOT;
+
+			default:
+				break;
+			}
+
+			throw new ArgumentException ($"The provided diagnostic id '{diagnosticId}' does not fall into the range of supported warning codes 2001 to 6000 (inclusive).");
+		}
 	}
 }

--- a/src/ILLink.Shared/TrimAnalysis/DiagnosticContext.cs
+++ b/src/ILLink.Shared/TrimAnalysis/DiagnosticContext.cs
@@ -8,6 +8,17 @@ namespace ILLink.Shared.TrimAnalysis
 {
 	readonly partial struct DiagnosticContext
 	{
+		/// <summary>
+		/// The diagnostic context may be entirely disabled or some kinds of warnings may be suppressed.
+		/// The suppressions are determined based on the <paramref name="id"/>.
+		/// Typically the suppressions will be based on diagnostic category <see cref="DiagnosticCategory"/>:
+		///  - Trimmer warnings (suppressed by RequiresUnreferencedCodeAttribute)
+		///  - AOT warnings (suppressed by RequiresDynamicCodeAttribute)
+		///  - Single-file warnings (suppressed by RequiresAssemblyFilesAttribute)
+		/// Note that not all categories are used/supported by all tools, for example the ILLink only handles trimmer warnings and ignores the rest.
+		/// </summary>
+		/// <param name="id">The diagnostic ID, this will be used to determine the category of diagnostic (trimmer, AOT, single-file)</param>
+		/// <param name="args">The arguments for diagnostic message.</param>
 		public partial void AddDiagnostic (DiagnosticId id, params string[] args);
 	}
 }

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -96,8 +96,6 @@ namespace Mono.Linker
 		/// </summary>
 		TypeDefinition? PopulateCacheForType (TypeDefinition type)
 		{
-			var originalType = type;
-
 			// Look in the declaring type if this is a compiler-generated type (state machine or display class).
 			// State machines can be emitted into display classes, so we may also need to go one more level up.
 			// To avoid depending on implementation details, we go up until we see a non-compiler-generated type.

--- a/src/linker/Linker/MessageOrigin.cs
+++ b/src/linker/Linker/MessageOrigin.cs
@@ -120,7 +120,7 @@ namespace Mono.Linker
 			(FileName, Provider, SourceLine, SourceColumn, ILOffset) == (other.FileName, other.Provider, other.SourceLine, other.SourceColumn, other.ILOffset);
 
 		public override bool Equals (object? obj) => obj is MessageOrigin messageOrigin && Equals (messageOrigin);
-		public override int GetHashCode () => (FileName, Provider, SourceLine, SourceColumn).GetHashCode ();
+		public override int GetHashCode () => (FileName, Provider, SourceLine, SourceColumn, ILOffset).GetHashCode ();
 		public static bool operator == (MessageOrigin lhs, MessageOrigin rhs) => lhs.Equals (rhs);
 		public static bool operator != (MessageOrigin lhs, MessageOrigin rhs) => !lhs.Equals (rhs);
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptAttributeAttribute (typeof (TypeArrayAttribute))]
 		[KeepsPublicConstructor (typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods ("Mono.Linker.Tests.Cases.DataFlow.AttributeConstructorDataflow+ClassWithKeptPublicMethods")]
-		[TypeArray(new Type[] { typeof (AttributeConstructorDataflow) })]
+		[TypeArray (new Type[] { typeof (AttributeConstructorDataflow) })]
 		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -16,8 +16,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		[KeptAttributeAttribute (typeof (KeepsPublicConstructorAttribute))]
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
+		[KeptAttributeAttribute (typeof (TypeArrayAttribute))]
 		[KeepsPublicConstructor (typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods ("Mono.Linker.Tests.Cases.DataFlow.AttributeConstructorDataflow+ClassWithKeptPublicMethods")]
+		[TypeArray(new Type[] { typeof (AttributeConstructorDataflow) })]
 		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()
@@ -107,6 +109,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 				[Kept]
 				public int Field;
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class TypeArrayAttribute : Attribute
+		{
+			[Kept]
+			public TypeArrayAttribute (Type[] types) // This should not trigger data flow analysis of the parameter
+			{
 			}
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptAttributeAttribute (typeof (TypeArrayAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods (Type = "Mono.Linker.Tests.Cases.DataFlow.AttributeFieldDataflow+ClassWithKeptPublicMethods")]
-		[TypeArray (Types = new Type[] { typeof (AttributeFieldDataflow) } )]
+		[TypeArray (Types = new Type[] { typeof (AttributeFieldDataflow) })]
 		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
@@ -16,8 +16,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		[KeptAttributeAttribute (typeof (KeepsPublicConstructorsAttribute))]
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
+		[KeptAttributeAttribute (typeof (TypeArrayAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
-		[KeepsPublicMethods ("Mono.Linker.Tests.Cases.DataFlow.AttributeFieldDataflow+ClassWithKeptPublicMethods")]
+		[KeepsPublicMethods (Type = "Mono.Linker.Tests.Cases.DataFlow.AttributeFieldDataflow+ClassWithKeptPublicMethods")]
+		[TypeArray (Types = new Type[] { typeof (AttributeFieldDataflow) } )]
 		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()
@@ -46,12 +48,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class KeepsPublicMethodsAttribute : Attribute
 		{
 			[Kept]
-			public KeepsPublicMethodsAttribute (
-				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-				string type)
+			public KeepsPublicMethodsAttribute ()
 			{
 			}
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public string Type;
 		}
 
 		[Kept]
@@ -73,6 +77,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[RequiresUnreferencedCode ("--ClassWithKeptPublicMethods--")]
 			public static void KeptMethod () { }
 			static void Method () { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class TypeArrayAttribute : Attribute
+		{
+			[Kept]
+			public TypeArrayAttribute ()
+			{
+			}
+
+			[Kept]
+			public Type[] Types;
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -16,8 +16,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		[KeptAttributeAttribute (typeof (KeepsPublicConstructorsAttribute))]
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
+		[KeptAttributeAttribute (typeof (TypeArrayAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
-		[KeepsPublicMethods ("Mono.Linker.Tests.Cases.DataFlow.AttributePropertyDataflow+ClassWithKeptPublicMethods")]
+		[KeepsPublicMethods (Type = "Mono.Linker.Tests.Cases.DataFlow.AttributePropertyDataflow+ClassWithKeptPublicMethods")]
+		[TypeArray (Types = new Type[] { typeof (AttributePropertyDataflow) })]
 		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
 		public static void Main ()
@@ -47,12 +49,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class KeepsPublicMethodsAttribute : Attribute
 		{
 			[Kept]
-			public KeepsPublicMethodsAttribute (
-				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-				string type)
+			public KeepsPublicMethodsAttribute ()
 			{
 			}
+
+			[field: Kept]
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public string Type { get; [Kept] set; }
 		}
 
 		[Kept]
@@ -74,6 +79,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[RequiresUnreferencedCode ("--ClassWithKeptPublicMethods--")]
 			public static void KeptMethod () { }
 			static void Method () { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class TypeArrayAttribute : Attribute
+		{
+			[Kept]
+			public TypeArrayAttribute ()
+			{
+			}
+
+			[field: Kept]
+			[Kept]
+			public Type[] Types { get; [Kept] set; }
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -126,7 +126,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			static IntPtr GetDangerous () { return IntPtr.Zero; }
 
 			[Kept]
-			[ExpectedWarning("IL2070")]
+			[ExpectedWarning ("IL2070")]
 			static unsafe void LocalStackAllocDeref (Type t)
 			{
 				// Code pattern from CoreLib which caused problems in AOT port

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -126,10 +126,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			static IntPtr GetDangerous () { return IntPtr.Zero; }
 
 			[Kept]
+			[ExpectedWarning("IL2070")]
+			static unsafe void LocalStackAllocDeref (Type t)
+			{
+				// Code pattern from CoreLib which caused problems in AOT port
+				// so making sure we handle this correctly (that is without failing)
+				int buffSize = 256;
+				byte* stackSpace = stackalloc byte[buffSize];
+				byte* buffer = stackSpace;
+
+				byte* toFree = buffer;
+				buffer = null;
+
+				// IL2070 - this is to make sure that DataFlow ran on the method's body
+				t.GetProperties ();
+			}
+
+			[Kept]
 			[ExpectedWarning ("IL2026")]
 			public static void Test ()
 			{
 				IntPtrDeref ();
+				LocalStackAllocDeref (null);
 			}
 		}
 	}


### PR DESCRIPTION
* Move GetDiagnosticCategory into shared code
* Describe the intent around usage of DiagnosticContext in a comment
* Minor fix in MessageOrigin GetHasCode
* Add tests for patterns which NativeAOT had trouble with

Linker changes made for https://github.com/dotnet/runtime/pull/71485