### PR TITLE
Test that basic ref field operations don't crash linker

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,6 @@
     <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup>
-    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <!-- ilasm -->
     <MicrosoftNETSdkILPackageVersion>7.0.0-rc.1.22374.4</MicrosoftNETSdkILPackageVersion>
     <!-- see https://github.com/dotnet/runtime/issues/1338 -->
@@ -21,7 +20,7 @@
     <MicrosoftDotNetApiCompatVersion>7.0.0-beta.22372.1</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21271.1</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
-    <MicrosoftCodeAnalysisVersion>4.3.0-2.final</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>4.4.0-2.22379.3</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.*</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <!-- This controls the version of the cecil package, or the version of cecil in the project graph

--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/BasicTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/BasicTests.g.cs
@@ -40,6 +40,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task LinkerHandlesRefFields ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task MultiLevelNestedClassesAllRemovedWhenNonUsed ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/Mono.Linker.Tests.Cases/Basic/LinkerHandlesRefFields.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/LinkerHandlesRefFields.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+	[ExpectedNoWarnings]
+	[SkipKeptItemsValidation]
+	class LinkerHandlesRefFields
+	{
+		ref struct RS
+		{
+			public ref int i;
+			public ref double d;
+			public RS2 rs2;
+			public ref string str;
+			public ref object obj;
+			public ref Type t;
+			public void MoveThis()
+			{
+				this = new RS ();
+			}
+		}
+
+		ref struct RS2
+		{
+			public ref int i;
+			public ref double d;
+			public ref string str;
+			public ref object obj;
+			public ref Type t;
+			public void MoveThis()
+			{
+				this = new RS2 ();
+			}
+		}
+
+		delegate RS2 RsParamRs2Return (RS rs);
+		delegate ref RS2 RefRSParamRefRs2Return (ref RS rs);
+		delegate ref int RsParamRefIntReturn (RS rs);
+
+		public static void Main(string[] args)
+		{
+			scoped RS rs = new RS ();
+			scoped RS2 rs2 = new RS2 ();
+
+			// Assign by value
+			rs.i = rs2.i;
+			rs2.d = rs2.d;
+			rs.obj = rs2.obj;
+			rs2.t = rs.t;
+
+			// Assign by ref
+			rs.i = ref rs2.i;
+			rs2.d = ref rs2.d;
+			rs.obj = ref rs2.obj;
+			rs2.t = ref rs.t;
+
+			// Assign in different basic blocks
+			if (args[0] == "") {
+				rs.i = ref rs2.i;
+				rs.d = rs2.d;
+				rs.obj = ref rs2.obj;
+				rs.t = rs2.t;
+			} else {
+				rs2.i = rs.i;
+				rs2.d = ref rs.d;
+				rs2.obj = rs.obj;
+				rs2.t = ref rs.t;
+			}
+
+			// Cast fields
+			rs.t = (Type) rs.obj;
+			rs.i = (int) rs.d;
+			rs2.i = (int) rs.d;
+
+			// In Lambdas
+			RsParamRs2Return f = (RS rs) => rs.rs2;
+			rs.rs2 = f (rs);
+			RefRSParamRefRs2Return h = (ref RS rs) => ref rs.rs2;
+			rs.rs2 = h (ref rs);
+			RsParamRefIntReturn g = (RS rs) => ref f (rs).i;
+			rs.i = g (rs);
+
+			// As parameters and returns for local functions
+			RS LocalMethod(RS2 rs)
+			{
+				rs.d = 0.2;
+				return new RS ();
+			}
+			rs = LocalMethod (rs.rs2);
+
+			ref RS LocalMethodRef(ref RS rs)
+			{
+				return ref rs;
+			}
+			ref RS refRs = ref LocalMethodRef (ref rs);
+			refRs = LocalMethodRef (ref rs);
+
+			ref int ReturnRefInt (ref int i)
+			{
+				return ref i;
+			}
+			rs.i = ReturnRefInt (ref rs2.i);
+
+			// Call methods with this
+			rs.MoveThis ();
+			rs2.MoveThis ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Basic/LinkerHandlesRefFields.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/LinkerHandlesRefFields.cs
@@ -24,7 +24,7 @@ namespace Mono.Linker.Tests.Cases.Basic
 			public ref string str;
 			public ref object obj;
 			public ref Type t;
-			public void MoveThis()
+			public void MoveThis ()
 			{
 				this = new RS ();
 			}
@@ -37,7 +37,7 @@ namespace Mono.Linker.Tests.Cases.Basic
 			public ref string str;
 			public ref object obj;
 			public ref Type t;
-			public void MoveThis()
+			public void MoveThis ()
 			{
 				this = new RS2 ();
 			}
@@ -47,7 +47,7 @@ namespace Mono.Linker.Tests.Cases.Basic
 		delegate ref RS2 RefRSParamRefRs2Return (ref RS rs);
 		delegate ref int RsParamRefIntReturn (RS rs);
 
-		public static void Main(string[] args)
+		public static void Main (string[] args)
 		{
 			scoped RS rs = new RS ();
 			scoped RS2 rs2 = new RS2 ();
@@ -91,14 +91,14 @@ namespace Mono.Linker.Tests.Cases.Basic
 			rs.i = g (rs);
 
 			// As parameters and returns for local functions
-			RS LocalMethod(RS2 rs)
+			RS LocalMethod (RS2 rs)
 			{
 				rs.d = 0.2;
 				return new RS ();
 			}
 			rs = LocalMethod (rs.rs2);
 
-			ref RS LocalMethodRef(ref RS rs)
+			ref RS LocalMethodRef (ref RS rs)
 			{
 				return ref rs;
 			}

--- a/test/Mono.Linker.Tests.Cases/Basic/LinkerHandlesRefFields.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/LinkerHandlesRefFields.cs
@@ -13,6 +13,9 @@ using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.Basic
 {
+	/// <summary>
+	/// This test is only to ensure that the linker does not crash when programs use ref fields (new to dotnet 7). This test does not validate any expected behaviors around ref fields.
+	/// </summary>
 	[ExpectedNoWarnings]
 	[SkipKeptItemsValidation]
 	class LinkerHandlesRefFields

--- a/test/Mono.Linker.Tests.Cases/Basic/UnusedFieldsOfStructsAreKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/UnusedFieldsOfStructsAreKept.cs
@@ -1,4 +1,6 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System.Runtime.CompilerServices;
+using System;
 
 namespace Mono.Linker.Tests.Cases.Basic
 {
@@ -8,6 +10,7 @@ namespace Mono.Linker.Tests.Cases.Basic
 		{
 			A a = new A ();
 			PreventCompilerOptimization (a);
+			R r = new R ();
 		}
 
 		[Kept]
@@ -26,6 +29,21 @@ namespace Mono.Linker.Tests.Cases.Basic
 			public void UnusedMethod ()
 			{
 			}
+		}
+
+		[KeptAttributeAttribute(typeof(IsByRefLikeAttribute))]
+		[KeptAttributeAttribute(typeof(CompilerFeatureRequiredAttribute))]
+		[KeptAttributeAttribute(typeof(ObsoleteAttribute))]
+		ref struct R
+		{
+			[Kept]
+			public ref int UnusedRefField;
+
+			[Kept]
+			int UnusedField;
+
+			[Kept]
+			int UsedField;
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Basic/UnusedFieldsOfStructsAreKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/UnusedFieldsOfStructsAreKept.cs
@@ -1,6 +1,6 @@
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using System.Runtime.CompilerServices;
 using System;
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Basic
 {
@@ -31,9 +31,9 @@ namespace Mono.Linker.Tests.Cases.Basic
 			}
 		}
 
-		[KeptAttributeAttribute(typeof(IsByRefLikeAttribute))]
-		[KeptAttributeAttribute(typeof(CompilerFeatureRequiredAttribute))]
-		[KeptAttributeAttribute(typeof(ObsoleteAttribute))]
+		[KeptAttributeAttribute (typeof (IsByRefLikeAttribute))]
+		[KeptAttributeAttribute (typeof (CompilerFeatureRequiredAttribute))]
+		[KeptAttributeAttribute (typeof (ObsoleteAttribute))]
 		ref struct R
 		{
 			[Kept]


### PR DESCRIPTION
Adds some tests with basic usage of ref fields to ensure the linker doesn't crash or produce incorrect warnings. Ref structs can't be used as type parameters, so some things like IEnumerable<RS> can't be tested.

Please let me know if I'm missing other cases where this could cause some issues. 