### PR TITLE
Fix syntax node scope and nullable warnings

### DIFF
--- a/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
@@ -32,7 +32,6 @@ namespace ILLink.CodeFix
 		protected async Task BaseRegisterCodeFixesAsync (CodeFixContext context)
 		{
 			var document = context.Document;
-			var root = await document.GetSyntaxRootAsync (context.CancellationToken).ConfigureAwait (false);
 			if (await document.GetSyntaxRootAsync (context.CancellationToken).ConfigureAwait (false) is not { } root)
 				return;
 			var diagnostic = context.Diagnostics.First ();

--- a/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
@@ -40,14 +40,14 @@ namespace ILLink.CodeFix
 			if (FindAttributableParent (targetNode, AttributableParentTargets) is not SyntaxNode attributableNode)
 				return;
 
-			if (await document.GetSemanticModelAsync (context.CancellationToken).ConfigureAwait (false) is not {} model)
+			if (await document.GetSemanticModelAsync (context.CancellationToken).ConfigureAwait (false) is not { } model)
 				return;
-			if (model.GetSymbolInfo (targetNode).Symbol is not {} targetSymbol)
+			if (model.GetSymbolInfo (targetNode).Symbol is not { } targetSymbol)
 				return;
-			if (model.GetDeclaredSymbol (attributableNode) is not {} attributableSymbol)
+			if (model.Compilation.GetTypeByMetadataName (FullyQualifiedAttributeName) is not { } attributeSymbol)
 				return;
-			if (model.Compilation.GetTypeByMetadataName (FullyQualifiedAttributeName) is not {} attributeSymbol)
-				return;
+			// N.B. May be null for FieldDeclaration, since field declarations can declare multiple variables
+			var attributableSymbol = model.GetDeclaredSymbol (attributableNode);
 
 			var attributeArguments = GetAttributeArguments (attributableSymbol, targetSymbol, SyntaxGenerator.GetGenerator (document), diagnostic);
 			var codeFixTitle = CodeFixTitle.ToString ();
@@ -110,7 +110,7 @@ namespace ILLink.CodeFix
 		}
 
 		protected abstract SyntaxNode[] GetAttributeArguments (
-			ISymbol attributableSymbol,
+			ISymbol? attributableSymbol,
 			ISymbol targetSymbol,
 			SyntaxGenerator syntaxGenerator,
 			Diagnostic diagnostic);

