### PR TITLE
Fix exception when generating warning for method definition

### DIFF
--- a/src/linker/Linker/MessageOrigin.cs
+++ b/src/linker/Linker/MessageOrigin.cs
@@ -83,7 +83,7 @@ namespace Mono.Linker
 			string? fileName = FileName;
 			if (Provider is MethodDefinition method &&
 				method.DebugInformation.HasSequencePoints) {
-				var offset = ILOffset ?? 0;
+				var offset = ILOffset ?? method.DebugInformation.SequencePoints[0].Offset;
 				SequencePoint? correspondingSequencePoint = method.DebugInformation.SequencePoints
 					.Where (s => s.Offset <= offset)?.Last ();
 


### PR DESCRIPTION
If we produce a warning for the method itself (no IL offset) and the method has debug symbols, it can happen that there's no sequence point for the first instruction. In that case the current code will crash because we expect to always find sequence point for offset 0.

Fix this by looking for the first sequence point instead.

Fixes https://github.com/dotnet/linker/issues/2971