### PR TITLE
Fixed AddSuppresionsBeforeAttributeRemoval test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.cs
@@ -6,20 +6,18 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
-#if !NETCOREAPP
-	[Reference ("System.Core.dll")]
-#endif
-	[SkipKeptItemsValidation]
 	[SetupLinkAttributesFile ("AddSuppressionsBeforeAttributeRemoval.xml")]
-	[LogDoesNotContain ("IL2067: Mono.Linker.Tests.Cases.Warnings.WarningSuppression.AddSuppressionsBeforeAttributeRemoval.Main()")]
+
+	[ExpectedNoWarnings]
 	public class AddSuppressionsBeforeAttributeRemoval
 	{
+		[Kept]
 		public static Type TriggerUnrecognizedPattern ()
 		{
 			return typeof (AddedPseudoAttributeAttribute);
 		}
 
-		[UnconditionalSuppressMessage ("ILLinker", "IL2067")]
+		[UnconditionalSuppressMessage ("ILLinker", "IL2072")]
 		public static void Main ()
 		{
 			Expression.Call (TriggerUnrecognizedPattern (), "", Type.EmptyTypes);

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.xml
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <linker xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../src/ILLink.Shared/ILLink.LinkAttributes.xsd">
-	<assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+	<assembly fullname="*">
 		<type fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
 			<attribute internal="RemoveAttributeInstances" />
 		</type>


### PR DESCRIPTION
The test generated warnings which were not checked. The XML file was pointing to the wrong assembly and the linker raised IL2072 warning. Instead, the test verified the suppression of warning IL2067, which was not raised by the linker in the first place.

@vitek-karas 