--- a/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace ILLink.CodeFix
 		{
 			var document = context.Document;
 			var root = await document.GetSyntaxRootAsync (context.CancellationToken).ConfigureAwait (false);
-			if (root is null)
+			if (await document.GetSyntaxRootAsync (context.CancellationToken).ConfigureAwait (false) is not { } root)
 				return;
 			var diagnostic = context.Diagnostics.First ();
 			SyntaxNode targetNode = root.FindNode (diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);

--- a/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/BaseAttributeCodeFixProvider.cs
@@ -33,8 +33,10 @@ namespace ILLink.CodeFix
 		{
 			var document = context.Document;
 			var root = await document.GetSyntaxRootAsync (context.CancellationToken).ConfigureAwait (false);
+			if (root is null)
+				return;
 			var diagnostic = context.Diagnostics.First ();
-			SyntaxNode targetNode = root!.FindNode (diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+			SyntaxNode targetNode = root.FindNode (diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
 			if (FindAttributableParent (targetNode, AttributableParentTargets) is not SyntaxNode attributableNode)
 				return;
 
@@ -42,9 +44,11 @@ namespace ILLink.CodeFix
 				return;
 			if (model.GetSymbolInfo (targetNode).Symbol is not {} targetSymbol)
 				return;
+			if (model.GetDeclaredSymbol (attributableNode) is not {} attributableSymbol)
+				return;
+			if (model.Compilation.GetTypeByMetadataName (FullyQualifiedAttributeName) is not {} attributeSymbol)
+				return;
 
-			var attributableSymbol = model.GetDeclaredSymbol (attributableNode)!;
-			var attributeSymbol = model.Compilation.GetTypeByMetadataName (FullyQualifiedAttributeName)!;
 			var attributeArguments = GetAttributeArguments (attributableSymbol, targetSymbol, SyntaxGenerator.GetGenerator (document), diagnostic);
 			var codeFixTitle = CodeFixTitle.ToString ();
 

--- a/src/ILLink.CodeFix/RequiresAssemblyFilesCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresAssemblyFilesCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace ILLink.CodeFix
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 
-		protected override SyntaxNode[] GetAttributeArguments (ISymbol attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
+		protected override SyntaxNode[] GetAttributeArguments (ISymbol? attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
 		{
 			var symbolDisplayName = targetSymbol.GetDisplayName ();
 			if (string.IsNullOrEmpty (symbolDisplayName) || HasPublicAccessibility (attributableSymbol))

--- a/src/ILLink.CodeFix/RequiresDynamicCodeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresDynamicCodeCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace ILLink.CodeFix
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 
-		protected override SyntaxNode[] GetAttributeArguments (ISymbol attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
+		protected override SyntaxNode[] GetAttributeArguments (ISymbol? attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
 		{
 			var symbolDisplayName = targetSymbol.GetDisplayName ();
 			if (string.IsNullOrEmpty (symbolDisplayName) || HasPublicAccessibility (attributableSymbol))

--- a/src/ILLink.CodeFix/RequiresUnreferencedCodeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresUnreferencedCodeCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace ILLink.CodeFix
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 
-		protected override SyntaxNode[] GetAttributeArguments (ISymbol attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
+		protected override SyntaxNode[] GetAttributeArguments (ISymbol? attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
 		{
 			var symbolDisplayName = targetSymbol.GetDisplayName ();
 			if (string.IsNullOrEmpty (symbolDisplayName) || HasPublicAccessibility (attributableSymbol))

--- a/src/ILLink.CodeFix/UnconditionalSuppressMessageCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/UnconditionalSuppressMessageCodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace ILLink.CodeFix
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 
-		protected override SyntaxNode[] GetAttributeArguments (ISymbol attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
+		protected override SyntaxNode[] GetAttributeArguments (ISymbol? attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
 		{
 			// Category of the attribute
 			var ruleCategory = syntaxGenerator.AttributeArgument (

--- a/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis;

--- a/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis;

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -83,7 +83,7 @@ public class C
     public void M3() => M2(M1());
 }
 """;
-			await VerifyRequiresUnreferencedCodeCodeFix(test, fixtest, new[] {
+			await VerifyRequiresUnreferencedCodeCodeFix (test, fixtest, new[] {
 				// /0/Test0.cs(9,25): warning IL2026: Using member 'C.M1()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. message.
 				VerifyCS.Diagnostic(DiagnosticId.RequiresUnreferencedCode).WithSpan(9, 25, 9, 29).WithArguments("C.M1()", " message.", ""),
 			}, new[] {

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -54,6 +54,43 @@ build_property.{MSBuildPropertyOptionNames.EnableTrimAnalyzer} = true")));
 		}
 
 
+		[Fact]
+		public async Task WarningInArgument ()
+		{
+			var test = """
+using System.Diagnostics.CodeAnalysis;
+public class C
+{
+	[RequiresUnreferencedCode("message")]
+	public int M1() => 0;
+	public void M2(int x)
+	{
+	}
+	public void M3() => M2(M1());
+}
+""";
+			var fixtest = """
+using System.Diagnostics.CodeAnalysis;
+public class C
+{
+	[RequiresUnreferencedCode("message")]
+	public int M1() => 0;
+	public void M2(int x)
+	{
+	}
+
+    [RequiresUnreferencedCode()]
+    public void M3() => M2(M1());
+}
+""";
+			await VerifyRequiresUnreferencedCodeCodeFix(test, fixtest, new[] {
+				// /0/Test0.cs(9,25): warning IL2026: Using member 'C.M1()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. message.
+				VerifyCS.Diagnostic(DiagnosticId.RequiresUnreferencedCode).WithSpan(9, 25, 9, 29).WithArguments("C.M1()", " message.", ""),
+			}, new[] {
+				// /0/Test0.cs(10,6): error CS7036: There is no argument given that corresponds to the required formal parameter 'message' of 'RequiresUnreferencedCodeAttribute.RequiresUnreferencedCodeAttribute(string)'
+				DiagnosticResult.CompilerError("CS7036").WithSpan(10, 6, 10, 32).WithArguments("message", "System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute.RequiresUnreferencedCodeAttribute(string)"),
+			});
+		}
 
 		[Fact]
 		public async Task SimpleDiagnosticFix ()


### PR DESCRIPTION
The syntax node scope should be the innermost node, otherwise
GetSymbolInfo will often return null. As an example, GetSymbolInfo will
return null for an ArgumentSyntax node, but the underlying expression
will likely resolve into a symbol.

Also adds proper null checks in case any of the providers return null.