### PR TITLE
Fix a bug with null value passed to annotated parameter on attribute

### DIFF
--- a/src/linker/Linker.Dataflow/AttributeDataFlow.cs
+++ b/src/linker/Linker.Dataflow/AttributeDataFlow.cs
@@ -50,6 +50,9 @@ namespace Mono.Linker.Dataflow
 		MultiValue GetValueForCustomAttributeArgument (CustomAttributeArgument argument)
 		{
 			if (argument.Type.Name == "Type") {
+				if (argument.Value is null)
+					return NullValue.Instance;
+
 				TypeDefinition? referencedType = ((TypeReference) argument.Value).ResolveToTypeDefinition (_context);
 				return referencedType == null
 					? UnknownValue.Instance
@@ -57,7 +60,7 @@ namespace Mono.Linker.Dataflow
 			}
 
 			if (argument.Type.MetadataType == MetadataType.String)
-				return new KnownStringValue ((string) argument.Value);
+				return argument.Value is null ? NullValue.Instance : new KnownStringValue ((string) argument.Value);
 
 			// We shouldn't have gotten a non-null annotation for this from GetParameterAnnotation
 			throw new InvalidOperationException ();

--- a/src/linker/Linker.Dataflow/CompilerGeneratedCallGraph.cs
+++ b/src/linker/Linker.Dataflow/CompilerGeneratedCallGraph.cs
@@ -9,15 +9,15 @@ namespace Mono.Linker.Dataflow
 {
 	sealed class CompilerGeneratedCallGraph
 	{
-		readonly Dictionary<IMemberDefinition, HashSet<IMemberDefinition>> callGraph;
+		readonly Dictionary<IMemberDefinition, HashSet<IMemberDefinition>> _callGraph;
 
-		public CompilerGeneratedCallGraph () => callGraph = new Dictionary<IMemberDefinition, HashSet<IMemberDefinition>> ();
+		public CompilerGeneratedCallGraph () => _callGraph = new Dictionary<IMemberDefinition, HashSet<IMemberDefinition>> ();
 
 		void TrackCallInternal (IMemberDefinition fromMember, IMemberDefinition toMember)
 		{
-			if (!callGraph.TryGetValue (fromMember, out HashSet<IMemberDefinition>? toMembers)) {
+			if (!_callGraph.TryGetValue (fromMember, out HashSet<IMemberDefinition>? toMembers)) {
 				toMembers = new HashSet<IMemberDefinition> ();
-				callGraph.Add (fromMember, toMembers);
+				_callGraph.Add (fromMember, toMembers);
 			}
 			toMembers.Add (toMember);
 		}
@@ -48,7 +48,7 @@ namespace Mono.Linker.Dataflow
 			visited.Add (start);
 			queue.Enqueue (start);
 			while (queue.TryDequeue (out IMemberDefinition? method)) {
-				if (!callGraph.TryGetValue (method, out HashSet<IMemberDefinition>? callees))
+				if (!_callGraph.TryGetValue (method, out HashSet<IMemberDefinition>? callees))
 					continue;
 
 				foreach (var callee in callees) {

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -16,9 +16,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		[KeptAttributeAttribute (typeof (KeepsPublicConstructorAttribute))]
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
+		[KeptAttributeAttribute (typeof (KeepsPublicFieldsAttribute))]
 		[KeptAttributeAttribute (typeof (TypeArrayAttribute))]
 		[KeepsPublicConstructor (typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods ("Mono.Linker.Tests.Cases.DataFlow.AttributeConstructorDataflow+ClassWithKeptPublicMethods")]
+		[KeepsPublicFields (null, null)]
 		[TypeArray (new Type[] { typeof (AttributeConstructorDataflow) })]
 		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
@@ -51,6 +53,23 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 				string type)
+			{
+			}
+		}
+
+		// Used to test null parameter values
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class KeepsPublicFieldsAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicFieldsAttribute (
+				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+				Type type,
+				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+				string typeName)
 			{
 			}
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
@@ -16,9 +16,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		[KeptAttributeAttribute (typeof (KeepsPublicConstructorsAttribute))]
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
+		[KeptAttributeAttribute (typeof (KeepsPublicFieldsAttribute))]
 		[KeptAttributeAttribute (typeof (TypeArrayAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods (Type = "Mono.Linker.Tests.Cases.DataFlow.AttributeFieldDataflow+ClassWithKeptPublicMethods")]
+		[KeepsPublicFields (Type = null, TypeName = null)]
 		[TypeArray (Types = new Type[] { typeof (AttributeFieldDataflow) })]
 		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
@@ -56,6 +58,27 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public string Type;
+		}
+
+		// Use to test null values
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class KeepsPublicFieldsAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicFieldsAttribute ()
+			{
+			}
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			public Type Type;
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			public string TypeName;
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -16,9 +16,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		[KeptAttributeAttribute (typeof (KeepsPublicConstructorsAttribute))]
 		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
+		[KeptAttributeAttribute (typeof (KeepsPublicFieldsAttribute))]
 		[KeptAttributeAttribute (typeof (TypeArrayAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
 		[KeepsPublicMethods (Type = "Mono.Linker.Tests.Cases.DataFlow.AttributePropertyDataflow+ClassWithKeptPublicMethods")]
+		[KeepsPublicFields (Type = null, TypeName = null)]
 		[TypeArray (Types = new Type[] { typeof (AttributePropertyDataflow) })]
 		// Trimmer only for now - https://github.com/dotnet/linker/issues/2273
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = ProducedBy.Trimmer)]
@@ -58,6 +60,29 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public string Type { get; [Kept] set; }
+		}
+
+		// Used to test null values
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class KeepsPublicFieldsAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicFieldsAttribute ()
+			{
+			}
+
+			[field: Kept]
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			public Type Type { get; [Kept] set; }
+
+			[field: Kept]
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			public string TypeName { get; [Kept] set; }
 		}
 
 		[Kept]


### PR DESCRIPTION
This also makes small tweaks to help with linker->AOT sync.