### PR TITLE
IL2121 warnings point to XML files correctly

### DIFF
--- a/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
+++ b/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using ILLink.Shared;
-using Mono.Cecil;
 
 namespace Mono.Linker.Steps
 {
@@ -23,16 +22,14 @@ namespace Mono.Linker.Steps
 			// Suppressions targeting warning caused by anything but the linker should not be reported.
 			// Suppressions targeting RedundantSuppression warning should not be reported.
 			redundantSuppressions = redundantSuppressions
-				.Where (suppression => ((DiagnosticId) suppression.suppressMessageInfo.Id).GetDiagnosticCategory () == DiagnosticCategory.Trimming)
-				.Where (suppression => ((DiagnosticId) suppression.suppressMessageInfo.Id) != DiagnosticId.RedundantSuppression);
+				.Where (suppressionInfo => ((DiagnosticId) suppressionInfo.suppression.SuppressMessageInfo.Id).GetDiagnosticCategory () == DiagnosticCategory.Trimming)
+				.Where (suppressionInfo => ((DiagnosticId) suppressionInfo.suppression.SuppressMessageInfo.Id) != DiagnosticId.RedundantSuppression);
 
-			foreach (var (provider, suppressMessageInfo) in redundantSuppressions) {
-				var source = GetSuppresionProvider (provider);
+			foreach (var (provider, suppression) in redundantSuppressions) {
+				var source = context.Suppressions.GetSuppressionOrigin (provider, suppression);
 
-				context.LogWarning (new MessageOrigin (source), DiagnosticId.RedundantSuppression, $"IL{suppressMessageInfo.Id:0000}");
+				context.LogWarning (new MessageOrigin (source), DiagnosticId.RedundantSuppression, $"IL{suppression.SuppressMessageInfo.Id:0000}");
 			}
 		}
-
-		private static ICustomAttributeProvider GetSuppresionProvider (ICustomAttributeProvider provider) => provider is ModuleDefinition module ? module.Assembly : provider;
 	}
 }

--- a/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
+++ b/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
@@ -22,11 +22,11 @@ namespace Mono.Linker.Steps
 			// Suppressions targeting warning caused by anything but the linker should not be reported.
 			// Suppressions targeting RedundantSuppression warning should not be reported.
 			redundantSuppressions = redundantSuppressions
-				.Where (suppressionInfo => ((DiagnosticId) suppressionInfo.suppression.SuppressMessageInfo.Id).GetDiagnosticCategory () == DiagnosticCategory.Trimming)
-				.Where (suppressionInfo => ((DiagnosticId) suppressionInfo.suppression.SuppressMessageInfo.Id) != DiagnosticId.RedundantSuppression);
+				.Where (suppression => ((DiagnosticId) suppression.SuppressMessageInfo.Id).GetDiagnosticCategory () == DiagnosticCategory.Trimming)
+				.Where (suppression => ((DiagnosticId) suppression.SuppressMessageInfo.Id) != DiagnosticId.RedundantSuppression);
 
-			foreach (var (provider, suppression) in redundantSuppressions) {
-				var source = context.Suppressions.GetSuppressionOrigin (provider, suppression);
+			foreach (var suppression in redundantSuppressions) {
+				var source = context.Suppressions.GetSuppressionOrigin (suppression);
 
 				context.LogWarning (new MessageOrigin (source), DiagnosticId.RedundantSuppression, $"IL{suppression.SuppressMessageInfo.Id:0000}");
 			}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -281,6 +281,9 @@ namespace Mono.Linker.Steps
 			// instead of the per-assembly stores.
 			foreach (var (provider, annotations) in xmlInfo.CustomAttributes)
 				Context.CustomAttributes.PrimaryAttributeInfo.AddCustomAttributes (provider, annotations);
+
+			foreach (var (ca, origin) in xmlInfo.CustomAttributesOrigins)
+				Context.CustomAttributes.PrimaryAttributeInfo.CustomAttributesOrigins.Add (ca, origin);
 		}
 
 		void Complete ()

--- a/src/linker/Linker/AttributeInfo.cs
+++ b/src/linker/Linker/AttributeInfo.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using Mono.Cecil;
 
 namespace Mono.Linker
