### PR TITLE
Suppress warning in instance fields 

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -72,6 +72,15 @@ namespace ILLink.RoslynAnalyzer
 			if (checkAssociatedSymbol && member is IMethodSymbol { AssociatedSymbol: { } associated } && associated.HasAttribute (requiresAttribute))
 				return true;
 
+			// When using instance fields suppress the warning if the constructor has already the Requires annotation
+			if (member is IFieldSymbol field && !field.IsStatic) {
+				foreach (var constructor in field.ContainingType.InstanceConstructors) {
+					if (!constructor.HasAttribute (requiresAttribute))
+						return false;
+				}
+				return true;
+			}
+
 			return false;
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -25,6 +25,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestRequiresOnBaseButNotOnDerived ();
 			TestRequiresOnDerivedButNotOnBase ();
 			TestRequiresOnBaseAndDerived ();
+			TestInstanceFieldSuppression ();
 			TestSuppressionsOnClass ();
 			TestStaticMethodOnRequiresTypeSuppressedByRequiresOnMethod ();
 			TestStaticConstructorCalls ();
@@ -244,6 +245,22 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		{
 			ClassWithInstanceField instance = new ClassWithInstanceField ();
 			var _ = instance.field;
+		}
+
+		public class ClassWithInstanceFieldWhichInitsDangerousClass
+		{
+			private ClassWithRequires _instanceField = new ClassWithRequires ();
+
+			[RequiresUnreferencedCode ("Calling the constructor is dangerous")]
+			[RequiresDynamicCode ("Calling the constructor is dangerous")]
+			public ClassWithInstanceFieldWhichInitsDangerousClass () { }
+		}
+
+		[ExpectedWarning ("IL2026", "Calling the constructor is dangerous")]
+		[ExpectedWarning ("IL3050", "Calling the constructor is dangerous", ProducedBy = ProducedBy.Analyzer)]
+		static void TestInstanceFieldSuppression ()
+		{
+			_ = new ClassWithInstanceFieldWhichInitsDangerousClass ();
 		}
 
 		[RequiresUnreferencedCode ("Message for --StaticCtorTriggeredByMethodCall2--")]


### PR DESCRIPTION
Suppress warning in instance fields if the instance constructors are annotated with Requires

Fixes https://github.com/dotnet/linker/issues/2970
Related to https://github.com/dotnet/runtime/pull/73853