### PR TITLE
Synchronize file type between analyzer and linker

### DIFF
--- a/src/analyzer/LinkerAnalyzerCore/DependencyGraph.cs
+++ b/src/analyzer/LinkerAnalyzerCore/DependencyGraph.cs
@@ -46,9 +46,8 @@ namespace LinkerAnalyzer.Core
 			Console.WriteLine ("Loading dependency tree from: {0}", filename);
 
 			try {
-				using (var fileStream = File.OpenRead (filename))
-				using (var zipStream = new GZipStream (fileStream, CompressionMode.Decompress)) {
-					Load (zipStream);
+				using (var fileStream = File.OpenRead (filename)) {
+					Load (fileStream);
 				}
 			} catch (Exception) {
 				Console.WriteLine ("Unable to open and read the dependencies.");
@@ -56,13 +55,13 @@ namespace LinkerAnalyzer.Core
 			}
 		}
 
-		void Load (GZipStream zipStream)
+		void Load (FileStream fileStream)
 		{
-			using (XmlReader reader = XmlReader.Create (zipStream)) {
+			using (XmlReader reader = XmlReader.Create (fileStream)) {
 				while (reader.Read ()) {
 					switch (reader.NodeType) {
 					case XmlNodeType.Element:
-						//Console.WriteLine (reader.Name);
+						// Console.WriteLine (reader.Name);
 						if (reader.Name == "edge" && reader.IsStartElement ()) {
 							string b = reader.GetAttribute ("b");
 							string e = reader.GetAttribute ("e");

--- a/src/analyzer/LinkerAnalyzerCore/DependencyGraph.cs
+++ b/src/analyzer/LinkerAnalyzerCore/DependencyGraph.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Xml;
 
 namespace LinkerAnalyzer.Core

--- a/src/analyzer/README.md
+++ b/src/analyzer/README.md
@@ -27,7 +27,7 @@ For .NET SDK style projects, you will want to use `_TrimmerDumpDependencies` ins
 
 ```msbuild /p:_TrimmerDumpDependencies=true /p:Configuration=Release YourAppProject.csproj```
 
-After a successful build, there will be a linker-dependencies.xml.gz
+After a successful build, there will be a linker-dependencies.xml
 file created, containing the information for the analyzer.
 
 ## How to use the analyzer
@@ -35,12 +35,12 @@ file created, containing the information for the analyzer.
 Let say you would like to know, why a type, Android.App.Activity for
 example, was marked by the linker. So run the analyzer like this:
 
-```illinkanalyzer -t Android.App.Activity linker-dependencies.xml.gz```
+```illinkanalyzer -t Android.App.Activity linker-dependencies.xml```
 
 Output:
 
 ```
-Loading dependency tree from: linker-dependencies.xml.gz
+Loading dependency tree from: linker-dependencies.xml
 
 --- Type dependencies: 'Android.App.Activity' -----------------------
 
@@ -69,12 +69,12 @@ linker step.
 Now we might want to see the `MainActivity` dependencies. That could
 be done by the following analyzer run:
 
-```illinkanalyzer -r TypeDef:XA.App.MainActivity linker-dependencies.xml.gz```
+```illinkanalyzer -r TypeDef:XA.App.MainActivity linker-dependencies.xml```
 
 Output:
 
 ```
-Loading dependency tree from: linker-dependencies.xml.gz
+Loading dependency tree from: linker-dependencies.xml
 
 --- Raw dependencies: 'TypeDef:XA.App.MainActivity' -----------------
 
@@ -104,7 +104,7 @@ just dependency on the Mark step.
 ```
 Usage:
 
-	illinkanalyzer [Options] <linker-dependency-file.xml.gz>
+	illinkanalyzer [Options] <linker-dependency-file.xml>
 
 Options:
 


### PR DESCRIPTION
The linker dumps unzipped files when dependencies are generated. This request ensures that users of the analyzer can dump dependencies and then immediately use the analyzer without having to unzip their files first. I also updated the README to reflect the changes.