@@ -11,9 +13,23 @@ namespace Mono.Linker
 	{
 		public Dictionary<ICustomAttributeProvider, CustomAttribute[]> CustomAttributes { get; }
 
+		public Dictionary<CustomAttribute, MessageOrigin> CustomAttributesOrigins { get; }
+
 		public AttributeInfo ()
 		{
 			CustomAttributes = new Dictionary<ICustomAttributeProvider, CustomAttribute[]> ();
+			CustomAttributesOrigins = new Dictionary<CustomAttribute, MessageOrigin> ();
+		}
+
+		public void AddCustomAttributes (ICustomAttributeProvider provider, CustomAttribute[] customAttributes, MessageOrigin[] origins)
+		{
+			Debug.Assert (customAttributes.Length == origins.Length);
+
+			AddCustomAttributes (provider, customAttributes);
+
+			foreach (var (customAttribute, origin) in customAttributes.Zip (origins)) {
+				CustomAttributesOrigins.Add (customAttribute, origin);
+			}
 		}
 
 		public void AddCustomAttributes (ICustomAttributeProvider provider, CustomAttribute[] customAttributes)

--- a/src/linker/Linker/CustomAttributeSource.cs
+++ b/src/linker/Linker/CustomAttributeSource.cs
@@ -73,6 +73,17 @@ namespace Mono.Linker
 			}
 		}
 
+		public bool TryGetCustomAttributeOrigin (ICustomAttributeProvider provider, CustomAttribute customAttribute, out MessageOrigin origin)
+		{
+			if (PrimaryAttributeInfo.CustomAttributesOrigins.TryGetValue (customAttribute, out origin))
+				return true;
+
+			if (!TryGetEmbeddedXmlInfo (provider, out var embeddedXml))
+				return false;
+
+			return embeddedXml.CustomAttributesOrigins.TryGetValue (customAttribute, out origin);
+		}
+
 		public bool HasAny (ICustomAttributeProvider provider)
 		{
 			if (provider.HasCustomAttributes)

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -21,12 +21,14 @@ namespace Mono.Linker
 			public SuppressMessageInfo SuppressMessageInfo { get; }
 			public bool Used { get; set; }
 			public CustomAttribute OriginAttribute { get; }
+			public ICustomAttributeProvider Provider { get; }
 
-			public Suppression (SuppressMessageInfo suppressMessageInfo, bool used, CustomAttribute originAttribute)
+			public Suppression (SuppressMessageInfo suppressMessageInfo, bool used, CustomAttribute originAttribute, ICustomAttributeProvider provider)
 			{
 				SuppressMessageInfo = suppressMessageInfo;
 				Used = used;
 				OriginAttribute = originAttribute;
+				Provider = provider;
 			}
 		}
 
@@ -41,15 +43,15 @@ namespace Mono.Linker
 			InitializedAssemblies = new HashSet<AssemblyDefinition> ();
 		}
 
-		void AddSuppression (Suppression suppression, ICustomAttributeProvider provider)
+		void AddSuppression (Suppression suppression)
 		{
 			var used = false;
-			if (!_suppressions.TryGetValue (provider, out var suppressions)) {
+			if (!_suppressions.TryGetValue (suppression.Provider, out var suppressions)) {
 				suppressions = new Dictionary<int, Suppression> ();
-				_suppressions.Add (provider, suppressions);
+				_suppressions.Add (suppression.Provider, suppressions);
 			} else if (suppressions.TryGetValue (suppression.SuppressMessageInfo.Id, out Suppression? value)) {
 				used = value.Used;
-				string? elementName = provider is MemberReference memberRef ? memberRef.GetDisplayName () : provider.ToString ();
+				string? elementName = suppression.Provider is MemberReference memberRef ? memberRef.GetDisplayName () : suppression.Provider.ToString ();
 				_context.LogMessage ($"Element '{elementName}' has more than one unconditional suppression. Note that only the last one is used.");
 			}
 
@@ -91,12 +93,12 @@ namespace Mono.Linker
 			TryGetSuppressionsForProvider (provider, out _);
 		}
 
-		public IEnumerable<(ICustomAttributeProvider provider, Suppression suppression)> GetUnusedSuppressions ()
+		public IEnumerable<Suppression> GetUnusedSuppressions ()
 		{
 			foreach (var (provider, suppressions) in _suppressions) {
 				foreach (var (_, suppression) in suppressions) {
 					if (!suppression.Used)
-						yield return (provider, suppression);
+						yield return suppression;
 				}
 			}
 		}
@@ -174,9 +176,9 @@ namespace Mono.Linker
 			if (GetModuleFromProvider (provider) is ModuleDefinition module) {
 				var assembly = module.Assembly;
 				if (InitializedAssemblies.Add (assembly)) {
-					foreach (var (suppression, target) in DecodeAssemblyAndModuleSuppressions (module)) {
-						AddSuppression (suppression, target);
-						membersToScan.Add (target);
+					foreach (var suppression in DecodeAssemblyAndModuleSuppressions (module)) {
+						AddSuppression (suppression);
+						membersToScan.Add (suppression.Provider);
 					}
 				}
 			}
@@ -187,7 +189,7 @@ namespace Mono.Linker
 				if (member is ModuleDefinition or AssemblyDefinition)
 					continue;
 				foreach (var suppression in DecodeSuppressions (member))
-					AddSuppression (suppression, member);
+					AddSuppression (suppression);
 			}
 
 			return _suppressions.TryGetValue (provider, out suppressions);
@@ -268,11 +270,11 @@ namespace Mono.Linker
 				if (!TryDecodeSuppressMessageAttributeData (ca, out var info))
 					continue;
 
-				yield return new Suppression (info, used: false, originAttribute: ca);
+				yield return new Suppression (info, used: false, originAttribute: ca, provider);
 			}
 		}
 
