### PR TITLE
Added test for #3001

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/TestSystemTypeBase.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/TestSystemTypeBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 
@@ -26,6 +27,7 @@ namespace System
 
 		public override string Name => throw new NotImplementedException ();
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 		public override ConstructorInfo[] GetConstructors (BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
@@ -46,61 +48,74 @@ namespace System
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
 		public override EventInfo GetEvent (string name, BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
 		public override EventInfo[] GetEvents (BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
 		public override FieldInfo GetField (string name, BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
 		public override FieldInfo[] GetFields (BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
 		public override Type GetInterface (string name, bool ignoreCase)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
 		public override Type[] GetInterfaces ()
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
 		public override MemberInfo[] GetMembers (BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
 		public override MethodInfo[] GetMethods (BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
 		public override Type GetNestedType (string name, BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
 		public override Type[] GetNestedTypes (BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
 		public override PropertyInfo[] GetProperties (BindingFlags bindingAttr)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 		public override object InvokeMember (string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
 		{
 			throw new NotImplementedException ();
@@ -116,16 +131,19 @@ namespace System
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 		protected override ConstructorInfo GetConstructorImpl (BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
 		protected override MethodInfo GetMethodImpl (string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
 		{
 			throw new NotImplementedException ();
 		}
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
 		protected override PropertyInfo GetPropertyImpl (string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
 		{
 			throw new NotImplementedException ();

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -32,6 +32,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestFromFieldToThis ();
 			TestFromThisToOthers ();
 			TestFromGenericParameterToThis<MethodThisDataFlow> ();
+
+			TestIntrinsicOnDerivedType ();
 		}
 
 		[ExpectedWarning ("IL2075",
@@ -80,6 +82,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
 		static MethodThisDataFlowTypeTest GetWithNonPublicMethods ()
+		{
+			return null;
+		}
+
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents)]
+		static MethodThisDataFlowTypeTest GetWithPublicEvents ()
 		{
 			return null;
 		}
@@ -139,6 +147,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			GetWithPublicMethods ().PropagateToReturn ();
 			GetWithPublicMethods ().PropagateToField ();
 			GetWithPublicMethods ().PropagateToThis ();
+		}
+
+		static void TestIntrinsicOnDerivedType ()
+		{
+			GetWithPublicEvents ().IntrinsicOnDerivedType ();
 		}
 
 		class NonTypeType
@@ -227,6 +240,15 @@ namespace System
 		public void PropagateToThis ()
 		{
 			this.RequireThisNonPublicMethods ();
+		}
+
+		[ExpectedNoWarnings]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents)]
+		public void IntrinsicOnDerivedType ()
+		{
+			const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
+			// https://github.com/dotnet/linker/issues/3001
+			// GetEvents (DefaultBindingFlags);
 		}
 
 		public object PropertyRequireThisPublicMethods {


### PR DESCRIPTION
The test function call GetEvents(BindingFlags) override on a class derving from type. The linker understands the call as intrinsic, the analyzer does not and produces a warning. The test is currently disabled by commenting out the offending GetEvents(...) call.

This is a repro test for #3001 