### PR TITLE
Do not report redundant suppressions on trimmed members

### DIFF
--- a/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
+++ b/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
@@ -33,7 +33,6 @@ namespace Mono.Linker.Steps
 				context.LogWarning (new MessageOrigin (source), DiagnosticId.RedundantSuppression, $"IL{suppression.SuppressMessageInfo.Id:0000}");
 			}
 
-
 			bool ProviderIsMarked (ICustomAttributeProvider provider)
 			{
 				if (provider is PropertyDefinition property) {

--- a/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
+++ b/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
@@ -23,7 +23,8 @@ namespace Mono.Linker.Steps
 			// Suppressions targeting RedundantSuppression warning should not be reported.
 			redundantSuppressions = redundantSuppressions
 				.Where (suppression => ((DiagnosticId) suppression.SuppressMessageInfo.Id).GetDiagnosticCategory () == DiagnosticCategory.Trimming)
-				.Where (suppression => ((DiagnosticId) suppression.SuppressMessageInfo.Id) != DiagnosticId.RedundantSuppression);
+				.Where (suppression => ((DiagnosticId) suppression.SuppressMessageInfo.Id) != DiagnosticId.RedundantSuppression)
+				.Where (suppression => context.Annotations.IsMarked (suppression.Provider));
 
 			foreach (var suppression in redundantSuppressions) {
 				var source = context.Suppressions.GetSuppressionOrigin (suppression);

--- a/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
+++ b/src/linker/Linker.Steps/CheckSuppressionsDispatcher.cs
@@ -36,13 +36,14 @@ namespace Mono.Linker.Steps
 			bool ProviderIsMarked (ICustomAttributeProvider provider)
 			{
 				if (provider is PropertyDefinition property) {
-					return context.Annotations.IsMarked (property.GetMethod) || context.Annotations.IsMarked (property.SetMethod);
+					return (property.GetMethod != null && context.Annotations.IsMarked (property.GetMethod))
+						|| (property.SetMethod != null && context.Annotations.IsMarked (property.SetMethod));
 				}
 
 				if (provider is EventDefinition @event) {
-					return context.Annotations.IsMarked (@event.AddMethod)
-						|| context.Annotations.IsMarked (@event.InvokeMethod)
-						|| context.Annotations.IsMarked (@event.RemoveMethod);
+					return (@event.AddMethod != null && context.Annotations.IsMarked (@event.AddMethod))
+						|| (@event.InvokeMethod != null && context.Annotations.IsMarked (@event.InvokeMethod))
+						|| (@event.RemoveMethod != null && context.Annotations.IsMarked (@event.RemoveMethod));
 				}
 
 				return context.Annotations.IsMarked (provider);

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -19,14 +19,13 @@ namespace Mono.Linker
 		public class Suppression
 		{
 			public SuppressMessageInfo SuppressMessageInfo { get; }
-			public bool Used { get; set; }
+			public bool Used { get; set; } = false;
 			public CustomAttribute OriginAttribute { get; }
 			public ICustomAttributeProvider Provider { get; }
 
-			public Suppression (SuppressMessageInfo suppressMessageInfo, bool used, CustomAttribute originAttribute, ICustomAttributeProvider provider)
+			public Suppression (SuppressMessageInfo suppressMessageInfo, CustomAttribute originAttribute, ICustomAttributeProvider provider)
 			{
 				SuppressMessageInfo = suppressMessageInfo;
-				Used = used;
 				OriginAttribute = originAttribute;
 				Provider = provider;
 			}
@@ -270,7 +269,7 @@ namespace Mono.Linker
 				if (!TryDecodeSuppressMessageAttributeData (ca, out var info))
 					continue;
 
-				yield return new Suppression (info, used: false, originAttribute: ca, provider);
+				yield return new Suppression (info, originAttribute: ca, provider);
 			}
 		}
 
@@ -297,13 +296,13 @@ namespace Mono.Linker
 
 				var scope = info.Scope?.ToLower ();
 				if (info.Target == null && (scope == "module" || scope == null)) {
-					yield return new Suppression (info, used: false, originAttribute: instance, provider);
+					yield return new Suppression (info, originAttribute: instance, provider);
 					continue;
 				}
 
 				switch (scope) {
 				case "module":
-					yield return new Suppression (info, used: false, originAttribute: instance, provider);
+					yield return new Suppression (info, originAttribute: instance, provider);
 					break;
 
 				case "type":
@@ -312,7 +311,7 @@ namespace Mono.Linker
 						break;
 
 					foreach (var result in DocumentationSignatureParser.GetMembersForDocumentationSignature (info.Target, module, _context))
-						yield return new Suppression (info, used: false, originAttribute: instance, result);
+						yield return new Suppression (info, originAttribute: instance, result);
 
 					break;
 				default:

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInMembersAndTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInMembersAndTypes.cs
@@ -19,17 +19,27 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			RedundantSuppressionOnType.Test ();
 			RedundantSuppressionOnMethod.Test ();
 			RedundantSuppressionOnNestedType.Test ();
+
 			RedundantSuppressionOnPropertyGet.Test ();
 			RedundantSuppressionOnProperty.Test ();
+			RedundantSuppressionOnPropertyWithOnlyGet.Test ();
+			RedundantSuppressionOnPropertyWithOnlySet.Test ();
+			RedundantSuppressionOnPropertyAccessedByReflection.Test ();
+
 			RedundantSuppressionOnEventAdd.Test ();
 			RedundantSuppressionOnEvent.Test ();
+			RedundantSuppressionOnEventAccessedByReflection.Test ();
+
 			MultipleRedundantSuppressions.Test ();
 			RedundantAndUsedSuppressions.Test ();
+
 			DoNotReportNonLinkerSuppressions.Test ();
 			DoNotReportSuppressionsOnMethodsConvertedToThrow.Test ();
+
 			SuppressRedundantSuppressionWarning.Test ();
-			RedundantSuppressionWithRUC.Test ();
 			DoNotReportUnnecessaryRedundantWarningSuppressions.Test ();
+
+			RedundantSuppressionWithRUC.Test ();
 		}
 
 		public static Type TriggerUnrecognizedPattern ()
@@ -101,6 +111,58 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			public static void Test ()
 			{
 				var property = TrimmerCompatibleProperty;
+				TrimmerCompatibleProperty = "test";
+			}
+
+			[ExpectedWarning ("IL2121", "IL2071", ProducedBy = ProducedBy.Trimmer)]
+			[UnconditionalSuppressMessage ("Test", "IL2071")]
+			public static string TrimmerCompatibleProperty {
+				get {
+					return TrimmerCompatibleMethod ();
+				}
+				set {
+					value = TrimmerCompatibleMethod ();
+				}
+			}
+		}
+
+		public class RedundantSuppressionOnPropertyWithOnlyGet
+		{
+			public static void Test ()
+			{
+				var property = TrimmerCompatibleProperty;
+			}
+
+			[ExpectedWarning ("IL2121", "IL2071", ProducedBy = ProducedBy.Trimmer)]
+			[UnconditionalSuppressMessage ("Test", "IL2071")]
+			public static string TrimmerCompatibleProperty {
+				get {
+					return TrimmerCompatibleMethod ();
+				}
+			}
+		}
+
+		public class RedundantSuppressionOnPropertyWithOnlySet
+		{
+			public static void Test ()
+			{
+				TrimmerCompatibleProperty = "test";
+			}
+
+			[ExpectedWarning ("IL2121", "IL2071", ProducedBy = ProducedBy.Trimmer)]
+			[UnconditionalSuppressMessage ("Test", "IL2071")]
+			public static string TrimmerCompatibleProperty {
+				set {
+					value = TrimmerCompatibleMethod ();
+				}
+			}
+		}
+
+		public class RedundantSuppressionOnPropertyAccessedByReflection
+		{
+			public static void Test ()
+			{
+				typeof (RedundantSuppressionOnPropertyAccessedByReflection).GetProperty ("TrimmerCompatibleProperty");
 			}
 
 			[ExpectedWarning ("IL2121", "IL2071", ProducedBy = ProducedBy.Trimmer)]
@@ -116,7 +178,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 		{
 			public static void Test ()
 			{
-				Event += EventSubscriber;
+				TrimmerCompatibleEvent += EventSubscriber;
 			}
 
 			static void EventSubscriber (object sender, EventArgs e)
@@ -124,7 +186,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 			}
 
-			static event EventHandler<EventArgs> Event {
+			public static event EventHandler<EventArgs> TrimmerCompatibleEvent {
 				[ExpectedWarning ("IL2121", "IL2072", ProducedBy = ProducedBy.Trimmer)]
 				[UnconditionalSuppressMessage ("Test", "IL2072")]
 				add { TrimmerCompatibleMethod (); }
@@ -136,7 +198,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 		{
 			public static void Test ()
 			{
-				Event += EventSubscriber;
+				TrimmerCompatibleEvent += EventSubscriber;
 			}
 
 			static void EventSubscriber (object sender, EventArgs e)
@@ -146,7 +208,22 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 			[ExpectedWarning ("IL2121", "IL2072", ProducedBy = ProducedBy.Trimmer)]
 			[UnconditionalSuppressMessage ("Test", "IL2072")]
-			static event EventHandler<EventArgs> Event {
+			public static event EventHandler<EventArgs> TrimmerCompatibleEvent {
+				add { TrimmerCompatibleMethod (); }
+				remove { }
+			}
+		}
+
+		public class RedundantSuppressionOnEventAccessedByReflection
+		{
+			public static void Test ()
+			{
+				typeof (RedundantSuppressionOnEventAccessedByReflection).GetEvent ("TrimmerCompatibleEvent");
+			}
+
+			[ExpectedWarning ("IL2121", "IL2072", ProducedBy = ProducedBy.Trimmer)]
+			[UnconditionalSuppressMessage ("Test", "IL2072")]
+			public static event EventHandler<EventArgs> TrimmerCompatibleEvent {
 				add { TrimmerCompatibleMethod (); }
 				remove { }
 			}
@@ -240,7 +317,6 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			public static void Test ()
 			{
 				MethodMarkedRUC ();
-
 			}
 
 			[ExpectedWarning ("IL2121", "IL2072", ProducedBy = ProducedBy.Trimmer)]

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
@@ -15,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 	[SkipKeptItemsValidation]
 	class DetectRedundantSuppressionsTrimmedMembersTarget
 	{
-		[ExpectedWarning("IL2072")]
+		[ExpectedWarning ("IL2072")]
 		static void Main ()
 		{
 			Expression.Call (TriggerUnrecognizedPattern (), "", Type.EmptyTypes);

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: UnconditionalSuppressMessage ("Test", "IL2071", Scope = "type", Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.UnusedTypeWithRedundantSuppression")]
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+	[ExpectedNoWarnings]
+	[SkipKeptItemsValidation]
+	class DetectRedundantSuppressionsTrimmedMembersTarget
+	{
+		[ExpectedWarning("IL2072")]
+		static void Main ()
+		{
+			Expression.Call (TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+		}
+
+		public static Type TriggerUnrecognizedPattern ()
+		{
+			return typeof (DetectRedundantSuppressionsTrimmedMembersTarget);
+		}
+	}
+
+	class UnusedTypeWithRedundantSuppression
+	{
+
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
@@ -7,7 +7,9 @@ using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-[assembly: UnconditionalSuppressMessage ("Test", "IL2071", Scope = "type", Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.UnusedTypeWithRedundantSuppression")]
+[assembly: UnconditionalSuppressMessage ("Test", "IL2071",
+	Scope = "type",
+	Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.UnusedTypeWithRedundantSuppression")]
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
@@ -10,6 +10,15 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 [assembly: UnconditionalSuppressMessage ("Test", "IL2071",
 	Scope = "type",
 	Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.UnusedTypeWithRedundantSuppression")]
+[assembly: UnconditionalSuppressMessage ("Test", "IL2071",
+	Scope = "member",
+	Target = "P:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.UnusedTypeWithMembers.UnusedPropertyWithSuppression")]
+[assembly: UnconditionalSuppressMessage ("Test", "IL2071",
+	Scope = "member",
+	Target = "E:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.UnusedTypeWithMembers.UnusedEventWithSuppression")]
+[assembly: UnconditionalSuppressMessage ("Test", "IL2071",
+	Scope = "member",
+	Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.UnusedTypeWithMembers.UnusedMethodWithSuppression")]
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
@@ -31,6 +40,17 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 	class UnusedTypeWithRedundantSuppression
 	{
+	}
 
+	class UnusedTypeWithMembers
+	{
+		int UnusedPropertyWithSuppression { get; set; }
+
+		event EventHandler<EventArgs> UnusedEventWithSuppression {
+			add { }
+			remove { }
+		}
+
+		void UnusedMethodWithSuppression () { }
 	}
 }


### PR DESCRIPTION
The code allowed for reporting redundant suppressions on members which were removed by the linker.

This was possible e.g. when we had an assembly level suppression targeting a trimmed away member and had another warning triggered in the assembly. 

Added filter checking whether the suppression's provider is marked. Should fix #2990 

The change run into problems with suppressions on properties and events (they are not marked, only their accessors are). The PR introduces workaround for this.