-		IEnumerable<(Suppression suppression, ICustomAttributeProvider Target)> DecodeAssemblyAndModuleSuppressions (ModuleDefinition module)
+		IEnumerable<Suppression> DecodeAssemblyAndModuleSuppressions (ModuleDefinition module)
 		{
 			AssemblyDefinition assembly = module.Assembly;
 			foreach (var suppression in DecodeGlobalSuppressions (module, assembly))
@@ -284,7 +286,7 @@ namespace Mono.Linker
 			}
 		}
 
-		IEnumerable<(Suppression suppression, ICustomAttributeProvider Target)> DecodeGlobalSuppressions (ModuleDefinition module, ICustomAttributeProvider provider)
+		IEnumerable<Suppression> DecodeGlobalSuppressions (ModuleDefinition module, ICustomAttributeProvider provider)
 		{
 			var attributes = _context.CustomAttributes.GetCustomAttributes (provider).
 					Where (a => TypeRefHasUnconditionalSuppressions (a.AttributeType));
@@ -295,13 +297,13 @@ namespace Mono.Linker
 
 				var scope = info.Scope?.ToLower ();
 				if (info.Target == null && (scope == "module" || scope == null)) {
-					yield return (new Suppression (info, used: false, originAttribute: instance), provider);
+					yield return new Suppression (info, used: false, originAttribute: instance, provider);
 					continue;
 				}
 
 				switch (scope) {
 				case "module":
-					yield return (new Suppression (info, used: false, originAttribute: instance), provider);
+					yield return new Suppression (info, used: false, originAttribute: instance, provider);
 					break;
 
 				case "type":
@@ -310,7 +312,7 @@ namespace Mono.Linker
 						break;
 
 					foreach (var result in DocumentationSignatureParser.GetMembersForDocumentationSignature (info.Target, module, _context))
-						yield return (new Suppression (info, used: false, originAttribute: instance), result);
+						yield return new Suppression (info, used: false, originAttribute: instance, result);
 
 					break;
 				default:
@@ -326,13 +328,13 @@ namespace Mono.Linker
 				typeRef.Namespace == "System.Diagnostics.CodeAnalysis";
 		}
 
-		public MessageOrigin GetSuppressionOrigin (ICustomAttributeProvider provider, Suppression suppression)
+		public MessageOrigin GetSuppressionOrigin (Suppression suppression)
 		{
-			if (_context.CustomAttributes.TryGetCustomAttributeOrigin (provider, suppression.OriginAttribute, out MessageOrigin origin))
+			if (_context.CustomAttributes.TryGetCustomAttributeOrigin (suppression.Provider, suppression.OriginAttribute, out MessageOrigin origin))
 				return origin;
-			if (provider is ModuleDefinition module)
+			if (suppression.Provider is ModuleDefinition module)
 				return new MessageOrigin (module.Assembly);
-			return new MessageOrigin (provider);
+			return new MessageOrigin (suppression.Provider);
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsFromXML.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsFromXML.cs
@@ -12,6 +12,8 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
 	[SkipKeptItemsValidation]
 	[ExpectedNoWarnings]
+	[ExpectedWarning ("IL2121", "IL2026", ProducedBy = ProducedBy.Trimmer, FileName = "DetectRedundantSuppressionsFromXML.xml", SourceLine = 7)]
+	[ExpectedWarning ("IL2121", "IL2109", ProducedBy = ProducedBy.Trimmer, FileName = "DetectRedundantSuppressionsFromXML.xml", SourceLine = 12)]
 	[SetupLinkAttributesFile ("DetectRedundantSuppressionsFromXML.xml")]
 	public class DetectRedundantSuppressionsFromXML
 	{
@@ -20,12 +22,8 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			DetectRedundantSuppressions.Test ();
 		}
 
-		[ExpectedWarning ("IL2121", "IL2109", ProducedBy = ProducedBy.Trimmer)]
 		public class DetectRedundantSuppressions
 		{
-			// The warning should ideally point to XML.
-			// https://github.com/dotnet/linker/issues/2923
-			[ExpectedWarning ("IL2121", "IL2026", ProducedBy = ProducedBy.Trimmer)]
 			public static void Test ()
 			{
 				DoNotTriggerWarning ();


### PR DESCRIPTION
Fixes #2923. Redundant suppressions from XML will be reported in XML, not target.

\cc @vitek-karas 