### PR TITLE
Use warning levels

### DIFF
--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -566,7 +566,7 @@ namespace Mono.Linker
 		/// <returns>New MessageContainer of 'Warning' category</returns>
 		public void LogWarning (string text, int code, MessageOrigin origin, string subcategory = MessageSubCategory.None)
 		{
-			WarnVersion version = GetWarningVersion ();
+			WarnVersion version = GetWarningVersion (code);
 			MessageContainer warning = MessageContainer.CreateWarningMessage (this, text, code, origin, version, subcategory);
 			_cachedWarningMessageContainers.Add (warning);
 		}
@@ -582,7 +582,7 @@ namespace Mono.Linker
 		/// <returns>New MessageContainer of 'Warning' category</returns>
 		public void LogWarning (MessageOrigin origin, DiagnosticId id, params string[] args)
 		{
-			WarnVersion version = GetWarningVersion ();
+			WarnVersion version = GetWarningVersion ((int)id);
 			MessageContainer warning = MessageContainer.CreateWarningMessage (this, origin, id, version, args);
 			_cachedWarningMessageContainers.Add (warning);
 		}
@@ -730,9 +730,11 @@ namespace Mono.Linker
 			return SingleWarn.TryGetValue (assemblyName, out value) && value;
 		}
 
-		static WarnVersion GetWarningVersion ()
+		static WarnVersion GetWarningVersion (int code)
 		{
 			// This should return an increasing WarnVersion for new warning waves.
+			if (code > 2116)
+				return WarnVersion.ILLink7;
 			return WarnVersion.ILLink5;
 		}
 

--- a/src/linker/Linker/WarnVersion.cs
+++ b/src/linker/Linker/WarnVersion.cs
@@ -7,6 +7,7 @@ namespace Mono.Linker
 	{
 		ILLink0 = 0,
 		ILLink5 = 5,
+		ILLink7 = 7,
 		Latest = 9999,
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Warnings/CanSetWarningVersion7.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/CanSetWarningVersion7.cs
@@ -8,14 +8,14 @@ namespace Mono.Linker.Tests.Cases.Warnings
 {
 	[SkipKeptItemsValidation]
 	[SetupLinkerArgument ("--verbose")]
-	[SetupLinkerArgument ("--warn", "5")]
+	[SetupLinkerArgument ("--warn", "7")]
 	[ExpectedNoWarnings]
-	public class CanSetWarningVersion5
+	public class CanSetWarningVersion7
 	{
 		public static void Main ()
 		{
-			GetMethod ();
 			AccessCompilerGeneratedCode.Test ();
+			GetMethod ();
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
@@ -39,7 +39,8 @@ namespace Mono.Linker.Tests.Cases.Warnings
 				lambda ();
 			}
 
-			// This warns with --warn 7, but not --warn 5.
+			[ExpectedWarning ("IL2118", "<" + nameof (LambdaWithDataflow) + ">",
+				ProducedBy = ProducedBy.Trimmer)]
 			public static void Test ()
 			{
 				typeof (AccessCompilerGeneratedCode).RequiresAll ();


### PR DESCRIPTION
This moves warning codes added since .NET 6 into a new warning wave for 7. It removes the compiler-generated code warnings that are appearing when trimming a 6.0 app with the 7.0 linker - but doesn't fix the IL2070 and IL2067 warnings (existing warning codes, which are now showing up due to improvements in how we understand byrefs).