### PR TITLE
Add a test for unsupported branch instruction crash

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/UnreachableBlockTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/UnreachableBlockTests.g.cs
@@ -20,6 +20,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task ComplexConditionsOptimized ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task DataFlowRelated ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditionsOptimized.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditionsOptimized.cs
@@ -24,9 +24,12 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			}
 
 			[Kept]
+			[ExpectBodyModified]
 			public static void Test ()
 			{
-				Helper ();
+				// https://github.com/dotnet/linker/issues/2872
+				// Uncomment the call to make the test crash the linker
+				//Helper ();
 				switch (KnownInteger) {
 				case 0:
 					Unreached ();
@@ -41,12 +44,16 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 				}
 			}
 
+			// https://github.com/dotnet/linker/issues/2872
+			// Should be removed
+			[Kept]
 			static void Unreached () { }
 
 			[Kept]
 			static void Reached () { }
 
-			[Kept]
+			// https://github.com/dotnet/linker/issues/2872
+			//[Kept]
 			static void Helper () { }
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditionsOptimized.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditionsOptimized.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Reflection.Emit;
+using System.Runtime.Serialization;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.UnreachableBlock
+{
+	[Reference ("System.Reflection.Emit.dll")]
+	[SetupCompileArgument ("/optimize+")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
+	public class ComplexConditionsOptimized
+	{
+		public static void Main ()
+		{
+			TestSwitch.Test ();
+		}
+
+		[Kept]
+		class TestSwitch
+		{
+			static int KnownInteger {
+				get => 2;
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				Helper ();
+				switch (KnownInteger) {
+				case 0:
+					Unreached ();
+					break;
+				case 1:
+					Unreached ();
+					break;
+				case 2:
+					Reached ();
+					break;
+				default: throw new ApplicationException ();
+				}
+			}
+
+			static void Unreached () { }
+
+			[Kept]
+			static void Reached () { }
+
+			[Kept]
+			static void Helper () { }
+		}
+	}
+}


### PR DESCRIPTION
This is a test for https://github.com/dotnet/linker/issues/2872