### PR TITLE
Preserve all interfaces in library mode

### DIFF
--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -153,6 +153,11 @@ namespace Mono.Linker.Steps
 				//
 				preserve = preserve_anything;
 				Annotations.SetMembersPreserve (type, preserve);
+				// Keep all interfaces and interface members in library mode
+				if (type.IsInterface) {
+					Annotations.Mark (type, new DependencyInfo (DependencyKind.RootAssembly, type.Module.Assembly), new MessageOrigin (type.Module.Assembly));
+					Annotations.SetPreserve (type, TypePreserve.All);
+				}
 				break;
 			default:
 				Annotations.Mark (type, new DependencyInfo (DependencyKind.RootAssembly, type.Module.Assembly), new MessageOrigin (type.Module.Assembly));

--- a/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
@@ -214,11 +214,13 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			[Kept]
 			public void InternalInterfaceMethod () { }
 
+			[Kept]
 			void IInternalInterface.ExplicitImplementationInternalInterfaceMethod () { }
 
 			[Kept]
 			public static void InternalStaticInterfaceMethod () { }
 
+			[Kept]
 			static void IInternalStaticInterface.ExplicitImplementationInternalStaticInterfaceMethod () { }
 
 			[Kept]
@@ -253,6 +255,7 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			[Kept]
 			public void InternalInterfaceMethod () { }
 
+			[Kept]
 			void IInternalInterface.ExplicitImplementationInternalInterfaceMethod () { }
 
 			[Kept]
@@ -297,11 +300,13 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			[Kept]
 			public void InternalInterfaceMethod () { }
 
+			[Kept]
 			void IInternalInterface.ExplicitImplementationInternalInterfaceMethod () { }
 
 			[Kept]
 			public static void InternalStaticInterfaceMethod () { }
 
+			[Kept]
 			static void IInternalStaticInterface.ExplicitImplementationInternalStaticInterfaceMethod () { }
 
 			[Kept]
@@ -332,6 +337,7 @@ namespace Mono.Linker.Tests.Cases.Libraries
 		{
 			internal UninstantiatedPublicClassWithPrivateInterface () { }
 
+			[Kept]
 			void IPrivateInterface.PrivateInterfaceMethod () { }
 		}
 
@@ -358,8 +364,10 @@ namespace Mono.Linker.Tests.Cases.Libraries
 		[Kept]
 		internal interface IInternalInterface
 		{
+			[Kept]
 			void InternalInterfaceMethod ();
 
+			[Kept]
 			void ExplicitImplementationInternalInterfaceMethod ();
 		}
 
@@ -369,12 +377,14 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			[Kept] // https://github.com/dotnet/linker/issues/2733
 			static abstract void InternalStaticInterfaceMethod ();
 
+			[Kept]
 			static abstract void ExplicitImplementationInternalStaticInterfaceMethod ();
 		}
 
 		[Kept]
 		private interface IPrivateInterface
 		{
+			[Kept]
 			void PrivateInterfaceMethod ();
 		}
 	}


### PR DESCRIPTION
Annotate all interfaces as fully preserved when an assembly in in library mode. This will keep all interfaces and all interface methods in library mode regardless of visibility or use.

Fixes https://github.com/dotnet/linker/issues/2881