### PR TITLE
Add MakeGenericMethod tests for static interface methods

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
@@ -749,6 +749,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TTwo> ()
 			{
 			}
+
 			class StaticInterfaceMethods
 			{
 				public static void Test ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
@@ -351,6 +351,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 				TestWithMultipleArgumentsWithRequirements ();
 
+				StaticInterfaceMethods.Test ();
 				NewConstraint.Test ();
 				StructConstraint.Test ();
 				UnmanagedConstraint.Test ();
@@ -631,7 +632,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					.MakeGenericMethod (typeof (T));
 			}
 
-
 			static void TestWithRequirementsViaRuntimeMethod ()
 			{
 				typeof (MakeGenericMethod).GetRuntimeMethod (nameof (GenericWithRequirements), Type.EmptyTypes)
@@ -748,6 +748,35 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TOne,
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TTwo> ()
 			{
+			}
+			class StaticInterfaceMethods
+			{
+				public static void Test ()
+				{
+					KnownType ();
+					UnannotatedGenericParam<int> ();
+					AnnotatedGenericParam<int> ();
+				}
+
+				static MethodInfo KnownType ()
+					=> typeof (IFoo).GetMethod ("Method")
+					.MakeGenericMethod (new Type[] { typeof (int) });
+
+				[ExpectedWarning ("IL2090", "T", "PublicMethods")]
+				static MethodInfo UnannotatedGenericParam<T> ()
+					=> typeof (IFoo).GetMethod ("Method")
+					.MakeGenericMethod (new Type[] { typeof (T) });
+
+				static MethodInfo AnnotatedGenericParam<
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+					=> typeof (IFoo).GetMethod ("Method")
+					.MakeGenericMethod (new Type[] { typeof (T) });
+
+				interface IFoo
+				{
+					static abstract T Method<
+						[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ();
+				}
 			}
 
 			class NewConstraint


### PR DESCRIPTION
Part of https://github.com/dotnet/linker/issues/2058