### PR TITLE
Add test for dotnet/runtime#73048

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeDataflow.cs
@@ -93,6 +93,113 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				}
 			}
 
+			[ExpectedWarning ("IL2072", nameof (GetWithPublicMethods), nameof (DataFlowTypeExtensions.RequiresAll), CompilerGeneratedCode = true)]
+			static IEnumerable<object[]> ReturnManyObjects ()
+			{
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				Type t = GetWithPublicMethods ();
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				yield return new object[] { 1, 2, new object[] { 1, 2 }, new object[] { 1, 2 } };
+				t.RequiresAll ();
+			}
+
 			public static void Test ()
 			{
 				FlowAcrossYieldReturn ().GetEnumerator ().MoveNext (); // Has to call MoveNext otherwise AOT will actually remove it
@@ -103,6 +210,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				FlowParameterAcrossYieldReturn ();
 				FlowUnannotatedParameterAcrossYieldReturn ();
 				FlowAcrossYieldReturnWithBackwardsBranch ();
+				
+				foreach (var o in ReturnManyObjects ());
 			}
 		}
 


### PR DESCRIPTION
Running dataflow analysis on the added test takes about 20 seconds. Double the number of `yield returns` and it will take several minutes.

In the runtime repo we're running into this on https://github.com/dotnet/runtime/blob/main/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTestData.cs (method `SerializableObjects()`). That one has even more `yield returns` and I lost patience waiting for it to finish.