### PR TITLE
Adds a test with two annotated out params for the same method.

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -166,7 +166,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			static Type _publicPropertiesField;
 
 			[Kept]
-			static void TwoOutRefs(
+			static void TwoOutRefs (
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 				out Type publicMethods,
@@ -179,9 +179,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[Kept]
-			[ExpectedWarning ("IL2069")]
-			[ExpectedWarning ("IL2069")]
-			public static void Test()
+			[ExpectedWarning ("IL2069", ProducedBy = ProducedBy.Trimmer)]
+			[ExpectedWarning ("IL2069", ProducedBy = ProducedBy.Trimmer)]
+			public static void Test ()
 			{
 				TwoOutRefs (out _publicMethodsField, out _publicPropertiesField);
 			}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -179,6 +179,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[Kept]
+			// https://github.com/dotnet/linker/issues/2874
 			[ExpectedWarning ("IL2069", ProducedBy = ProducedBy.Trimmer)]
 			[ExpectedWarning ("IL2069", ProducedBy = ProducedBy.Trimmer)]
 			public static void Test ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -34,6 +34,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			PassRefToParameter (null);
 
 			PointerDereference.Test ();
+			MultipleOutRefsToField.Test ();
 		}
 
 		[Kept]
@@ -148,6 +149,41 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				IntPtrDeref ();
 				LocalStackAllocDeref (null);
+			}
+		}
+
+		[Kept]
+		class MultipleOutRefsToField
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			static Type _publicMethodsField;
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+			static Type _publicPropertiesField;
+
+			[Kept]
+			static void TwoOutRefs(
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				out Type publicMethods,
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+				out Type publicProperties)
+			{
+				publicMethods = null;
+				publicProperties = null;
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2069")]
+			[ExpectedWarning ("IL2069")]
+			public static void Test()
+			{
+				TwoOutRefs (out _publicMethodsField, out _publicPropertiesField);
 			}
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
@@ -190,6 +190,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 		}
 
+		#region InheritsFromType
 		class InheritsFromType : Type
 		{
 			public void MethodWithRefAndImplicitThis ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] ref Type type1,
@@ -368,5 +369,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				throw new NotImplementedException ();
 			}
 		}
+		#endregion
 	}
 }


### PR DESCRIPTION
Test for https://github.com/dotnet/linker/issues/2874.