### PR TITLE
Add a test for stack overflow when marking lambda which indirectly marks itself

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeAccessedViaReflection.cs
@@ -26,6 +26,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			AsyncIteratorStateMachines.Test ();
 			Lambdas.Test ();
 			LocalFunctions.Test ();
+
+			LambdaWhichMarksItself.Test ();
 		}
 
 		class BaseTypeWithIteratorStateMachines
@@ -393,6 +395,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (Lambdas).RequiresAll ();
 
 				test.GetType ().RequiresAll ();
+			}
+		}
+
+		class LambdaWhichMarksItself
+		{
+			static void RequiresAllOnT<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T> () { }
+
+			public static void Test ()
+			{
+				var a = () => {
+					// https://github.com/dotnet/linker/issues/2903
+					//RequiresAllOnT<LambdaWhichMarksItself> ();
+				};
+
+				a ();
 			}
 		}
 


### PR DESCRIPTION
The lambda calls a generic method which has annotation on the generic argument to keep `All`, and the lambda passes its own parent type as the argument. So the annotation will end up marking the lambda itself.

This is a test for https://github.com/dotnet/linker/issues/2903

The test is disabled by commenting out the code which causes the bug.