### PR TITLE
Add current runtime code quality analyzer settings to linker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -40,11 +40,1359 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:suggestion
 
 ### Code Style Analyzers
 
+## BCL analyzer rules
+
+# BCL0001: Ensure minimum API surface is respected
+dotnet_diagnostic.BCL0001.severity = warning
+
+# BCL0010: AppContext default value expected to be true
+dotnet_diagnostic.BCL0010.severity = warning
+
+# BCL0011: AppContext default value defined in if statement with incorrect pattern
+dotnet_diagnostic.BCL0011.severity = warning
+
+# BCL0012: AppContext default value defined in if statement at root of switch case
+dotnet_diagnostic.BCL0012.severity = warning
+
+# BCL0015: Invalid P/Invoke call
+dotnet_diagnostic.BCL0015.severity = none
+
+# BCL0020: Invalid SR.Format call
+dotnet_diagnostic.BCL0020.severity = warning
+
+## CA analyzer rules
+
+dotnet_analyzer_diagnostic.category-performance.severity = warning
+dotnet_analyzer_diagnostic.category-maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-reliability.severity = warning
+dotnet_analyzer_diagnostic.category-usage.severity = warning
+#dotnet_analyzer_diagnostic.category-style.severity = warning
+
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity = none
+
+# CA1001: Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1001.severity = none
+
+# CA1002: Do not expose generic lists
+dotnet_diagnostic.CA1002.severity = none
+
+# CA1003: Use generic event handler instances
+dotnet_diagnostic.CA1003.severity = none
+
+# CA1005: Avoid excessive parameters on generic types
+dotnet_diagnostic.CA1005.severity = none
+
+# CA1008: Enums should have zero value
+dotnet_diagnostic.CA1008.severity = none
+
+# CA1010: Generic interface should also be implemented
+dotnet_diagnostic.CA1010.severity = none
+
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = none
+
+# CA1014: Mark assemblies with CLSCompliant
+dotnet_diagnostic.CA1014.severity = none
+
+# CA1016: Mark assemblies with assembly version
+dotnet_diagnostic.CA1016.severity = none
+
+# CA1017: Mark assemblies with ComVisible
+dotnet_diagnostic.CA1017.severity = none
+
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = warning
+
+# CA1019: Define accessors for attribute arguments
+dotnet_diagnostic.CA1019.severity = none
+
+# CA1021: Avoid out parameters
+dotnet_diagnostic.CA1021.severity = none
+
+# CA1024: Use properties where appropriate
+dotnet_diagnostic.CA1024.severity = none
+
+# CA1027: Mark enums with FlagsAttribute
+dotnet_diagnostic.CA1027.severity = none
+
+# CA1028: Enum Storage should be Int32
+dotnet_diagnostic.CA1028.severity = none
+
+# CA1030: Use events where appropriate
+dotnet_diagnostic.CA1030.severity = none
+
+# CA1031: Do not catch general exception types
+dotnet_diagnostic.CA1031.severity = none
+
+# CA1032: Implement standard exception constructors
+dotnet_diagnostic.CA1032.severity = none
+
+# CA1033: Interface methods should be callable by child types
+dotnet_diagnostic.CA1033.severity = none
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.CA1034.severity = none
+
+# CA1036: Override methods on comparable types
+dotnet_diagnostic.CA1036.severity = none
+
+# CA1040: Avoid empty interfaces
+dotnet_diagnostic.CA1040.severity = none
+
+# CA1041: Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = none
+
+# CA1043: Use Integral Or String Argument For Indexers
+dotnet_diagnostic.CA1043.severity = none
+
+# CA1044: Properties should not be write only
+dotnet_diagnostic.CA1044.severity = none
+
+# CA1045: Do not pass types by reference
+dotnet_diagnostic.CA1045.severity = none
+
+# CA1046: Do not overload equality operator on reference types
+dotnet_diagnostic.CA1046.severity = none
+
+# CA1047: Do not declare protected member in sealed type
+dotnet_diagnostic.CA1047.severity = warning
+
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = warning
+
+# CA1051: Do not declare visible instance fields
+dotnet_diagnostic.CA1051.severity = none
+
+# CA1052: Static holder types should be Static or NotInheritable
+dotnet_diagnostic.CA1052.severity = warning
+dotnet_code_quality.CA1052.api_surface = private, internal
+
+# CA1054: URI-like parameters should not be strings
+dotnet_diagnostic.CA1054.severity = none
+
+# CA1055: URI-like return values should not be strings
+dotnet_diagnostic.CA1055.severity = none
+
+# CA1056: URI-like properties should not be strings
+dotnet_diagnostic.CA1056.severity = none
+
+# CA1058: Types should not extend certain base types
+dotnet_diagnostic.CA1058.severity = none
+
+# CA1060: Move pinvokes to native methods class
+dotnet_diagnostic.CA1060.severity = none
+
+# CA1061: Do not hide base class methods
+dotnet_diagnostic.CA1061.severity = none
+
+# CA1062: Validate arguments of public methods
+dotnet_diagnostic.CA1062.severity = none
+
+# CA1063: Implement IDisposable Correctly
+dotnet_diagnostic.CA1063.severity = none
+
+# CA1064: Exceptions should be public
+dotnet_diagnostic.CA1064.severity = none
+
+# CA1065: Do not raise exceptions in unexpected locations
+dotnet_diagnostic.CA1065.severity = none
+
+# CA1066: Implement IEquatable when overriding Object.Equals
+dotnet_diagnostic.CA1066.severity = warning
+
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
+dotnet_diagnostic.CA1067.severity = warning
+
+# CA1068: CancellationToken parameters must come last
+dotnet_diagnostic.CA1068.severity = none
+
+# CA1069: Enums values should not be duplicated
+dotnet_diagnostic.CA1069.severity = none
+
+# CA1070: Do not declare event fields as virtual
+dotnet_diagnostic.CA1070.severity = suggestion
+
+# CA1200: Avoid using cref tags with a prefix
+dotnet_diagnostic.CA1200.severity = suggestion
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = none
+
+# CA1304: Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = none
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = none
+
+# CA1307: Specify StringComparison for clarity
+dotnet_diagnostic.CA1307.severity = none
+
+# CA1308: Normalize strings to uppercase
+dotnet_diagnostic.CA1308.severity = none
+
+# CA1309: Use ordinal string comparison
+dotnet_diagnostic.CA1309.severity = none
+
+# CA1310: Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = suggestion
+
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = warning
+
+# CA1401: P/Invokes should not be visible
+dotnet_diagnostic.CA1401.severity = warning
+
+# CA1416: Validate platform compatibility
+dotnet_diagnostic.CA1416.severity = warning
+
+# CA1417: Do not use 'OutAttribute' on string parameters for P/Invokes
+dotnet_diagnostic.CA1417.severity = warning
+
+# CA1418: Use valid platform string
+dotnet_diagnostic.CA1418.severity = warning
+
+# CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+dotnet_diagnostic.CA1419.severity = warning
+
+# CA1420: Property, type, or attribute requires runtime marshalling
+dotnet_diagnostic.CA1420.severity = warning
+
+# CA1421: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# CA1501: Avoid excessive inheritance
+dotnet_diagnostic.CA1501.severity = none
+
+# CA1502: Avoid excessive complexity
+dotnet_diagnostic.CA1502.severity = none
+
+# CA1505: Avoid unmaintainable code
+dotnet_diagnostic.CA1505.severity = none
+
+# CA1506: Avoid excessive class coupling
+dotnet_diagnostic.CA1506.severity = none
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = warning
+
+# CA1508: Avoid dead conditional code
+dotnet_diagnostic.CA1508.severity = none
+
+# CA1509: Invalid entry in code metrics rule specification file
+dotnet_diagnostic.CA1509.severity = none
+
+# CA1700: Do not name enum values 'Reserved'
+dotnet_diagnostic.CA1700.severity = none
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none
+
+# CA1708: Identifiers should differ by more than case
+dotnet_diagnostic.CA1708.severity = none
+
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = none
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = none
+
+# CA1712: Do not prefix enum values with type name
+dotnet_diagnostic.CA1712.severity = none
+
+# CA1713: Events should not have 'Before' or 'After' prefix
+dotnet_diagnostic.CA1713.severity = none
+
+# CA1715: Identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = none
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = none
+
+# CA1720: Identifier contains type name
+dotnet_diagnostic.CA1720.severity = none
+
+# CA1721: Property names should not match get methods
+dotnet_diagnostic.CA1721.severity = none
+
+# CA1724: Type names should not match namespaces
+dotnet_diagnostic.CA1724.severity = none
+
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA1727: Use PascalCase for named placeholders
+dotnet_diagnostic.CA1727.severity = warning
+
+# CA1802: Use literals where appropriate
+dotnet_diagnostic.CA1802.severity = warning
+dotnet_code_quality.CA1802.api_surface = private, internal
+
+# CA1805: Member is explicitly initialized to it's default value
+dotnet_diagnostic.CA1805.severity = none
+
+# CA1806: Do not ignore method results
+dotnet_diagnostic.CA1806.severity = none
+
+# CA1810: Initialize reference type static fields inline
+dotnet_diagnostic.CA1810.severity = warning
+
+# CA1812: Avoid uninstantiated internal classes
+dotnet_diagnostic.CA1812.severity = none
+
+# CA1813: Avoid unsealed attributes
+dotnet_diagnostic.CA1813.severity = none
+
+# CA1814: Prefer jagged arrays over multidimensional
+dotnet_diagnostic.CA1814.severity = none
+
+# CA1815: Override equals and operator equals on value types
+dotnet_diagnostic.CA1815.severity = none
+
+# call GC.SuppressFinalize(object)
+dotnet_diagnostic.CA1816.severity = none
+
+# CA1819: Properties should not return arrays
+dotnet_diagnostic.CA1819.severity = none
+
+# CA1820: Test for empty strings using string length
+dotnet_diagnostic.CA1820.severity = none
+
+# CA1821: Remove empty Finalizers
+dotnet_diagnostic.CA1821.severity = warning
+
+# CA1822: Mark members as static
+dotnet_diagnostic.CA1822.severity = warning
+dotnet_code_quality.CA1822.api_surface = private, internal
+
+# CA1823: Avoid unused private fields
+dotnet_diagnostic.CA1823.severity = warning
+
+# CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
+dotnet_diagnostic.CA1824.severity = warning
+
+# CA1825: Avoid zero-length array allocations
+dotnet_diagnostic.CA1825.severity = warning
+
+# CA1826: Do not use Enumerable methods on indexable collections
+dotnet_diagnostic.CA1826.severity = warning
+
+# CA1827: Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.CA1827.severity = warning
+
+# CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+dotnet_diagnostic.CA1828.severity = warning
+
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = warning
+
+# CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+dotnet_diagnostic.CA1830.severity = warning
+
+# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1831.severity = warning
+
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1832.severity = warning
+
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1833.severity = warning
+
+# CA1834: Use 'StringBuilder.Append(char)'
+dotnet_diagnostic.CA1834.severity = warning
+
+# CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+dotnet_diagnostic.CA1835.severity = warning
+
+# CA1836: Prefer IsEmpty over Count
+dotnet_diagnostic.CA1836.severity = warning
+
+# CA1837: Use 'Environment.ProcessId'
+dotnet_diagnostic.CA1837.severity = warning
+
+# CA1838: Avoid 'StringBuilder' parameters for P/Invokes
+dotnet_diagnostic.CA1838.severity = warning
+
+# CA1839: Use 'Environment.ProcessPath'
+dotnet_diagnostic.CA1839.severity = warning
+
+# CA1840: Use 'Environment.CurrentManagedThreadId'
+dotnet_diagnostic.CA1840.severity = warning
+
+# CA1841: Prefer Dictionary.Contains methods
+dotnet_diagnostic.CA1841.severity = warning
+
+# CA1842: Do not use 'WhenAll' with a single task
+dotnet_diagnostic.CA1842.severity = warning
+
+# CA1843: Do not use 'WaitAll' with a single task
+dotnet_diagnostic.CA1843.severity = warning
+
+# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
+dotnet_diagnostic.CA1844.severity = warning
+
+# CA1845: Use span-based 'string.Concat'
+dotnet_diagnostic.CA1845.severity = warning
+
+# CA1846: Prefer 'AsSpan' over 'Substring'
+dotnet_diagnostic.CA1846.severity = warning
+
+# CA1847: Use char literal for a single character lookup
+dotnet_diagnostic.CA1847.severity = warning
+
+# CA1848: Use the LoggerMessage delegates
+dotnet_diagnostic.CA1848.severity = none
+
+# CA1849: Call async methods when in an async method
+dotnet_diagnostic.CA1849.severity = suggestion
+
+# CA1850: Prefer static 'HashData' method over 'ComputeHash'
+dotnet_diagnostic.CA1850.severity = warning
+
+# CA1851: Possible multiple enumerations of 'IEnumerable' collection
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = warning
+
+# CA1853: Unnecessary call to 'Dictionary.ContainsKey(key)'
+dotnet_diagnostic.CA1853.severity = warning
+
+# CA1854: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+dotnet_diagnostic.CA1854.severity = warning
+
+# CA2000: Dispose objects before losing scope
+dotnet_diagnostic.CA2000.severity = none
+
+# CA2002: Do not lock on objects with weak identity
+dotnet_diagnostic.CA2002.severity = none
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = warning
+
+# CA2008: Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.CA2008.severity = warning
+
+# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+dotnet_diagnostic.CA2009.severity = warning
+
+# CA2011: Avoid infinite recursion
+dotnet_diagnostic.CA2011.severity = warning
+
+# CA2012: Use ValueTasks correctly
+dotnet_diagnostic.CA2012.severity = warning
+
+# CA2013: Do not use ReferenceEquals with value types
+dotnet_diagnostic.CA2013.severity = warning
+
+# CA2014: Do not use stackalloc in loops
+dotnet_diagnostic.CA2014.severity = warning
+
+# CA2015: Do not define finalizers for types derived from MemoryManager<T>
+dotnet_diagnostic.CA2015.severity = warning
+
+# CA2016: Forward the 'CancellationToken' parameter to methods
+dotnet_diagnostic.CA2016.severity = warning
+
+# CA2017: Parameter count mismatch
+dotnet_diagnostic.CA2017.severity = warning
+
+# CA2018: 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+dotnet_diagnostic.CA2018.severity = warning
+
+# CA2019: Improper 'ThreadStatic' field initialization
+dotnet_diagnostic.CA2019.severity = warning
+
+# CA2100: Review SQL queries for security vulnerabilities
+dotnet_diagnostic.CA2100.severity = none
+
+# CA2101: Specify marshaling for P/Invoke string arguments
+dotnet_diagnostic.CA2101.severity = none
+
+# CA2109: Review visible event handlers
+dotnet_diagnostic.CA2109.severity = none
+
+# CA2119: Seal methods that satisfy private interfaces
+dotnet_diagnostic.CA2119.severity = none
+
+# CA2153: Do Not Catch Corrupted State Exceptions
+dotnet_diagnostic.CA2153.severity = none
+
+# CA2200: Rethrow to preserve stack details
+dotnet_diagnostic.CA2200.severity = warning
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = none
+
+# CA2207: Initialize value type static fields inline
+dotnet_diagnostic.CA2207.severity = warning
+
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = warning
+dotnet_code_quality.CA2208.api_surface = public
+
+# CA2211: Non-constant fields should not be visible
+dotnet_diagnostic.CA2211.severity = none
+
+# CA2213: Disposable fields should be disposed
+dotnet_diagnostic.CA2213.severity = none
+
+# CA2214: Do not call overridable methods in constructors
+dotnet_diagnostic.CA2214.severity = none
+
+# CA2215: Dispose methods should call base class dispose
+dotnet_diagnostic.CA2215.severity = none
+
+# CA2216: Disposable types should declare finalizer
+dotnet_diagnostic.CA2216.severity = none
+
+# CA2217: Do not mark enums with FlagsAttribute
+dotnet_diagnostic.CA2217.severity = none
+
+# CA2218: Override GetHashCode on overriding Equals
+dotnet_diagnostic.CA2218.severity = none
+
+# CA2219: Do not raise exceptions in finally clauses
+dotnet_diagnostic.CA2219.severity = none
+
+# CA2224: Override Equals on overloading operator equals
+dotnet_diagnostic.CA2224.severity = none
+
+# CA2225: Operator overloads have named alternates
+dotnet_diagnostic.CA2225.severity = none
+
+# CA2226: Operators should have symmetrical overloads
+dotnet_diagnostic.CA2226.severity = none
+
+# CA2227: Collection properties should be read only
+dotnet_diagnostic.CA2227.severity = none
+
+# CA2229: Implement serialization constructors
+dotnet_diagnostic.CA2229.severity = warning
+
+# CA2231: Overload operator equals on overriding value type Equals
+dotnet_diagnostic.CA2231.severity = none
+
+# CA2234: Pass system uri objects instead of strings
+dotnet_diagnostic.CA2234.severity = none
+
+# CA2235: Mark all non-serializable fields
+dotnet_diagnostic.CA2235.severity = none
+
+# CA2237: Mark ISerializable types with serializable
+dotnet_diagnostic.CA2237.severity = none
+
+# CA2241: Provide correct arguments to formatting methods
+dotnet_diagnostic.CA2241.severity = warning
+
+# CA2242: Test for NaN correctly
+dotnet_diagnostic.CA2242.severity = warning
+
+# CA2243: Attribute string literals should parse correctly
+dotnet_diagnostic.CA2243.severity = warning
+
+# CA2244: Do not duplicate indexed element initializations
+dotnet_diagnostic.CA2244.severity = warning
+
+# CA2245: Do not assign a property to itself
+dotnet_diagnostic.CA2245.severity = warning
+
+# CA2246: Assigning symbol and its member in the same statement
+dotnet_diagnostic.CA2246.severity = warning
+
+# CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+dotnet_diagnostic.CA2247.severity = warning
+
+# CA2248: Provide correct 'enum' argument to 'Enum.HasFlag'
+dotnet_diagnostic.CA2248.severity = warning
+
+# CA2249: Consider using 'string.Contains' instead of 'string.IndexOf'
+dotnet_diagnostic.CA2249.severity = warning
+
+# CA2250: Use 'ThrowIfCancellationRequested'
+dotnet_diagnostic.CA2250.severity = warning
+
+# CA2251: Use 'string.Equals'
+dotnet_diagnostic.CA2251.severity = warning
+
+# CA2252: This API requires opting into preview features
+dotnet_diagnostic.CA2252.severity = error
+
+# CA2253: Named placeholders should not be numeric values
+dotnet_diagnostic.CA2253.severity = warning
+
+# CA2254: Template should be a static expression
+dotnet_diagnostic.CA2254.severity = none
+
+# CA2255: The 'ModuleInitializer' attribute should not be used in libraries
+dotnet_diagnostic.CA2255.severity = warning
+
+# CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+dotnet_diagnostic.CA2256.severity = warning
+
+# CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+dotnet_diagnostic.CA2257.severity = warning
+
+# CA2258: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+dotnet_diagnostic.CA2258.severity = warning
+
+# CA2259: 'ThreadStatic' only affects static fields
+dotnet_diagnostic.CA2259.severity = warning
+
+# CA2300: Do not use insecure deserializer BinaryFormatter
+dotnet_diagnostic.CA2300.severity = none
+
+# CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+dotnet_diagnostic.CA2301.severity = none
+
+# CA2302: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+dotnet_diagnostic.CA2302.severity = none
+
+# CA2305: Do not use insecure deserializer LosFormatter
+dotnet_diagnostic.CA2305.severity = none
+
+# CA2310: Do not use insecure deserializer NetDataContractSerializer
+dotnet_diagnostic.CA2310.severity = none
+
+# CA2311: Do not deserialize without first setting NetDataContractSerializer.Binder
+dotnet_diagnostic.CA2311.severity = none
+
+# CA2312: Ensure NetDataContractSerializer.Binder is set before deserializing
+dotnet_diagnostic.CA2312.severity = none
+
+# CA2315: Do not use insecure deserializer ObjectStateFormatter
+dotnet_diagnostic.CA2315.severity = none
+
+# CA2321: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+dotnet_diagnostic.CA2321.severity = none
+
+# CA2322: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+dotnet_diagnostic.CA2322.severity = none
+
+# CA2326: Do not use TypeNameHandling values other than None
+dotnet_diagnostic.CA2326.severity = none
+
+# CA2327: Do not use insecure JsonSerializerSettings
+dotnet_diagnostic.CA2327.severity = none
+
+# CA2328: Ensure that JsonSerializerSettings are secure
+dotnet_diagnostic.CA2328.severity = none
+
+# CA2329: Do not deserialize with JsonSerializer using an insecure configuration
+dotnet_diagnostic.CA2329.severity = none
+
+# CA2330: Ensure that JsonSerializer has a secure configuration when deserializing
+dotnet_diagnostic.CA2330.severity = none
+
+# CA2350: Do not use DataTable.ReadXml() with untrusted data
+dotnet_diagnostic.CA2350.severity = none
+
+# CA2351: Do not use DataSet.ReadXml() with untrusted data
+dotnet_diagnostic.CA2351.severity = none
+
+# CA2352: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+dotnet_diagnostic.CA2352.severity = none
+
+# CA2353: Unsafe DataSet or DataTable in serializable type
+dotnet_diagnostic.CA2353.severity = none
+
+# CA2354: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+dotnet_diagnostic.CA2354.severity = none
+
+# CA2355: Unsafe DataSet or DataTable type found in deserializable object graph
+dotnet_diagnostic.CA2355.severity = none
+
+# CA2356: Unsafe DataSet or DataTable type in web deserializable object graph
+dotnet_diagnostic.CA2356.severity = none
+
+# CA2361: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+dotnet_diagnostic.CA2361.severity = none
+
+# CA2362: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+dotnet_diagnostic.CA2362.severity = none
+
+# CA3001: Review code for SQL injection vulnerabilities
+dotnet_diagnostic.CA3001.severity = none
+
+# CA3002: Review code for XSS vulnerabilities
+dotnet_diagnostic.CA3002.severity = none
+
+# CA3003: Review code for file path injection vulnerabilities
+dotnet_diagnostic.CA3003.severity = none
+
+# CA3004: Review code for information disclosure vulnerabilities
+dotnet_diagnostic.CA3004.severity = none
+
+# CA3005: Review code for LDAP injection vulnerabilities
+dotnet_diagnostic.CA3005.severity = none
+
+# CA3006: Review code for process command injection vulnerabilities
+dotnet_diagnostic.CA3006.severity = none
+
+# CA3007: Review code for open redirect vulnerabilities
+dotnet_diagnostic.CA3007.severity = none
+
+# CA3008: Review code for XPath injection vulnerabilities
+dotnet_diagnostic.CA3008.severity = none
+
+# CA3009: Review code for XML injection vulnerabilities
+dotnet_diagnostic.CA3009.severity = none
+
+# CA3010: Review code for XAML injection vulnerabilities
+dotnet_diagnostic.CA3010.severity = none
+
+# CA3011: Review code for DLL injection vulnerabilities
+dotnet_diagnostic.CA3011.severity = none
+
+# CA3012: Review code for regex injection vulnerabilities
+dotnet_diagnostic.CA3012.severity = none
+
+# CA3061: Do Not Add Schema By URL
+dotnet_diagnostic.CA3061.severity = warning
+
+# CA3075: Insecure DTD processing in XML
+dotnet_diagnostic.CA3075.severity = warning
+
+# CA3076: Insecure XSLT script processing.
+dotnet_diagnostic.CA3076.severity = warning
+
+# CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
+dotnet_diagnostic.CA3077.severity = warning
+
+# CA3147: Mark Verb Handlers With Validate Antiforgery Token
+dotnet_diagnostic.CA3147.severity = warning
+
+# CA5350: Do Not Use Weak Cryptographic Algorithms
+dotnet_diagnostic.CA5350.severity = warning
+
+# CA5351: Do Not Use Broken Cryptographic Algorithms
+dotnet_diagnostic.CA5351.severity = warning
+
+# CA5358: Review cipher mode usage with cryptography experts
+dotnet_diagnostic.CA5358.severity = none
+
+# CA5359: Do Not Disable Certificate Validation
+dotnet_diagnostic.CA5359.severity = warning
+
+# CA5360: Do Not Call Dangerous Methods In Deserialization
+dotnet_diagnostic.CA5360.severity = warning
+
+# CA5361: Do Not Disable SChannel Use of Strong Crypto
+dotnet_diagnostic.CA5361.severity = warning
+
+# CA5362: Potential reference cycle in deserialized object graph
+dotnet_diagnostic.CA5362.severity = none
+
+# CA5363: Do Not Disable Request Validation
+dotnet_diagnostic.CA5363.severity = warning
+
+# CA5364: Do Not Use Deprecated Security Protocols
+dotnet_diagnostic.CA5364.severity = warning
+
+# CA5365: Do Not Disable HTTP Header Checking
+dotnet_diagnostic.CA5365.severity = warning
+
+# CA5366: Use XmlReader for 'DataSet.ReadXml()'
+dotnet_diagnostic.CA5366.severity = none
+
+# CA5367: Do Not Serialize Types With Pointer Fields
+dotnet_diagnostic.CA5367.severity = none
+
+# CA5368: Set ViewStateUserKey For Classes Derived From Page
+dotnet_diagnostic.CA5368.severity = warning
+
+# CA5369: Use XmlReader for 'XmlSerializer.Deserialize()'
+dotnet_diagnostic.CA5369.severity = none
+
+# CA5370: Use XmlReader for XmlValidatingReader constructor
+dotnet_diagnostic.CA5370.severity = warning
+
+# CA5371: Use XmlReader for 'XmlSchema.Read()'
+dotnet_diagnostic.CA5371.severity = none
+
+# CA5372: Use XmlReader for XPathDocument constructor
+dotnet_diagnostic.CA5372.severity = none
+
+# CA5373: Do not use obsolete key derivation function
+dotnet_diagnostic.CA5373.severity = warning
+
+# CA5374: Do Not Use XslTransform
+dotnet_diagnostic.CA5374.severity = warning
+
+# CA5375: Do Not Use Account Shared Access Signature
+dotnet_diagnostic.CA5375.severity = none
+
+# CA5376: Use SharedAccessProtocol HttpsOnly
+dotnet_diagnostic.CA5376.severity = warning
+
+# CA5377: Use Container Level Access Policy
+dotnet_diagnostic.CA5377.severity = warning
+
+# CA5378: Do not disable ServicePointManagerSecurityProtocols
+dotnet_diagnostic.CA5378.severity = warning
+
+# CA5379: Ensure Key Derivation Function algorithm is sufficiently strong
+dotnet_diagnostic.CA5379.severity = warning
+
+# CA5380: Do Not Add Certificates To Root Store
+dotnet_diagnostic.CA5380.severity = warning
+
+# CA5381: Ensure Certificates Are Not Added To Root Store
+dotnet_diagnostic.CA5381.severity = warning
+
+# CA5382: Use Secure Cookies In ASP.NET Core
+dotnet_diagnostic.CA5382.severity = none
+
+# CA5383: Ensure Use Secure Cookies In ASP.NET Core
+dotnet_diagnostic.CA5383.severity = none
+
+# CA5384: Do Not Use Digital Signature Algorithm (DSA)
+dotnet_diagnostic.CA5384.severity = warning
+
+# CA5385: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+dotnet_diagnostic.CA5385.severity = warning
+
+# CA5386: Avoid hardcoding SecurityProtocolType value
+dotnet_diagnostic.CA5386.severity = none
+
+# CA5387: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+dotnet_diagnostic.CA5387.severity = none
+
+# CA5388: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+dotnet_diagnostic.CA5388.severity = none
+
+# CA5389: Do Not Add Archive Item's Path To The Target File System Path
+dotnet_diagnostic.CA5389.severity = none
+
+# CA5390: Do not hard-code encryption key
+dotnet_diagnostic.CA5390.severity = none
+
+# CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers
+dotnet_diagnostic.CA5391.severity = none
+
+# CA5392: Use DefaultDllImportSearchPaths attribute for P/Invokes
+dotnet_diagnostic.CA5392.severity = none
+
+# CA5393: Do not use unsafe DllImportSearchPath value
+dotnet_diagnostic.CA5393.severity = none
+
+# CA5394: Do not use insecure randomness
+dotnet_diagnostic.CA5394.severity = none
+
+# CA5395: Miss HttpVerb attribute for action methods
+dotnet_diagnostic.CA5395.severity = none
+
+# CA5396: Set HttpOnly to true for HttpCookie
+dotnet_diagnostic.CA5396.severity = none
+
+# CA5397: Do not use deprecated SslProtocols values
+dotnet_diagnostic.CA5397.severity = none
+
+# CA5398: Avoid hardcoded SslProtocols values
+dotnet_diagnostic.CA5398.severity = none
+
+# CA5399: HttpClients should enable certificate revocation list checks
+dotnet_diagnostic.CA5399.severity = none
+
+# CA5400: Ensure HttpClient certificate revocation list check is not disabled
+dotnet_diagnostic.CA5400.severity = none
+
+# CA5401: Do not use CreateEncryptor with non-default IV
+dotnet_diagnostic.CA5401.severity = none
+
+# CA5402: Use CreateEncryptor with the default IV
+dotnet_diagnostic.CA5402.severity = none
+
+# CA5403: Do not hard-code certificate
+dotnet_diagnostic.CA5403.severity = none
+
+# CA5404: Do not disable token validation checks
+dotnet_diagnostic.CA5404.severity = none
+
+# CA5405: Do not always skip token validation in delegates
+dotnet_diagnostic.CA5405.severity = none
+
+## SA Analyzer warnings
+
+# SA0001: XML comments
+dotnet_diagnostic.SA0001.severity = none
+
+# SA1000: Spacing around keywords
+# suggestion until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3478 is resolved
+dotnet_diagnostic.SA1000.severity = suggestion
+
+# SA1001: Commas should not be preceded by whitespace
+dotnet_diagnostic.SA1001.severity = warning
+
+# SA1002: Semicolons should not be preceded by a space
+dotnet_diagnostic.SA1002.severity = none
+
+# SA1003: Operator should not appear at the end of a line
+dotnet_diagnostic.SA1003.severity = none
+
+# SA1004: Documentation line should begin with a space
+dotnet_diagnostic.SA1004.severity = none
+
+# SA1005: Single line comment should begin with a space
+dotnet_diagnostic.SA1005.severity = none
+
+# SA1008: Opening parenthesis should not be preceded by a space
+dotnet_diagnostic.SA1008.severity = none
+
+# SA1009: Closing parenthesis should not be followed by a space
+dotnet_diagnostic.SA1009.severity = none
+
+# SA1010: Opening square brackets should not be preceded by a space
+dotnet_diagnostic.SA1010.severity = none
+
+# SA1011: Closing square bracket should be followed by a space
+dotnet_diagnostic.SA1011.severity = none
+
+# SA1012: Opening brace should be followed by a space
+dotnet_diagnostic.SA1012.severity = none
+
+# SA1013: Closing brace should be preceded by a space
+dotnet_diagnostic.SA1013.severity = none
+
+# SA1014: Opening generic brackets should not be preceded by a space
+dotnet_diagnostic.SA1014.severity = warning
+
+# SA1015: Closing generic bracket should not be followed by a space
+dotnet_diagnostic.SA1015.severity = none
+
+# SA1018: Nullable type symbol should not be preceded by a space
+dotnet_diagnostic.SA1018.severity = warning
+
+# SA1020: Increment symbol should not be preceded by a space
+dotnet_diagnostic.SA1020.severity = warning
+
+# SA1021: Negative sign should be preceded by a space
+dotnet_diagnostic.SA1021.severity = none
+
+# SA1023: Dereference symbol '*' should not be preceded by a space."
+dotnet_diagnostic.SA1023.severity = none
+
+# SA1024: Colon should be followed by a space
+dotnet_diagnostic.SA1024.severity = none
+
+# SA1025: Code should not contain multiple whitespace characters in a row
+dotnet_diagnostic.SA1025.severity = none
+
+# SA1026: Keyword followed by span or blank line
+dotnet_diagnostic.SA1026.severity = warning
+
+# SA1027: Tabs and spaces should be used correctly
+dotnet_diagnostic.SA1027.severity = warning
+
+# SA1028: Code should not contain trailing whitespace
+dotnet_diagnostic.SA1028.severity = warning
+
+# SA1100: Do not prefix calls with base unless local implementation exists
+dotnet_diagnostic.SA1100.severity = none
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# SA1102: Query clause should follow previous clause
+dotnet_diagnostic.SA1102.severity = warning
+
+# SA1105: Query clauses spanning multiple lines should begin on own line
+dotnet_diagnostic.SA1105.severity = warning
+
+# SA1106: Code should not contain empty statements
+dotnet_diagnostic.SA1106.severity = none
+
+# SA1107: Code should not contain multiple statements on one line
+dotnet_diagnostic.SA1107.severity = none
+
+# SA1108: Block statements should not contain embedded comments
+dotnet_diagnostic.SA1108.severity = none
+
+# SA1110: Opening parenthesis or bracket should be on declaration line
+dotnet_diagnostic.SA1110.severity = none
+
+# SA1111: Closing parenthesis should be on line of last parameter
+dotnet_diagnostic.SA1111.severity = none
+
+# SA1113: Comma should be on the same line as previous parameter
+dotnet_diagnostic.SA1113.severity = warning
+
+# SA1114: Parameter list should follow declaration
+dotnet_diagnostic.SA1114.severity = none
+
+# SA1115: Parameter should begin on the line after the previous parameter
+dotnet_diagnostic.SA1115.severity = warning
+
+# SA1116: Split parameters should start on line after declaration
+dotnet_diagnostic.SA1116.severity = none
+
+# SA1117: Parameters should be on same line or separate lines
+dotnet_diagnostic.SA1117.severity = none
+
+# SA1118: Parameter should not span multiple lines
+dotnet_diagnostic.SA1118.severity = none
+
+# SA1119: Statement should not use unnecessary parenthesis
+dotnet_diagnostic.SA1119.severity = none
+
+# SA1120: Comments should contain text
+dotnet_diagnostic.SA1120.severity = none
+
+# SA1121: Use built-in type alias
+dotnet_diagnostic.SA1121.severity = warning
+
+# SA1122: Use string.Empty for empty strings
+dotnet_diagnostic.SA1122.severity = none
+
+# SA1123: Region should not be located within a code element
+dotnet_diagnostic.SA1123.severity = none
+
+# SA1124: Do not use regions
+dotnet_diagnostic.SA1124.severity = none
+
+# SA1125: Use shorthand for nullable types
+dotnet_diagnostic.SA1125.severity = none
+
+# SA1127: Generic type constraints should be on their own line
+dotnet_diagnostic.SA1127.severity = none
+
+# SA1128: Put constructor initializers on their own line
+dotnet_diagnostic.SA1128.severity = none
+
+# SA1129: Do not use default value type constructor
+dotnet_diagnostic.SA1129.severity = warning
+
+# SA1130: Use lambda syntax
+dotnet_diagnostic.SA1130.severity = none
+
+# SA1131: Constant values should appear on the right-hand side of comparisons
+dotnet_diagnostic.SA1131.severity = none
+
+# SA1132: Do not combine fields
+dotnet_diagnostic.SA1132.severity = none
+
+# SA1133: Do not combine attributes
+dotnet_diagnostic.SA1133.severity = none
+
+# SA1134: Each attribute should be placed on its own line of code
+dotnet_diagnostic.SA1134.severity = none
+
+# SA1135: Using directive should be qualified
+dotnet_diagnostic.SA1135.severity = none
+
+# SA1136: Enum values should be on separate lines
+dotnet_diagnostic.SA1136.severity = none
+
+# SA1137: Elements should have the same indentation
+dotnet_diagnostic.SA1137.severity = none
+
+# SA1139: Use literal suffix notation instead of casting
+dotnet_diagnostic.SA1139.severity = none
+
+# SA1141: Use tuple syntax
+dotnet_diagnostic.SA1141.severity = warning
+
+# SA1142: Refer to tuple elements by name
+dotnet_diagnostic.SA1142.severity = warning
+
+# SA1200: Using directive should appear within a namespace declaration
+dotnet_diagnostic.SA1200.severity = none
+
+# SA1201: Elements should appear in the correct order
+dotnet_diagnostic.SA1201.severity = none
+
+# SA1202: Elements should be ordered by access
+dotnet_diagnostic.SA1202.severity = none
+
+# SA1203: Constants should appear before fields
+dotnet_diagnostic.SA1203.severity = none
+
+# SA1204: Static elements should appear before instance elements
+dotnet_diagnostic.SA1204.severity = none
+
+# SA1205: Partial elements should declare an access modifier
+dotnet_diagnostic.SA1205.severity = warning
+
+# SA1206: Keyword ordering - TODO Re-enable as warning after https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3527
+dotnet_diagnostic.SA1206.severity = suggestion
+
+# SA1208: Using directive ordering
+dotnet_diagnostic.SA1208.severity = none
+
+# SA1209: Using alias directives should be placed after all using namespace directives
+dotnet_diagnostic.SA1209.severity = none
+
+# SA1210: Using directives should be ordered alphabetically by the namespaces
+dotnet_diagnostic.SA1210.severity = none
+
+# SA1211: Using alias directive ordering
+dotnet_diagnostic.SA1211.severity = none
+
+# SA1212: A get accessor appears after a set accessor within a property or indexer
+dotnet_diagnostic.SA1212.severity = warning
+
+# SA1214: Readonly fields should appear before non-readonly fields
+dotnet_diagnostic.SA1214.severity = none
+
+# SA1216: Using static directives should be placed at the correct location
+dotnet_diagnostic.SA1216.severity = none
+
+# SA1300: Element should begin with an uppercase letter
+dotnet_diagnostic.SA1300.severity = none
+
+# SA1302: Interface names should begin with I
+dotnet_diagnostic.SA1302.severity = warning
+
+# SA1303: Const field names should begin with upper-case letter
+dotnet_diagnostic.SA1303.severity = none
+
+# SA1304: Non-private readonly fields should begin with upper-case letter
+dotnet_diagnostic.SA1304.severity = none
+
+# SA1306: Field should begin with lower-case letter
+dotnet_diagnostic.SA1306.severity = none
+
+# SA1307: Field should begin with upper-case letter
+dotnet_diagnostic.SA1307.severity = none
+
+# SA1308: Field should not begin with the prefix 's_'
+dotnet_diagnostic.SA1308.severity = none
+
+# SA1309: Field names should not begin with underscore
+dotnet_diagnostic.SA1309.severity = none
+
+# SA1310: Field should not contain an underscore
+dotnet_diagnostic.SA1310.severity = none
+
+# SA1311: Static readonly fields should begin with upper-case letter
+dotnet_diagnostic.SA1311.severity = none
+
+# SA1312: Variable should begin with lower-case letter
+dotnet_diagnostic.SA1312.severity = none
+
+# SA1313: Parameter should begin with lower-case letter
+dotnet_diagnostic.SA1313.severity = none
+
+# SA1314: Type parameter names should begin with T
+dotnet_diagnostic.SA1314.severity = none
+
+# SA1316: Tuple element names should use correct casing
+dotnet_diagnostic.SA1316.severity = none
+
+# SA1400: Member should declare an access modifier
+dotnet_diagnostic.SA1400.severity = warning
+
+# SA1401: Fields should be private
+dotnet_diagnostic.SA1401.severity = none
+
+# SA1402: File may only contain a single type
+dotnet_diagnostic.SA1402.severity = none
+
+# SA1403: File may only contain a single namespace
+dotnet_diagnostic.SA1403.severity = none
+
+# SA1404: Code analysis suppression should have justification
+dotnet_diagnostic.SA1404.severity = warning
+
+# SA1405: Debug.Assert should provide message text
+dotnet_diagnostic.SA1405.severity = none
+
+# SA1407: Arithmetic expressions should declare precedence
+dotnet_diagnostic.SA1407.severity = none
+
+# SA1408: Conditional expressions should declare precedence
+dotnet_diagnostic.SA1408.severity = none
+
+# SA1410: Remove delegate parens when possible
+dotnet_diagnostic.SA1410.severity = warning
+
+# SA1411: Attribute constructor shouldn't use unnecessary parenthesis
+dotnet_diagnostic.SA1411.severity = warning
+
+# SA1413: Use trailing comma in multi-line initializers
+dotnet_diagnostic.SA1413.severity = none
+
+# SA1414: Tuple types in signatures should have element names
+dotnet_diagnostic.SA1414.severity = none
+
+# SA1500: Braces for multi-line statements should not share line
+dotnet_diagnostic.SA1500.severity = none
+
+# SA1501: Statement should not be on a single line
+dotnet_diagnostic.SA1501.severity = none
+
+# SA1502: Element should not be on a single line
+dotnet_diagnostic.SA1502.severity = none
+
+# SA1503: Braces should not be omitted
+dotnet_diagnostic.SA1503.severity = none
+
+# SA1504: All accessors should be single-line or multi-line
+dotnet_diagnostic.SA1504.severity = none
+
+# SA1505: An opening brace should not be followed by a blank line
+dotnet_diagnostic.SA1505.severity = none
+
+# SA1506: Element documentation headers should not be followed by blank line
+dotnet_diagnostic.SA1506.severity = none
+
+# SA1507: Code should not contain multiple blank lines in a row
+dotnet_diagnostic.SA1507.severity = none
+
+# SA1508: A closing brace should not be preceded by a blank line
+dotnet_diagnostic.SA1508.severity = none
+
+# SA1509: Opening braces should not be preceded by blank line
+dotnet_diagnostic.SA1509.severity = none
+
+# SA1510: 'else' statement should not be preceded by a blank line
+dotnet_diagnostic.SA1510.severity = none
+
+# SA1512: Single-line comments should not be followed by blank line
+dotnet_diagnostic.SA1512.severity = none
+
+# SA1513: Closing brace should be followed by blank line
+dotnet_diagnostic.SA1513.severity = none
+
+# SA1514: Element documentation header should be preceded by blank line
+dotnet_diagnostic.SA1514.severity = none
+
+# SA1515: Single-line comment should be preceded by blank line
+dotnet_diagnostic.SA1515.severity = none
+
+# SA1516: Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = none
+
+# SA1517: Code should not contain blank lines at start of file
+dotnet_diagnostic.SA1517.severity = warning
+
+# SA1518: Code should not contain blank lines at the end of the file
+dotnet_diagnostic.SA1518.severity = warning
+
+# SA1519: Braces should not be omitted from multi-line child statement
+dotnet_diagnostic.SA1519.severity = none
+
+# SA1520: Use braces consistently
+dotnet_diagnostic.SA1520.severity = none
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# SA1601: Partial elements should be documented
+dotnet_diagnostic.SA1601.severity = none
+
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = none
+
+# SA1604: Element documentation should have summary
+dotnet_diagnostic.SA1604.severity = none
+
+# SA1605: Partial element documentation should have summary
+dotnet_diagnostic.SA1605.severity = none
+
+# SA1606: Element documentation should have summary text
+dotnet_diagnostic.SA1606.severity = none
+
+# SA1608: Element documentation should not have default summary
+dotnet_diagnostic.SA1608.severity = none
+
+# SA1610: Property documentation should have value text
+dotnet_diagnostic.SA1610.severity = none
+
+# SA1611: The documentation for parameter 'message' is missing
+dotnet_diagnostic.SA1611.severity = none
+
+# SA1612: The parameter documentation is at incorrect position
+dotnet_diagnostic.SA1612.severity = none
+
+# SA1614: Element parameter documentation should have text
+dotnet_diagnostic.SA1614.severity = none
+
+# SA1615: Element return value should be documented
+dotnet_diagnostic.SA1615.severity = none
+
+# SA1616: Element return value documentation should have text
+dotnet_diagnostic.SA1616.severity = none
+
+# SA1618: The documentation for type parameter is missing
+dotnet_diagnostic.SA1618.severity = none
+
+# SA1619: The documentation for type parameter is missing
+dotnet_diagnostic.SA1619.severity = none
+
+# SA1622: Generic type parameter documentation should have text
+dotnet_diagnostic.SA1622.severity = none
+
+# SA1623: Property documentation text
+dotnet_diagnostic.SA1623.severity = none
+
+# SA1624: Because the property only contains a visible get accessor, the documentation summary text should begin with 'Gets'
+dotnet_diagnostic.SA1624.severity = none
+
+# SA1625: Element documentation should not be copied and pasted
+dotnet_diagnostic.SA1625.severity = none
+
+# SA1626: Single-line comments should not use documentation style slashes
+dotnet_diagnostic.SA1626.severity = none
+
+# SA1627: The documentation text within the \'exception\' tag should not be empty
+dotnet_diagnostic.SA1627.severity = none
+
+# SA1629: Documentation text should end with a period
+dotnet_diagnostic.SA1629.severity = none
+
+# SA1633: File should have header
+dotnet_diagnostic.SA1633.severity = none
+
+# SA1642: Constructor summary documentation should begin with standard text
+dotnet_diagnostic.SA1642.severity = none
+
+# SA1643: Destructor summary documentation should begin with standard text
+dotnet_diagnostic.SA1643.severity = none
+
+# SA1649: File name should match first type name
+dotnet_diagnostic.SA1649.severity = none
+
+## IDE analyzer rules
+
+# IDE0001: Simplify name
+dotnet_diagnostic.IDE0001.severity = suggestion
+
+# IDE0002: Simplify member access
+dotnet_diagnostic.IDE0002.severity = suggestion
+
+# IDE0003: Remove this or Me qualification
+dotnet_diagnostic.IDE0003.severity = suggestion
+
 # IDE0004: Remove unnecessary cast
 dotnet_diagnostic.IDE0004.severity = warning
 
 # IDE0005: Remove unnecessary usings/imports
 dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0007: Use implicit type
+dotnet_diagnostic.IDE0007.severity = silent
+
+# IDE0008: Use explicit type
+dotnet_diagnostic.IDE0008.severity = suggestion
+
+# IDE0009: Add this or Me qualification
+dotnet_diagnostic.IDE0009.severity = silent
+
+# IDE0010: Add missing cases
+dotnet_diagnostic.IDE0010.severity = silent
+
+# IDE0011: Add braces
+dotnet_diagnostic.IDE0011.severity = silent
+
+# IDE0016: Use 'throw' expression
+dotnet_diagnostic.IDE0016.severity = silent
+
+# IDE0017: Simplify object initialization
+dotnet_diagnostic.IDE0017.severity = suggestion
+
+# IDE0018: Inline variable declaration
+dotnet_diagnostic.IDE0018.severity = suggestion
 
 # IDE0019: Use pattern matching
 dotnet_diagnostic.IDE0019.severity = warning
@@ -52,11 +1400,47 @@ dotnet_diagnostic.IDE0019.severity = warning
 # IDE0020: Use pattern matching
 dotnet_diagnostic.IDE0020.severity = warning
 
+# IDE0021: Use expression body for constructors
+dotnet_diagnostic.IDE0021.severity = silent
+
+# IDE0022: Use expression body for methods
+dotnet_diagnostic.IDE0022.severity = silent
+
+# IDE0023: Use expression body for operators
+dotnet_diagnostic.IDE0023.severity = silent
+
+# IDE0024: Use expression body for operators
+dotnet_diagnostic.IDE0024.severity = silent
+
+# IDE0025: Use expression body for properties
+dotnet_diagnostic.IDE0025.severity = silent
+
+# IDE0026: Use expression body for indexers
+dotnet_diagnostic.IDE0026.severity = silent
+
+# IDE0027: Use expression body for accessors
+dotnet_diagnostic.IDE0027.severity = silent
+
+# IDE0028: Simplify collection initialization
+dotnet_diagnostic.IDE0028.severity = suggestion
+
 # IDE0029: Null check can be simplified
 dotnet_diagnostic.IDE0029.severity = warning
 
+# IDE0030: Use coalesce expression
+dotnet_diagnostic.IDE0030.severity = warning
+
 # IDE0031: Null check can be simplified
 dotnet_diagnostic.IDE0031.severity = warning
+
+# IDE0032: Use auto property
+dotnet_diagnostic.IDE0032.severity = silent
+
+# IDE0033: Use explicitly provided tuple name
+dotnet_diagnostic.IDE0033.severity = suggestion
+
+# IDE0034: Simplify 'default' expression
+dotnet_diagnostic.IDE0034.severity = suggestion
 
 # IDE0035: Remove unreachable code
 dotnet_diagnostic.IDE0035.severity = warning
@@ -64,11 +1448,23 @@ dotnet_diagnostic.IDE0035.severity = warning
 # IDE0036: Order modifiers
 dotnet_diagnostic.IDE0036.severity = warning
 
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = silent
+
+# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0038.severity = suggestion
+
 # IDE0039: Prefer local functions over anonymous functions
 dotnet_diagnostic.IDE0039.severity = warning
 
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = suggestion
+
 # IDE0041: Null check can be simplified
 dotnet_diagnostic.IDE0041.severity = warning
+
+# IDE0042: Deconstruct variable declaration
+dotnet_diagnostic.IDE0042.severity = silent
 
 # IDE0043: Format string contains invalid placeholder
 dotnet_diagnostic.IDE0043.severity = warning
@@ -76,8 +1472,20 @@ dotnet_diagnostic.IDE0043.severity = warning
 # IDE0044: Make field readonly
 dotnet_diagnostic.IDE0044.severity = warning
 
+# IDE0045: Use conditional expression for assignment
+dotnet_diagnostic.IDE0045.severity = suggestion
+
+# IDE0046: Use conditional expression for return
+dotnet_diagnostic.IDE0046.severity = suggestion
+
 # IDE0047: Parentheses can be removed
 dotnet_diagnostic.IDE0047.severity = warning
+
+# IDE0048: Add parentheses for clarity
+dotnet_diagnostic.IDE0048.severity = silent
+
+# IDE0049: Use language keywords instead of framework type names for type references
+dotnet_diagnostic.IDE0049.severity = warning
 
 # IDE0051: Remove unused private members (no reads or writes)
 dotnet_diagnostic.IDE0051.severity = warning
@@ -91,14 +1499,50 @@ dotnet_diagnostic.IDE0053.severity = warning
 # IDE0054: Use compound assignment
 dotnet_diagnostic.IDE0054.severity = warning
 
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = suggestion
+
+# IDE0056: Use index operator
+dotnet_diagnostic.IDE0056.severity = suggestion
+
+# IDE0057: Use range operator
+dotnet_diagnostic.IDE0057.severity = suggestion
+
+# IDE0058: Expression value is never used
+dotnet_diagnostic.IDE0058.severity = silent
+
 # IDE0059: Unnecessary assignment to a value
 dotnet_diagnostic.IDE0059.severity = warning
 
 # IDE0060: Remove unused parameter
 dotnet_diagnostic.IDE0060.severity = warning
 
+# IDE0061: Use expression body for local functions
+dotnet_diagnostic.IDE0061.severity = silent
+
+# IDE0062: Make local function 'static'
+dotnet_diagnostic.IDE0062.severity = warning
+
+# IDE0063: Use simple 'using' statement
+dotnet_diagnostic.IDE0063.severity = silent
+
+# IDE0064: Make readonly fields writable
+dotnet_diagnostic.IDE0064.severity = silent
+
 # IDE0065: Using directives to be placed outside the namespace
 dotnet_diagnostic.IDE0065.severity = warning
+
+# IDE0066: Convert switch statement to expression
+dotnet_diagnostic.IDE0066.severity = suggestion
+
+# IDE0070: Use 'System.HashCode'
+dotnet_diagnostic.IDE0070.severity = suggestion
+
+# IDE0071: Simplify interpolation
+dotnet_diagnostic.IDE0071.severity = warning
+
+# IDE0072: Add missing cases
+dotnet_diagnostic.IDE0072.severity = silent
 
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning
@@ -107,39 +1551,114 @@ file_header_template = Copyright (c) .NET Foundation and contributors. All right
 # IDE0074: Use compound assignment
 dotnet_diagnostic.IDE0074.severity = warning
 
+# IDE0075: Simplify conditional expression
+dotnet_diagnostic.IDE0075.severity = silent
+
+# IDE0076: Invalid global 'SuppressMessageAttribute'
+dotnet_diagnostic.IDE0076.severity = warning
+
+# IDE0077: Avoid legacy format target in 'SuppressMessageAttribute'
+dotnet_diagnostic.IDE0077.severity = silent
+
+# IDE0078: Use pattern matching
+dotnet_diagnostic.IDE0078.severity = suggestion
+
+# IDE0079: Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = suggestion
+
+# IDE0080: Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0080.severity = warning
+
+# IDE0081: Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0081.severity = none
+
 # IDE0082: Convert typeof to nameof
 dotnet_diagnostic.IDE0082.severity = warning
 
 # IDE0083: Use is not pattern matching
 #dotnet_diagnostic.IDE0083.severity = warning // requires new C# for Mono
 
+# IDE0084: Use pattern matching (IsNot operator)
+dotnet_diagnostic.IDE0084.severity = none
+
+# IDE0090: Use 'new(...)'
+dotnet_diagnostic.IDE0090.severity = silent
+
+# IDE0100: Remove redundant equality
+dotnet_diagnostic.IDE0100.severity = warning
+
 # IDE0110: Remove unnecessary discard
 dotnet_diagnostic.IDE0110.severity = warning
 
-## CA analyzer rules
-dotnet_analyzer_diagnostic.category-performance.severity = warning
-dotnet_analyzer_diagnostic.category-maintainability.severity = warning
-dotnet_analyzer_diagnostic.category-reliability.severity = warning
-dotnet_analyzer_diagnostic.category-usage.severity = warning
-#dotnet_analyzer_diagnostic.category-style.severity = warning
+# IDE0120: Simplify LINQ expression
+dotnet_diagnostic.IDE0120.severity = none
 
-# call GC.SuppressFinalize(object)
-dotnet_diagnostic.CA1816.severity = none
+# IDE0130: Namespace does not match folder structure
+dotnet_diagnostic.IDE0130.severity = silent
 
-# CA1834: Use 'StringBuilder.Append(char)'
-dotnet_diagnostic.CA1834.severity = none
+# IDE0140: Simplify object creation
+dotnet_diagnostic.IDE0140.severity = none
+
+# IDE0150: Prefer 'null' check over type check
+dotnet_diagnostic.IDE0150.severity = silent
+
+# IDE0160: Convert to block scoped namespace
+dotnet_diagnostic.IDE0160.severity = silent
+
+# IDE0161: Convert to file-scoped namespace
+dotnet_diagnostic.IDE0161.severity = silent
+
+# IDE0170: Simplify property pattern
+dotnet_diagnostic.IDE0170.severity = warning
+
+# IDE0180: Use tuple swap
+dotnet_diagnostic.IDE0180.severity = suggestion
+
+# IDE0200: Remove unnecessary lambda expression
+dotnet_diagnostic.IDE0200.severity = warning
+
+# IDE0210: Use top-level statements
+dotnet_diagnostic.IDE0210.severity = silent
+
+# IDE0211: Use program main
+dotnet_diagnostic.IDE0211.severity = silent
+
+# IDE0220: foreach cast
+dotnet_diagnostic.IDE0220.severity = silent
+
+# IDE0230: Use UTF8 string literal
+dotnet_diagnostic.IDE0230.severity = suggestion
+
+# IDE1005: Delegate invocation can be simplified.
+dotnet_diagnostic.IDE1005.severity = warning
+
+# IDE1006: Naming styles
+dotnet_diagnostic.IDE1006.severity = silent
+
+# IDE2000: Allow multiple blank lines
+dotnet_diagnostic.IDE2000.severity = silent
+
+# IDE2001: Embedded statements must be on their own line
+dotnet_diagnostic.IDE2001.severity = silent
+
+# IDE2002: Consecutive braces must not have blank line between them
+dotnet_diagnostic.IDE2002.severity = silent
+
+# IDE2003: Allow statement immediately after block
+dotnet_diagnostic.IDE2003.severity = silent
+
+# IDE2004: Blank line not allowed after constructor initializer colon
+dotnet_diagnostic.IDE2004.severity = silent
+
+## Other analyzer settings
 
 # RS2008 Ignore analyzer release tracking
 dotnet_diagnostic.RS2008.severity = none
 
-# Exception type is not sufficiently specific
-dotnet_diagnostic.CA2201.severity = none
-
 # xUnit1004: Test methods should not be skipped
 dotnet_diagnostic.xUnit1004.severity = none
 
-# CA1805: Member is explicitly initialized to it's default value
-dotnet_diagnostic.CA1805.severity = none
+### Folder specific configurations
 
 [src/linker/ref/**/*.cs]
 

--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -2,7 +2,7 @@
   <ItemGroup Condition="'$(RunAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" PrivateAssets="all" />
-    <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="all" /> -->
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="$(BootstrapBuildPath)/Microsoft.NET.ILLink.Analyzers.props" Condition="'$(BootstrapBuildPath)' != ''" />

--- a/src/ILLink.CodeFix/DynamicallyAccessedMembersCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/DynamicallyAccessedMembersCodeFixProvider.cs
@@ -69,15 +69,15 @@ namespace ILLink.CodeFix
 
 		private static readonly string[] AttributeOnReturn = {
 			DiagnosticId.DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsParameter.AsString (),
-			DiagnosticId.DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsMethodReturnType.AsString() ,
+			DiagnosticId.DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsMethodReturnType.AsString(),
 			DiagnosticId.DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsField.AsString (),
-			DiagnosticId.DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsThisParameter.AsString () ,
+			DiagnosticId.DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsThisParameter.AsString (),
 			DiagnosticId.DynamicallyAccessedMembersMismatchOnMethodReturnValueBetweenOverrides.AsString ()
 		};
 
 		private static readonly string[] AttributeOnGeneric = {
 			DiagnosticId.DynamicallyAccessedMembersMismatchTypeArgumentTargetsParameter.AsString(),
-			DiagnosticId.DynamicallyAccessedMembersMismatchTypeArgumentTargetsMethodReturnType.AsString () ,
+			DiagnosticId.DynamicallyAccessedMembersMismatchTypeArgumentTargetsMethodReturnType.AsString (),
 			DiagnosticId.DynamicallyAccessedMembersMismatchTypeArgumentTargetsField.AsString(),
 			DiagnosticId.DynamicallyAccessedMembersMismatchTypeArgumentTargetsThisParameter.AsString(),
 			DiagnosticId.DynamicallyAccessedMembersMismatchTypeArgumentTargetsGenericParameter.AsString(),

--- a/src/ILLink.CodeFix/RequiresAssemblyFilesCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresAssemblyFilesCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace ILLink.CodeFix
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 
-		protected override SyntaxNode[] GetAttributeArguments (ISymbol? attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic) => 
+		protected override SyntaxNode[] GetAttributeArguments (ISymbol? attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic) =>
 			RequiresHelpers.GetAttributeArgumentsForRequires (targetSymbol, syntaxGenerator, HasPublicAccessibility(attributableSymbol));
 	}
 }

--- a/src/ILLink.CodeFix/RequiresHelpers.cs
+++ b/src/ILLink.CodeFix/RequiresHelpers.cs
@@ -8,7 +8,7 @@ using ILLink.RoslynAnalyzer;
 
 namespace ILLink.CodeFixProvider
 {
-	sealed class RequiresHelpers
+	internal sealed class RequiresHelpers
 	{
 		internal static SyntaxNode[] GetAttributeArgumentsForRequires (ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, bool hasPublicAccessibility)
 		{

--- a/src/ILLink.CodeFix/UnconditionalSuppressMessageCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/UnconditionalSuppressMessageCodeFixProvider.cs
@@ -17,8 +17,8 @@ namespace ILLink.CodeFix
 	[ExportCodeFixProvider (LanguageNames.CSharp, Name = nameof (UnconditionalSuppressMessageCodeFixProvider)), Shared]
 	public class UnconditionalSuppressMessageCodeFixProvider : BaseAttributeCodeFixProvider
 	{
-		const string Justification = nameof (Justification);
-		const string UnconditionalSuppressMessageAttribute = nameof (UnconditionalSuppressMessageAttribute);
+		private const string Justification = nameof (Justification);
+		private const string UnconditionalSuppressMessageAttribute = nameof (UnconditionalSuppressMessageAttribute);
 		public const string FullyQualifiedUnconditionalSuppressMessageAttribute = "System.Diagnostics.CodeAnalysis." + UnconditionalSuppressMessageAttribute;
 
 		public sealed override ImmutableArray<string> FixableDiagnosticIds

--- a/src/ILLink.RoslynAnalyzer/COMAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/COMAnalyzer.cs
@@ -19,7 +19,7 @@ namespace ILLink.RoslynAnalyzer
 		private const string DllImportAttribute = nameof (DllImportAttribute);
 		private const string MarshalAsAttribute = nameof (MarshalAsAttribute);
 
-		static readonly DiagnosticDescriptor s_correctnessOfCOMCannotBeGuaranteed = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.CorrectnessOfCOMCannotBeGuaranteed,
+		private static readonly DiagnosticDescriptor s_correctnessOfCOMCannotBeGuaranteed = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.CorrectnessOfCOMCannotBeGuaranteed,
 			helpLinkUri: "https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-warnings/il2050");
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create (s_correctnessOfCOMCannotBeGuaranteed);

--- a/src/ILLink.RoslynAnalyzer/CompilationExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/CompilationExtensions.cs
@@ -73,7 +73,7 @@ namespace ILLink.RoslynAnalyzer
 
 			return type;
 		}
-		
+
 		// copied from https://github.com/dotnet/roslyn/blob/main/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
 		private static SymbolVisibility GetResultantVisibility (this ISymbol symbol)
 		{

--- a/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
@@ -35,12 +35,22 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		}
 
 		public bool Equals (CapturedReferenceValue other) => Reference == other.Reference;
+
+		public override bool Equals (object obj)
+		{
+			return obj is CapturedReferenceValue && Equals ((CapturedReferenceValue) obj);
+		}
+
+		public override int GetHashCode ()
+		{
+			throw new NotImplementedException ();
+		}
 	}
 
 
 	public struct CapturedReferenceLattice : ILattice<CapturedReferenceValue>
 	{
-		public CapturedReferenceValue Top => new CapturedReferenceValue ();
+		public CapturedReferenceValue Top => default (CapturedReferenceValue);
 
 		public CapturedReferenceValue Meet (CapturedReferenceValue left, CapturedReferenceValue right)
 		{

--- a/src/ILLink.RoslynAnalyzer/DataFlow/ControlFlowGraphProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/ControlFlowGraphProxy.cs
@@ -80,7 +80,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			return TryGetTryOrCatchOrFilter (regionProxy.Region.EnclosingRegion, out tryOrCatchOrFilterRegion);
 		}
 
-		static bool TryGetTryOrCatchOrFilter (ControlFlowRegion? region, out RegionProxy tryOrCatchOrFilterRegion)
+		private static bool TryGetTryOrCatchOrFilter (ControlFlowRegion? region, out RegionProxy tryOrCatchOrFilterRegion)
 		{
 			tryOrCatchOrFilterRegion = default;
 			// The check for ControlFlowRegionKind.Root prevents us from walking out to regions that

--- a/src/ILLink.RoslynAnalyzer/DataFlow/DynamicallyAccessedMembersBinder.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/DynamicallyAccessedMembersBinder.cs
@@ -367,7 +367,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		public static void GetAllOnType (this ITypeSymbol type, bool declaredOnly, List<ISymbol> members) => GetAllOnType (type, declaredOnly, members, new HashSet<ITypeSymbol> (SymbolEqualityComparer.Default));
 #pragma warning restore RS1024
 
-		static void GetAllOnType (ITypeSymbol type, bool declaredOnly, List<ISymbol> members, HashSet<ITypeSymbol> types)
+		private static void GetAllOnType (ITypeSymbol type, bool declaredOnly, List<ISymbol> members, HashSet<ITypeSymbol> types)
 		{
 			if (!types.Add (type))
 				return;

--- a/src/ILLink.RoslynAnalyzer/DataFlow/InterproceduralState.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/InterproceduralState.cs
@@ -10,7 +10,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 {
 	// Tracks the set of methods which get analyzed together during interprocedural analysis,
 	// and the possible states of hoisted locals in state machine methods and lambdas/local functions.
+#pragma warning disable CA1067 // Struct has its own Equals method
 	public struct InterproceduralState<TValue, TValueLattice> : IEquatable<InterproceduralState<TValue, TValueLattice>>
+#pragma warning restore CA1067 // Override Object.Equals(object) when implementing IEquatable<T>
 		where TValue : struct, IEquatable<TValue>
 		where TValueLattice : ILattice<TValue>
 	{
@@ -23,7 +25,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		// dictionary instead of the per-method dictionary.
 		public DefaultValueDictionary<LocalKey, Maybe<TValue>> HoistedLocals;
 
-		readonly InterproceduralStateLattice<TValue, TValueLattice> lattice;
+		private readonly InterproceduralStateLattice<TValue, TValueLattice> lattice;
 
 		public InterproceduralState (
 			ValueSet<MethodBodyValue> methods,
@@ -75,6 +77,11 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public bool TryGetHoistedLocal (LocalKey key, [NotNullWhen (true)] out TValue? value)
 			=> (value = HoistedLocals.Get (key).MaybeValue) != null;
+
+		public override int GetHashCode ()
+		{
+			throw new NotImplementedException ();
+		}
 	}
 
 	public struct InterproceduralStateLattice<TValue, TValueLattice> : ILattice<InterproceduralState<TValue, TValueLattice>>

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowAnalysis.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowAnalysis.cs
@@ -33,7 +33,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		protected readonly OperationBlockAnalysisContext Context;
 
-		readonly IOperation OperationBlock;
+		private readonly IOperation OperationBlock;
 
 		protected LocalDataFlowAnalysis (OperationBlockAnalysisContext context, IOperation operationBlock)
 		{
@@ -44,8 +44,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public void InterproceduralAnalyze ()
 		{
-			var methodGroupLattice = new ValueSetLattice<MethodBodyValue> ();
-			var hoistedLocalLattice = new DictionaryLattice<LocalKey, Maybe<TValue>, MaybeLattice<TValue, TLattice>> ();
+			var methodGroupLattice = default (ValueSetLattice<MethodBodyValue>);
+			var hoistedLocalLattice = default (DictionaryLattice<LocalKey, Maybe<TValue>, MaybeLattice<TValue, TLattice>>);
 			var interproceduralStateLattice = new InterproceduralStateLattice<TValue, TLattice> (
 				methodGroupLattice, hoistedLocalLattice);
 			var interproceduralState = interproceduralStateLattice.Top;
@@ -71,7 +71,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			}
 		}
 
-		void AnalyzeMethod (MethodBodyValue method, ref InterproceduralState<TValue, TLattice> interproceduralState)
+		private void AnalyzeMethod (MethodBodyValue method, ref InterproceduralState<TValue, TLattice> interproceduralState)
 		{
 			var cfg = method.ControlFlowGraph;
 			var lValueFlowCaptures = LValueFlowCapturesProvider.CreateLValueFlowCaptures (cfg);

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowState.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowState.cs
@@ -11,7 +11,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		where TValue : struct, IEquatable<TValue>
 		where TValueLattice : ILattice<TValue>
 	{
-		LocalState<TValue> current;
+		private LocalState<TValue> current;
 		public LocalState<TValue> Current {
 			get => current;
 			set => current = value;

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -36,10 +36,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public InterproceduralState<TValue, TValueLattice> InterproceduralState;
 
-		bool IsLValueFlowCapture (CaptureId captureId)
+		private bool IsLValueFlowCapture (CaptureId captureId)
 			=> lValueFlowCaptures.ContainsKey (captureId);
 
-		bool IsRValueFlowCapture (CaptureId captureId)
+		private bool IsRValueFlowCapture (CaptureId captureId)
 			=> !lValueFlowCaptures.TryGetValue (captureId, out var captureKind) || captureKind != FlowCaptureKind.LValueCapture;
 
 		public LocalDataFlowVisitor (
@@ -115,7 +115,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			return GetLocal (operation, state);
 		}
 
-		bool IsReferenceToCapturedVariable (ILocalReferenceOperation localReference)
+		private bool IsReferenceToCapturedVariable (ILocalReferenceOperation localReference)
 		{
 			var local = localReference.Local;
 
@@ -126,7 +126,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			return !ReferenceEquals (declaringSymbol, Method);
 		}
 
-		TValue GetLocal (ILocalReferenceOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
+		private TValue GetLocal (ILocalReferenceOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 		{
 			var local = new LocalKey (operation.Local);
 			if (IsReferenceToCapturedVariable (operation))
@@ -139,7 +139,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			return state.Get (local);
 		}
 
-		void SetLocal (ILocalReferenceOperation operation, TValue value, LocalDataFlowState<TValue, TValueLattice> state)
+		private void SetLocal (ILocalReferenceOperation operation, TValue value, LocalDataFlowState<TValue, TValueLattice> state)
 		{
 			var local = new LocalKey (operation.Local);
 			if (IsReferenceToCapturedVariable (operation))
@@ -275,7 +275,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// (don't have specific I*Operation types), such as pointer dereferences.
 				if (targetOperation.Kind is OperationKind.None)
 					break;
-				throw new NotImplementedException ($"{targetOperation.GetType ().ToString ()}: {targetOperation.Syntax.GetLocation ().GetLineSpan ()}");
+				throw new NotImplementedException ($"{targetOperation.GetType ()}: {targetOperation.Syntax.GetLocation ().GetLineSpan ()}");
 			}
 			return Visit (operation.Value, state);
 		}
@@ -286,7 +286,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			if (!operation.GetValueUsageInfo (Method).HasFlag (ValueUsageInfo.Read)) {
 				// There are known cases where this assert doesn't hold, because LValueFlowCaptureProvider
 				// produces the wrong result in some cases for flow captures with IsInitialization = true.
-				// https://github.com/dotnet/linker/issues/2749 
+				// https://github.com/dotnet/linker/issues/2749
 				// Debug.Assert (IsLValueFlowCapture (operation.Id));
 				return TopValue;
 			}
@@ -416,7 +416,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			return TopValue;
 		}
 
-		TValue ProcessMethodCall (
+		private TValue ProcessMethodCall (
 			IOperation operation,
 			IMethodSymbol method,
 			IOperation? instance,

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
@@ -10,9 +10,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 {
 	public readonly struct LocalKey : IEquatable<LocalKey>
 	{
-		readonly ILocalSymbol? Local;
+		private readonly ILocalSymbol? Local;
 
-		readonly CaptureId? CaptureId;
+		private readonly CaptureId? CaptureId;
 
 		public LocalKey (ILocalSymbol symbol) => (Local, CaptureId) = (symbol, null);
 
@@ -26,6 +26,16 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			if (Local != null)
 				return Local.ToString ();
 			return $"capture {CaptureId.GetHashCode ()}";
+		}
+
+		public override bool Equals (object obj)
+		{
+			return obj is LocalKey && Equals ((LocalKey) obj);
+		}
+
+		public override int GetHashCode ()
+		{
+			throw new NotImplementedException ();
 		}
 	}
 
@@ -41,7 +51,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public LocalState (TValue defaultValue)
 			: this (new DefaultValueDictionary<LocalKey, TValue> (defaultValue),
-				new DefaultValueDictionary<CaptureId, CapturedReferenceValue> (new CapturedReferenceValue ()))
+				new DefaultValueDictionary<CaptureId, CapturedReferenceValue> (default (CapturedReferenceValue)))
 		{
 		}
 
@@ -52,7 +62,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		}
 
 		public LocalState (DefaultValueDictionary<LocalKey, TValue> dictionary)
-			: this (dictionary, new DefaultValueDictionary<CaptureId, CapturedReferenceValue> (new CapturedReferenceValue ()))
+			: this (dictionary, new DefaultValueDictionary<CaptureId, CapturedReferenceValue> (default (CapturedReferenceValue)))
 		{
 		}
 
@@ -63,6 +73,16 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		public void Set (LocalKey key, TValue value) => Dictionary.Set (key, value);
 
 		public override string ToString () => Dictionary.ToString ();
+
+		public override bool Equals (object obj)
+		{
+			return obj is LocalState<TValue> && Equals ((LocalState<TValue>) obj);
+		}
+
+		public override int GetHashCode ()
+		{
+			throw new NotImplementedException ();
+		}
 	}
 
 	// Wrapper struct exists purely to substitute a concrete LocalKey for TKey of DictionaryLattice
@@ -76,7 +96,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		public LocalStateLattice (TValueLattice valueLattice)
 		{
 			Lattice = new DictionaryLattice<LocalKey, TValue, TValueLattice> (valueLattice);
-			CapturedReferenceLattice = new DictionaryLattice<CaptureId, CapturedReferenceValue, CapturedReferenceLattice> (new CapturedReferenceLattice ());
+			CapturedReferenceLattice = new DictionaryLattice<CaptureId, CapturedReferenceValue, CapturedReferenceLattice> (default (CapturedReferenceLattice));
 			Top = new (Lattice.Top);
 		}
 

--- a/src/ILLink.RoslynAnalyzer/DataFlow/MethodBodyValue.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/MethodBodyValue.cs
@@ -30,5 +30,15 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			Debug.Assert (ControlFlowGraph == other.ControlFlowGraph);
 			return true;
 		}
+
+		public override bool Equals (object obj)
+		{
+			return obj is MethodBodyValue && Equals ((MethodBodyValue) obj);
+		}
+
+		public override int GetHashCode ()
+		{
+			throw new NotImplementedException ();
+		}
 	}
 }

--- a/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -104,7 +104,7 @@ namespace ILLink.RoslynAnalyzer
 			});
 		}
 
-		static void ProcessGenericParameters (SyntaxNodeAnalysisContext context)
+		private static void ProcessGenericParameters (SyntaxNodeAnalysisContext context)
 		{
 			// RUC on the containing symbol normally silences warnings, but when examining a generic base type,
 			// the containing symbol is the declared derived type. RUC on the derived type does not silence
@@ -164,7 +164,7 @@ namespace ILLink.RoslynAnalyzer
 			}
 		}
 
-		static IEnumerable<Diagnostic> GetDynamicallyAccessedMembersDiagnostics (SingleValue sourceValue, SingleValue targetValue, Location location)
+		private static IEnumerable<Diagnostic> GetDynamicallyAccessedMembersDiagnostics (SingleValue sourceValue, SingleValue targetValue, Location location)
 		{
 			// The target should always be an annotated value, but the visitor design currently prevents
 			// declaring this in the type system.
@@ -172,13 +172,13 @@ namespace ILLink.RoslynAnalyzer
 				throw new NotImplementedException ();
 
 			var diagnosticContext = new DiagnosticContext (location);
-			var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction (diagnosticContext, new ReflectionAccessAnalyzer ());
+			var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction (diagnosticContext, default (ReflectionAccessAnalyzer));
 			requireDynamicallyAccessedMembersAction.Invoke (sourceValue, targetWithDynamicallyAccessedMembers);
 
 			return diagnosticContext.Diagnostics;
 		}
 
-		static void VerifyMemberOnlyApplyToTypesOrStrings (SymbolAnalysisContext context, ISymbol member)
+		private static void VerifyMemberOnlyApplyToTypesOrStrings (SymbolAnalysisContext context, ISymbol member)
 		{
 			if (member is IFieldSymbol field && field.GetDynamicallyAccessedMemberTypes () != DynamicallyAccessedMemberTypes.None && !field.Type.IsTypeInterestingForDataflow ())
 				context.ReportDiagnostic (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.DynamicallyAccessedMembersOnFieldCanOnlyApplyToTypesOrStrings), member.Locations[0], member.GetDisplayName ()));
@@ -196,7 +196,7 @@ namespace ILLink.RoslynAnalyzer
 			}
 		}
 
-		static void VerifyDamOnDerivedAndBaseMethodsMatch (SymbolAnalysisContext context, IMethodSymbol methodSymbol)
+		private static void VerifyDamOnDerivedAndBaseMethodsMatch (SymbolAnalysisContext context, IMethodSymbol methodSymbol)
 		{
 			if (methodSymbol.TryGetOverriddenMember (out var overriddenSymbol) && overriddenSymbol is IMethodSymbol overriddenMethod
 				&& context.Symbol is IMethodSymbol method) {
@@ -204,7 +204,7 @@ namespace ILLink.RoslynAnalyzer
 			}
 		}
 
-		static void VerifyDamOnMethodsMatch (SymbolAnalysisContext context, IMethodSymbol method, IMethodSymbol overriddenMethod)
+		private static void VerifyDamOnMethodsMatch (SymbolAnalysisContext context, IMethodSymbol method, IMethodSymbol overriddenMethod)
 		{
 			var methodReturnAnnotations = FlowAnnotations.GetMethodReturnValueAnnotation (method);
 			var overriddenMethodReturnAnnotations = FlowAnnotations.GetMethodReturnValueAnnotation (overriddenMethod);
@@ -279,7 +279,7 @@ namespace ILLink.RoslynAnalyzer
 					method.GetDisplayName (), overriddenMethod.GetDisplayName ()));
 		}
 
-		static void VerifyDamOnInterfaceAndImplementationMethodsMatch (SymbolAnalysisContext context, INamedTypeSymbol type)
+		private static void VerifyDamOnInterfaceAndImplementationMethodsMatch (SymbolAnalysisContext context, INamedTypeSymbol type)
 		{
 			foreach (var (interfaceMember, implementationMember) in type.GetMemberInterfaceImplementationPairs ()) {
 				if (implementationMember is IMethodSymbol implementationMethod
@@ -288,7 +288,7 @@ namespace ILLink.RoslynAnalyzer
 			}
 		}
 
-		static void VerifyDamOnPropertyAndAccessorMatch (SymbolAnalysisContext context, IMethodSymbol methodSymbol)
+		private static void VerifyDamOnPropertyAndAccessorMatch (SymbolAnalysisContext context, IMethodSymbol methodSymbol)
 		{
 			if ((methodSymbol.MethodKind != MethodKind.PropertyGet && methodSymbol.MethodKind != MethodKind.PropertySet)
 				|| (methodSymbol.AssociatedSymbol?.GetDynamicallyAccessedMemberTypes () == DynamicallyAccessedMemberTypes.None))

--- a/src/ILLink.RoslynAnalyzer/INamedTypeSymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/INamedTypeSymbolExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.RoslynAnalyzer
 {
-	static class INamedTypeSymbolExtensions
+	internal static class INamedTypeSymbolExtensions
 	{
 		/// <summary>
 		/// Returns true if <see paramref="type" /> has the same name as <see paramref="typename" />

--- a/src/ILLink.RoslynAnalyzer/IOperationExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/IOperationExtensions.cs
@@ -17,25 +17,25 @@ namespace ILLink.RoslynAnalyzer
 		public static ValueUsageInfo GetValueUsageInfo (this IOperation operation, ISymbol containingSymbol)
 		{
 			/*
-            |    code                  | Read | Write | ReadableRef | WritableRef | NonReadWriteRef |
-            | x.Prop = 1               |      |  ✔️   |             |             |                 |
-            | x.Prop += 1              |  ✔️  |  ✔️   |             |             |                 |
-            | x.Prop++                 |  ✔️  |  ✔️   |             |             |                 |
-            | Foo(x.Prop)              |  ✔️  |       |             |             |                 |
-            | Foo(x.Prop),             |      |       |     ✔️      |             |                 |
-               where void Foo(in T v)
-            | Foo(out x.Prop)          |      |       |             |     ✔️      |                 |
-            | Foo(ref x.Prop)          |      |       |     ✔️      |     ✔️      |                 |
-            | nameof(x)                |      |       |             |             |       ✔️        | ️
-            | sizeof(x)                |      |       |             |             |       ✔️        | ️
-            | typeof(x)                |      |       |             |             |       ✔️        | ️
-            | out var x                |      |  ✔️   |             |             |                 | ️
-            | case X x:                |      |  ✔️   |             |             |                 | ️
-            | obj is X x               |      |  ✔️   |             |             |                 |
-            | ref var x =              |      |       |     ✔️      |     ✔️      |                 |
-            | ref readonly var x =     |      |       |     ✔️      |             |                 |
+			|    code                  | Read | Write | ReadableRef | WritableRef | NonReadWriteRef |
+			| x.Prop = 1               |      |  ✔️   |             |             |                 |
+			| x.Prop += 1              |  ✔️  |  ✔️   |             |             |                 |
+			| x.Prop++                 |  ✔️  |  ✔️   |             |             |                 |
+			| Foo(x.Prop)              |  ✔️  |       |             |             |                 |
+			| Foo(x.Prop),             |      |       |     ✔️      |             |                 |
+			   where void Foo(in T v)
+			| Foo(out x.Prop)          |      |       |             |     ✔️      |                 |
+			| Foo(ref x.Prop)          |      |       |     ✔️      |     ✔️      |                 |
+			| nameof(x)                |      |       |             |             |       ✔️        | ️
+			| sizeof(x)                |      |       |             |             |       ✔️        | ️
+			| typeof(x)                |      |       |             |             |       ✔️        | ️
+			| out var x                |      |  ✔️   |             |             |                 | ️
+			| case X x:                |      |  ✔️   |             |             |                 | ️
+			| obj is X x               |      |  ✔️   |             |             |                 |
+			| ref var x =              |      |       |     ✔️      |     ✔️      |                 |
+			| ref readonly var x =     |      |       |     ✔️      |             |                 |
 
-            */
+			*/
 			if (operation is ILocalReferenceOperation localReference &&
 				localReference.IsDeclaration &&
 				!localReference.IsImplicit) // Workaround for https://github.com/dotnet/roslyn/issues/30753

--- a/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
@@ -109,7 +109,7 @@ namespace ILLink.RoslynAnalyzer
 			switch (symbol) {
 			case IFieldSymbol fieldSymbol:
 				sb.Append (fieldSymbol.ContainingSymbol.ToDisplayString (ILLinkTypeDisplayFormat));
-				sb.Append (".");
+				sb.Append ('.');
 				sb.Append (fieldSymbol.MetadataName);
 				break;
 
@@ -131,7 +131,7 @@ namespace ILLink.RoslynAnalyzer
 					// don't include the containing type's name. This matches the behavior of
 					// CSharpErrorMessageFormat.
 					sb.Append (methodSymbol.ContainingType.ToDisplayString (ILLinkTypeDisplayFormat));
-					sb.Append (".");
+					sb.Append ('.');
 				}
 				// Format parameter types with only type names.
 				sb.Append (methodSymbol.ToDisplayString (ILLinkMemberDisplayFormat));

--- a/src/ILLink.RoslynAnalyzer/ITypeSymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ITypeSymbolExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.RoslynAnalyzer
 {
-	static class ITypeSymbolExtensions
+	internal static class ITypeSymbolExtensions
 	{
 		[Flags]
 		private enum HierarchyFlags

--- a/src/ILLink.RoslynAnalyzer/ImmutableArrayOperations.cs
+++ b/src/ILLink.RoslynAnalyzer/ImmutableArrayOperations.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.RoslynAnalyzer
 {
-	sealed class ImmutableArrayOperations
+	internal sealed class ImmutableArrayOperations
 	{
 		internal static bool Contains<T, TComp> (ImmutableArray<T> list, T elem, TComp comparer)
 					where TComp : IEqualityComparer<T>

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -389,7 +389,7 @@ namespace ILLink.RoslynAnalyzer
 		/// </summary>
 		/// <param name="compilation">Compilation to search for members</param>
 		/// <returns>A list of special incomptaible members</returns>
-		protected virtual ImmutableArray<ISymbol> GetSpecialIncompatibleMembers (Compilation compilation) => new ImmutableArray<ISymbol> ();
+		protected virtual ImmutableArray<ISymbol> GetSpecialIncompatibleMembers (Compilation compilation) => default (ImmutableArray<ISymbol>);
 
 		/// <summary>
 		/// Verifies that the MSBuild requirements to run the analyzer are fulfilled

--- a/src/ILLink.RoslynAnalyzer/RequiresAssemblyFilesAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAssemblyFilesAnalyzer.cs
@@ -15,18 +15,18 @@ namespace ILLink.RoslynAnalyzer
 		private const string RequiresAssemblyFilesAttribute = nameof (RequiresAssemblyFilesAttribute);
 		public const string RequiresAssemblyFilesAttributeFullyQualifiedName = "System.Diagnostics.CodeAnalysis." + RequiresAssemblyFilesAttribute;
 
-		static readonly DiagnosticDescriptor s_locationRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.AvoidAssemblyLocationInSingleFile,
+		private static readonly DiagnosticDescriptor s_locationRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.AvoidAssemblyLocationInSingleFile,
 			helpLinkUri: "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000");
 
-		static readonly DiagnosticDescriptor s_getFilesRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.AvoidAssemblyGetFilesInSingleFile,
+		private static readonly DiagnosticDescriptor s_getFilesRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.AvoidAssemblyGetFilesInSingleFile,
 			helpLinkUri: "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001");
 
-		static readonly DiagnosticDescriptor s_requiresAssemblyFilesRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresAssemblyFiles,
+		private static readonly DiagnosticDescriptor s_requiresAssemblyFilesRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresAssemblyFiles,
 			helpLinkUri: "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3002");
 
-		static readonly DiagnosticDescriptor s_requiresAssemblyFilesAttributeMismatch = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresAssemblyFilesAttributeMismatch);
+		private static readonly DiagnosticDescriptor s_requiresAssemblyFilesAttributeMismatch = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresAssemblyFilesAttributeMismatch);
 
-		static readonly DiagnosticDescriptor s_requiresAssemblyFilesOnStaticCtor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresAssemblyFilesOnStaticConstructor);
+		private static readonly DiagnosticDescriptor s_requiresAssemblyFilesOnStaticCtor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresAssemblyFilesOnStaticConstructor);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create (s_locationRule, s_getFilesRule, s_requiresAssemblyFilesRule, s_requiresAssemblyFilesAttributeMismatch, s_requiresAssemblyFilesOnStaticCtor);
 

--- a/src/ILLink.RoslynAnalyzer/RequiresDynamicCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresDynamicCodeAnalyzer.cs
@@ -11,12 +11,12 @@ namespace ILLink.RoslynAnalyzer
 	[DiagnosticAnalyzer (LanguageNames.CSharp)]
 	public sealed class RequiresDynamicCodeAnalyzer : RequiresAnalyzerBase
 	{
-		const string RequiresDynamicCodeAttribute = nameof (RequiresDynamicCodeAttribute);
+		private const string RequiresDynamicCodeAttribute = nameof (RequiresDynamicCodeAttribute);
 		public const string FullyQualifiedRequiresDynamicCodeAttribute = "System.Diagnostics.CodeAnalysis." + RequiresDynamicCodeAttribute;
 
-		static readonly DiagnosticDescriptor s_requiresDynamicCodeOnStaticCtor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresDynamicCodeOnStaticConstructor);
-		static readonly DiagnosticDescriptor s_requiresDynamicCodeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresDynamicCode);
-		static readonly DiagnosticDescriptor s_requiresDynamicCodeAttributeMismatch = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresDynamicCodeAttributeMismatch);
+		private static readonly DiagnosticDescriptor s_requiresDynamicCodeOnStaticCtor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresDynamicCodeOnStaticConstructor);
+		private static readonly DiagnosticDescriptor s_requiresDynamicCodeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresDynamicCode);
+		private static readonly DiagnosticDescriptor s_requiresDynamicCodeAttributeMismatch = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresDynamicCodeAttributeMismatch);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 			ImmutableArray.Create (s_requiresDynamicCodeRule, s_requiresDynamicCodeAttributeMismatch, s_requiresDynamicCodeOnStaticCtor);

--- a/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresISymbolExtensions.cs
@@ -42,7 +42,7 @@ namespace ILLink.RoslynAnalyzer
 		/// Doesn't check the associated symbol for overrides and virtual methods because the analyzer should warn on mismatched between the property AND the accessors
 		/// </summary>
 		/// <param name="member">
-		///	Symbol that is either an overriding member or an overriden/virtual member
+		/// Symbol that is either an overriding member or an overriden/virtual member
 		/// </param>
 		public static bool IsOverrideInRequiresScope (this ISymbol member, string requiresAttribute)
 		{

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -17,18 +17,18 @@ namespace ILLink.RoslynAnalyzer
 		public const string RequiresUnreferencedCodeAttribute = nameof (RequiresUnreferencedCodeAttribute);
 		public const string FullyQualifiedRequiresUnreferencedCodeAttribute = "System.Diagnostics.CodeAnalysis." + RequiresUnreferencedCodeAttribute;
 
-		static readonly DiagnosticDescriptor s_requiresUnreferencedCodeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode);
-		static readonly DiagnosticDescriptor s_requiresUnreferencedCodeAttributeMismatch = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeAttributeMismatch);
-		static readonly DiagnosticDescriptor s_dynamicTypeInvocationRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode,
+		private static readonly DiagnosticDescriptor s_requiresUnreferencedCodeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode);
+		private static readonly DiagnosticDescriptor s_requiresUnreferencedCodeAttributeMismatch = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeAttributeMismatch);
+		private static readonly DiagnosticDescriptor s_dynamicTypeInvocationRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode,
 			new LocalizableResourceString (nameof (SharedStrings.DynamicTypeInvocationTitle), SharedStrings.ResourceManager, typeof (SharedStrings)),
 			new LocalizableResourceString (nameof (SharedStrings.DynamicTypeInvocationMessage), SharedStrings.ResourceManager, typeof (SharedStrings)));
-		static readonly DiagnosticDescriptor s_makeGenericTypeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericType);
-		static readonly DiagnosticDescriptor s_makeGenericMethodRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericMethod);
-		static readonly DiagnosticDescriptor s_requiresUnreferencedCodeOnStaticCtor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeOnStaticConstructor);
+		private static readonly DiagnosticDescriptor s_makeGenericTypeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericType);
+		private static readonly DiagnosticDescriptor s_makeGenericMethodRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericMethod);
+		private static readonly DiagnosticDescriptor s_requiresUnreferencedCodeOnStaticCtor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeOnStaticConstructor);
 
-		static readonly DiagnosticDescriptor s_typeDerivesFromRucClassRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeOnBaseClass);
+		private static readonly DiagnosticDescriptor s_typeDerivesFromRucClassRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeOnBaseClass);
 
-		static readonly Action<OperationAnalysisContext> s_dynamicTypeInvocation = operationContext => {
+		private static readonly Action<OperationAnalysisContext> s_dynamicTypeInvocation = operationContext => {
 			if (FindContainingSymbol (operationContext, DiagnosticTargets.All) is ISymbol containingSymbol &&
 				containingSymbol.IsInRequiresScope (RequiresUnreferencedCodeAttribute))
 				return;

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
@@ -7,7 +7,7 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial record ArrayValue
+	internal partial record ArrayValue
 	{
 		public readonly Dictionary<int, MultiValue> IndexValues;
 
@@ -23,7 +23,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 		public static MultiValue Create (int size) => Create (new ConstIntValue (size));
 
-		ArrayValue (SingleValue size)
+		private ArrayValue (SingleValue size)
 		{
 			Size = size;
 			IndexValues = new Dictionary<int, MultiValue> ();

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/DiagnosticContext.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/DiagnosticContext.cs
@@ -9,11 +9,11 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	readonly partial struct DiagnosticContext
+	public readonly partial struct DiagnosticContext
 	{
 		public List<Diagnostic> Diagnostics { get; } = new ();
 
-		readonly Location? Location { get; init; }
+		private readonly Location? Location { get; init; }
 
 		public DiagnosticContext (Location location)
 		{

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/FieldValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/FieldValue.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial record FieldValue
+	internal partial record FieldValue
 	{
 		public FieldValue (IFieldSymbol fieldSymbol) => FieldSymbol = fieldSymbol;
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
@@ -10,11 +10,11 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed partial class FlowAnnotations
+	internal sealed partial class FlowAnnotations
 	{
 		// In the analyzer there's no stateful data the flow annotations need to store
 		// so we just create a singleton on demand.
-		static readonly Lazy<FlowAnnotations> _instance = new (() => new FlowAnnotations (), isThreadSafe: true);
+		private static readonly Lazy<FlowAnnotations> _instance = new (() => new FlowAnnotations (), isThreadSafe: true);
 
 		public static FlowAnnotations Instance { get => _instance.Value; }
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericParameterValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericParameterValue.cs
@@ -13,7 +13,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// This is a System.Type value which represents generic parameter (basically result of typeof(T))
 	/// Its actual type is unknown, but it can have annotations.
 	/// </summary>
-	partial record GenericParameterValue
+	internal partial record GenericParameterValue
 	{
 		public GenericParameterValue (ITypeParameterSymbol typeParameterSymbol) => GenericParameter = new (typeParameterSymbol);
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
@@ -12,14 +12,14 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial struct HandleCallAction
+	internal partial struct HandleCallAction
 	{
 #pragma warning disable CA1822 // Mark members as static - the other partial implementations might need to be instance methods
 #pragma warning disable IDE0060 // Unused parameters - the other partial implementation may need the parameter
 
-		readonly ISymbol _owningSymbol;
-		readonly IOperation _operation;
-		readonly ReflectionAccessAnalyzer _reflectionAccessAnalyzer;
+		private readonly ISymbol _owningSymbol;
+		private readonly IOperation _operation;
+		private readonly ReflectionAccessAnalyzer _reflectionAccessAnalyzer;
 
 		public HandleCallAction (in DiagnosticContext diagnosticContext, ISymbol owningSymbol, IOperation operation)
 		{
@@ -27,7 +27,7 @@ namespace ILLink.Shared.TrimAnalysis
 			_operation = operation;
 			_diagnosticContext = diagnosticContext;
 			_annotations = FlowAnnotations.Instance;
-			_reflectionAccessAnalyzer = new ReflectionAccessAnalyzer ();
+			_reflectionAccessAnalyzer = default (ReflectionAccessAnalyzer);
 			_requireDynamicallyAccessedMembersAction = new (diagnosticContext, _reflectionAccessAnalyzer);
 		}
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodParameterValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodParameterValue.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial record MethodParameterValue
+	internal partial record MethodParameterValue
 	{
 		public MethodParameterValue (IParameterSymbol parameterSymbol)
 			: this (parameterSymbol, FlowAnnotations.GetMethodParameterAnnotation (parameterSymbol)) { }

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodProxy.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TypeSystemProxy
 {
-	readonly partial struct MethodProxy
+	internal readonly partial struct MethodProxy
 	{
 		public MethodProxy (IMethodSymbol method) => Method = method;
 
@@ -49,7 +49,7 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		internal partial bool ReturnsVoid () => Method.ReturnType.SpecialType == SpecialType.System_Void;
 
-		static bool IsTypeOf (ITypeSymbol type, string fullTypeName)
+		private static bool IsTypeOf (ITypeSymbol type, string fullTypeName)
 		{
 			if (type is not INamedTypeSymbol namedType)
 				return false;

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodReturnValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodReturnValue.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial record MethodReturnValue
+	internal partial record MethodReturnValue
 	{
 		public MethodReturnValue (IMethodSymbol methodSymbol)
 		{

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodThisParameterValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodThisParameterValue.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial record MethodThisParameterValue
+	internal partial record MethodThisParameterValue
 	{
 		public MethodThisParameterValue (IMethodSymbol methodSymbol)
 			: this (methodSymbol, methodSymbol.GetDynamicallyAccessedMemberTypes ()) { }

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/ReflectionAccessAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/ReflectionAccessAnalyzer.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILLink.RoslynAnalyzer.TrimAnalysis
 {
-	readonly struct ReflectionAccessAnalyzer
+	internal readonly struct ReflectionAccessAnalyzer
 	{
 #pragma warning disable CA1822 // Mark members as static - the other partial implementations might need to be instance methods
 		internal void GetReflectionAccessDiagnostics (in DiagnosticContext diagnosticContext, ITypeSymbol typeSymbol, DynamicallyAccessedMemberTypes requiredMemberTypes, bool declaredOnly = false)
@@ -71,7 +71,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				GetReflectionAccessDiagnosticsForMethod (diagnosticContext, c);
 		}
 
-		static void ReportRequiresUnreferencedCodeDiagnostic (in DiagnosticContext diagnosticContext, AttributeData requiresAttributeData, ISymbol member)
+		private static void ReportRequiresUnreferencedCodeDiagnostic (in DiagnosticContext diagnosticContext, AttributeData requiresAttributeData, ISymbol member)
 		{
 			var message = RequiresUnreferencedCodeUtils.GetMessageFromAttribute (requiresAttributeData);
 			var url = RequiresAnalyzerBase.GetUrlFromAttribute (requiresAttributeData);
@@ -105,7 +105,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				GetReflectionAccessDiagnosticsForMethod (diagnosticContext, propertySymbol.GetMethod);
 		}
 
-		static void GetDiagnosticsForEvent (in DiagnosticContext diagnosticContext, IEventSymbol eventSymbol)
+		private static void GetDiagnosticsForEvent (in DiagnosticContext diagnosticContext, IEventSymbol eventSymbol)
 		{
 			if (eventSymbol.AddMethod is not null)
 				GetReflectionAccessDiagnosticsForMethod (diagnosticContext, eventSymbol.AddMethod);
@@ -115,7 +115,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				GetReflectionAccessDiagnosticsForMethod (diagnosticContext, eventSymbol.RaiseMethod);
 		}
 
-		static void GetDiagnosticsForField (in DiagnosticContext diagnosticContext, IFieldSymbol fieldSymbol)
+		private static void GetDiagnosticsForField (in DiagnosticContext diagnosticContext, IFieldSymbol fieldSymbol)
 		{
 			if (fieldSymbol.TryGetRequiresUnreferencedCodeAttribute (out var requiresUnreferencedCodeAttributeData))
 				ReportRequiresUnreferencedCodeDiagnostic (diagnosticContext, requiresUnreferencedCodeAttributeData, fieldSymbol);

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -7,9 +7,9 @@ using ILLink.Shared.TypeSystemProxy;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial struct RequireDynamicallyAccessedMembersAction
+	internal partial struct RequireDynamicallyAccessedMembersAction
 	{
-		readonly ReflectionAccessAnalyzer _reflectionAccessAnalyzer;
+		private readonly ReflectionAccessAnalyzer _reflectionAccessAnalyzer;
 #pragma warning disable CA1822 // Mark members as static - the other partial implementations might need to be instance methods
 #pragma warning disable IDE0060 // Unused parameters - should be removed once methods are actually implemented
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/SingleValueExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/SingleValueExtensions.cs
@@ -19,7 +19,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 					TypeKind.TypeParameter =>
 						new NullableValueWithDynamicallyAccessedMembers (new TypeProxy (type),
 							new GenericParameterValue ((ITypeParameterSymbol) underlyingType)),
-					// typeof(Nullable<>) 
+					// typeof(Nullable<>)
 					TypeKind.Error => new SystemTypeValue (new TypeProxy (type)),
 					TypeKind.Class or TypeKind.Struct or TypeKind.Interface =>
 						new NullableSystemTypeValue (new TypeProxy (type), new SystemTypeValue (new TypeProxy (underlyingType))),

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
@@ -45,7 +45,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 					if (targetValue is not ValueWithDynamicallyAccessedMembers targetWithDynamicallyAccessedMembers)
 						throw new NotImplementedException ();
 
-					var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction (diagnosticContext, new ReflectionAccessAnalyzer ());
+					var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction (diagnosticContext, default (ReflectionAccessAnalyzer));
 					requireDynamicallyAccessedMembersAction.Invoke (sourceValue, targetWithDynamicallyAccessedMembers);
 				}
 			}

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPatternStore.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPatternStore.cs
@@ -9,9 +9,9 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 {
 	public readonly struct TrimAnalysisPatternStore
 	{
-		readonly Dictionary<(IOperation, bool), TrimAnalysisAssignmentPattern> AssignmentPatterns;
-		readonly Dictionary<IOperation, TrimAnalysisMethodCallPattern> MethodCallPatterns;
-		readonly ValueSetLattice<SingleValue> Lattice;
+		private readonly Dictionary<(IOperation, bool), TrimAnalysisAssignmentPattern> AssignmentPatterns;
+		private readonly Dictionary<IOperation, TrimAnalysisMethodCallPattern> MethodCallPatterns;
+		private readonly ValueSetLattice<SingleValue> Lattice;
 
 		public TrimAnalysisPatternStore (ValueSetLattice<SingleValue> lattice)
 		{

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -24,12 +24,12 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 	{
 		public readonly TrimAnalysisPatternStore TrimAnalysisPatterns;
 
-		readonly ValueSetLattice<SingleValue> _multiValueLattice;
+		private readonly ValueSetLattice<SingleValue> _multiValueLattice;
 
 		// Limit tracking array values to 32 values for performance reasons.
 		// There are many arrays much longer than 32 elements in .NET,
 		// but the interesting ones for the linker are nearly always less than 32 elements.
-		const int MaxTrackedArrayValues = 32;
+		private const int MaxTrackedArrayValues = 32;
 
 		public TrimAnalysisVisitor (
 			LocalStateLattice<MultiValue, ValueSetLattice<SingleValue>> lattice,
@@ -302,7 +302,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			}
 		}
 
-		static bool TryGetConstantValue (IOperation operation, out MultiValue constValue)
+		private static bool TryGetConstantValue (IOperation operation, out MultiValue constValue)
 		{
 			if (operation.ConstantValue.HasValue) {
 				object? constantValue = operation.ConstantValue.Value;
@@ -326,16 +326,16 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 					case SpecialType.System_Byte when constantValue is byte byteConstantValue:
 						constValue = new ConstIntValue (byteConstantValue);
 						return true;
-					case SpecialType.System_Int16 when constantValue is Int16 int16ConstantValue:
+					case SpecialType.System_Int16 when constantValue is short int16ConstantValue:
 						constValue = new ConstIntValue (int16ConstantValue);
 						return true;
-					case SpecialType.System_UInt16 when constantValue is UInt16 uint16ConstantValue:
+					case SpecialType.System_UInt16 when constantValue is ushort uint16ConstantValue:
 						constValue = new ConstIntValue (uint16ConstantValue);
 						return true;
-					case SpecialType.System_Int32 when constantValue is Int32 int32ConstantValue:
+					case SpecialType.System_Int32 when constantValue is int int32ConstantValue:
 						constValue = new ConstIntValue (int32ConstantValue);
 						return true;
-					case SpecialType.System_UInt32 when constantValue is UInt32 uint32ConstantValue:
+					case SpecialType.System_UInt32 when constantValue is uint uint32ConstantValue:
 						constValue = new ConstIntValue ((int) uint32ConstantValue);
 						return true;
 					}

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
@@ -37,16 +37,16 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 #if DEBUG
 #pragma warning disable CA1805 // Do not initialize unnecessarily
 		// Set this to a method name to trace the analysis of the method.
-		readonly string? traceMethod = null;
+		private readonly string? traceMethod = null;
 
-		bool trace = false;
+		private bool trace = false;
 
 		// Set this to true to print out the dataflow states encountered during the analysis.
-		readonly bool showStates = false;
+		private readonly bool showStates = false;
 
-		static readonly TracingType tracingMechanism = Debugger.IsAttached ? TracingType.Debug : TracingType.Console;
+		private static readonly TracingType tracingMechanism = Debugger.IsAttached ? TracingType.Debug : TracingType.Console;
 #pragma warning restore CA1805 // Do not initialize unnecessarily
-		ControlFlowGraphProxy cfg;
+		private ControlFlowGraphProxy cfg;
 
 		private enum TracingType
 		{
@@ -123,13 +123,13 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			}
 		}
 
-		static void WriteIndented (string? s, int level)
+		private static void WriteIndented (string? s, int level)
 		{
 			string[]? lines = s?.Trim ().Split (new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
 			if (lines == null)
 				return;
 			foreach (var line in lines) {
-				TraceWrite (new String ('\t', level));
+				TraceWrite (new string ('\t', level));
 				TraceWriteLine (line);
 			}
 		}

--- a/src/ILLink.Shared/Annotations.cs
+++ b/src/ILLink.Shared/Annotations.cs
@@ -79,9 +79,9 @@ namespace ILLink.Shared
 			}));
 		}
 
-		static readonly DynamicallyAccessedMemberTypes[] AllDynamicallyAccessedMemberTypes = GetAllDynamicallyAccessedMemberTypes ();
+		private static readonly DynamicallyAccessedMemberTypes[] AllDynamicallyAccessedMemberTypes = GetAllDynamicallyAccessedMemberTypes ();
 
-		static DynamicallyAccessedMemberTypes[] GetAllDynamicallyAccessedMemberTypes ()
+		private static DynamicallyAccessedMemberTypes[] GetAllDynamicallyAccessedMemberTypes ()
 		{
 			var values = new HashSet<DynamicallyAccessedMemberTypes> (
 								Enum.GetValues (typeof (DynamicallyAccessedMemberTypes))

--- a/src/ILLink.Shared/DataFlow/DefaultValueDictionary.cs
+++ b/src/ILLink.Shared/DataFlow/DefaultValueDictionary.cs
@@ -21,9 +21,9 @@ namespace ILLink.Shared.DataFlow
 		where TKey : IEquatable<TKey>
 		where TValue : IEquatable<TValue>
 	{
-		Dictionary<TKey, TValue>? Dictionary;
+		private Dictionary<TKey, TValue>? Dictionary;
 
-		readonly TValue DefaultValue;
+		private readonly TValue DefaultValue;
 
 		public DefaultValueDictionary (TValue defaultValue) => (Dictionary, DefaultValue) = (null, defaultValue);
 
@@ -81,13 +81,13 @@ namespace ILLink.Shared.DataFlow
 		public override string ToString ()
 		{
 			StringBuilder sb = new ();
-			sb.Append ("{");
+			sb.Append ('{');
 			if (Dictionary != null) {
 				foreach (var kvp in Dictionary)
 					sb.Append (Environment.NewLine).Append ('\t').Append (kvp.Key.ToString ()).Append (" -> ").Append (kvp.Value.ToString ());
 			}
 			sb.Append (Environment.NewLine).Append ("\t_ -> ").Append (DefaultValue.ToString ());
-			sb.Append (Environment.NewLine).Append ("}");
+			sb.Append (Environment.NewLine).Append ('}');
 			return sb.ToString ();
 		}
 

--- a/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
+++ b/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
@@ -25,10 +25,10 @@ namespace ILLink.Shared.DataFlow
 
 		// Data structure to store dataflow states for every basic block in the control flow graph,
 		// keeping the exception states shared across different basic blocks owned by the same try or catch region.
-		struct ControlFlowGraphState
+		private struct ControlFlowGraphState
 		{
 			// Dataflow states for each basic block
-			readonly Dictionary<TBlock, TState> blockOutput;
+			private readonly Dictionary<TBlock, TState> blockOutput;
 
 			// The control flow graph doesn't contain edges for exceptional control flow:
 			// - From any point in a try region to the start of any catch or finally
@@ -38,7 +38,7 @@ namespace ILLink.Shared.DataFlow
 			// when visiting operations inside of a try or catch region.
 
 			// Dataflow states for exceptions propagating out of try or catch regions
-			readonly Dictionary<TRegion, Box<TValue>> exceptionState;
+			private readonly Dictionary<TRegion, Box<TValue>> exceptionState;
 
 			// Control may flow through a finally region when an exception is thrown from anywhere in the corresponding
 			// try or catch regions, or as part of non-exceptional control flow out of a try or catch.
@@ -46,15 +46,15 @@ namespace ILLink.Shared.DataFlow
 			// propagated out of the finally.
 
 			// Dataflow states for finally blocks when exception propagate through the finally region
-			readonly Dictionary<TBlock, TValue> exceptionFinallyState;
+			private readonly Dictionary<TBlock, TValue> exceptionFinallyState;
 
 			// Finally regions may be reached (along non-exceptional paths)
 			// from multiple branches. This gets updated to track the normal finally input
 			// states from all of these branches (which aren't represented explicitly in the CFG).
-			readonly Dictionary<TRegion, TValue> finallyInputState;
+			private readonly Dictionary<TRegion, TValue> finallyInputState;
 
-			readonly TControlFlowGraph cfg;
-			readonly TLattice lattice;
+			private readonly TControlFlowGraph cfg;
+			private readonly TLattice lattice;
 
 			public ControlFlowGraphState (TControlFlowGraph cfg, TLattice lattice)
 			{

--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -17,7 +17,7 @@ namespace ILLink.Shared.DataFlow
 	{
 		// Since we're going to do lot of type checks for this class a lot, it is much more efficient
 		// if the class is sealed (as then the runtime can do a simple method table pointer comparison)
-		sealed class EnumerableValues : HashSet<TValue>
+		private sealed class EnumerableValues : HashSet<TValue>
 		{
 			public EnumerableValues (IEnumerable<TValue> values) : base (values) { }
 
@@ -32,9 +32,9 @@ namespace ILLink.Shared.DataFlow
 
 		public struct Enumerator : IEnumerator<TValue>, IDisposable, IEnumerator
 		{
-			readonly object? _value;
-			int _state;  // 0 before begining, 1 at item, 2 after end
-			readonly IEnumerator<TValue>? _enumerator;
+			private readonly object? _value;
+			private int _state;  // 0 before begining, 1 at item, 2 after end
+			private readonly IEnumerator<TValue>? _enumerator;
 
 			internal Enumerator (object? values)
 			{
@@ -87,13 +87,13 @@ namespace ILLink.Shared.DataFlow
 		//   null - no values (empty set)
 		//   TValue - single value itself
 		//   EnumerableValues typed object - multiple values, stored in the hashset
-		readonly object? _values;
+		private readonly object? _values;
 
 		public ValueSet (TValue value) => _values = value;
 
 		public ValueSet (IEnumerable<TValue> values) => _values = new EnumerableValues (values);
 
-		ValueSet (EnumerableValues values) => _values = values;
+		private ValueSet (EnumerableValues values) => _values = values;
 
 		public static implicit operator ValueSet<TValue> (TValue value) => new (value);
 
@@ -166,9 +166,9 @@ namespace ILLink.Shared.DataFlow
 		public override string ToString ()
 		{
 			StringBuilder sb = new ();
-			sb.Append ("{");
+			sb.Append ('{');
 			sb.Append (string.Join (",", this.Select (v => v.ToString ())));
-			sb.Append ("}");
+			sb.Append ('}');
 			return sb.ToString ();
 		}
 

--- a/src/ILLink.Shared/DiagnosticString.cs
+++ b/src/ILLink.Shared/DiagnosticString.cs
@@ -10,8 +10,8 @@ namespace ILLink.Shared
 {
 	public readonly struct DiagnosticString
 	{
-		readonly string _titleFormat;
-		readonly string _messageFormat;
+		private readonly string _titleFormat;
+		private readonly string _messageFormat;
 
 		public DiagnosticString (DiagnosticId diagnosticId)
 		{

--- a/src/ILLink.Shared/HashUtils.cs
+++ b/src/ILLink.Shared/HashUtils.cs
@@ -10,11 +10,11 @@ using System;
 
 namespace ILLink.Shared
 {
-	static class HashUtils
+	internal static class HashUtils
 	{
 #if NETSTANDARD2_0
 		// This constant is taken from code that Roslyn generates for GetHashCode of records.
-		const int Multiplier = -1521134295;
+		private const int Multiplier = -1521134295;
 #endif
 		public static int Combine<T1, T2> (T1 value1, T2 value2)
 			where T1 : notnull

--- a/src/ILLink.Shared/TrimAnalysis/ArrayValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/ArrayValue.cs
@@ -9,9 +9,9 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed partial record ArrayValue : SingleValue
+	internal sealed partial record ArrayValue : SingleValue
 	{
-		static ValueSetLattice<SingleValue> MultiValueLattice => default;
+		private static ValueSetLattice<SingleValue> MultiValueLattice => default;
 
 		public readonly SingleValue Size;
 

--- a/src/ILLink.Shared/TrimAnalysis/ConstIntValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/ConstIntValue.cs
@@ -11,7 +11,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// Represents a ldc on an int32.
 	/// </summary>
-	sealed record ConstIntValue : SingleValue
+	internal sealed record ConstIntValue : SingleValue
 	{
 		public ConstIntValue (int value) => Value = value;
 

--- a/src/ILLink.Shared/TrimAnalysis/DiagnosticContext.cs
+++ b/src/ILLink.Shared/TrimAnalysis/DiagnosticContext.cs
@@ -15,7 +15,7 @@ namespace ILLink.Shared.TrimAnalysis
 	///  - Single-file warnings (suppressed by RequiresAssemblyFilesAttribute)
 	/// Note that not all categories are used/supported by all tools, for example the ILLink only handles trimmer warnings and ignores the rest.
 	/// </summary>
-	readonly partial struct DiagnosticContext
+	public readonly partial struct DiagnosticContext
 	{
 		/// <param name="id">The diagnostic ID, this will be used to determine the category of diagnostic (trimmer, AOT, single-file)</param>
 		/// <param name="args">The arguments for diagnostic message.</param>

--- a/src/ILLink.Shared/TrimAnalysis/FieldValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/FieldValue.cs
@@ -6,5 +6,5 @@
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed partial record FieldValue : ValueWithDynamicallyAccessedMembers;
+	internal sealed partial record FieldValue : ValueWithDynamicallyAccessedMembers;
 }

--- a/src/ILLink.Shared/TrimAnalysis/FlowAnnotations.cs
+++ b/src/ILLink.Shared/TrimAnalysis/FlowAnnotations.cs
@@ -10,7 +10,7 @@ using ILLink.Shared.TypeSystemProxy;
 namespace ILLink.Shared.TrimAnalysis
 {
 	// Shared helpers to go from MethodProxy to dataflow values.
-	partial class FlowAnnotations
+	internal partial class FlowAnnotations
 	{
 		internal partial bool MethodRequiresDataFlowAnalysis (MethodProxy method);
 

--- a/src/ILLink.Shared/TrimAnalysis/GenericParameterValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/GenericParameterValue.cs
@@ -12,7 +12,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// This is a System.Type value which represents generic parameter (basically result of typeof(T))
 	/// Its actual type is unknown, but it can have annotations.
 	/// </summary>
-	sealed partial record GenericParameterValue : ValueWithDynamicallyAccessedMembers
+	internal sealed partial record GenericParameterValue : ValueWithDynamicallyAccessedMembers
 	{
 		public readonly GenericParameterProxy GenericParameter;
 	}

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -19,13 +19,13 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 namespace ILLink.Shared.TrimAnalysis
 {
 	[StructLayout (LayoutKind.Auto)] // A good way to avoid CS0282, we don't really care about field order
-	partial struct HandleCallAction
+	internal partial struct HandleCallAction
 	{
-		static ValueSetLattice<SingleValue> MultiValueLattice => default;
+		private static ValueSetLattice<SingleValue> MultiValueLattice => default;
 
-		readonly DiagnosticContext _diagnosticContext;
-		readonly FlowAnnotations _annotations;
-		readonly RequireDynamicallyAccessedMembersAction _requireDynamicallyAccessedMembersAction;
+		private readonly DiagnosticContext _diagnosticContext;
+		private readonly FlowAnnotations _annotations;
+		private readonly RequireDynamicallyAccessedMembersAction _requireDynamicallyAccessedMembersAction;
 
 		public bool Invoke (MethodProxy calledMethod, MultiValue instanceValue, IReadOnlyList<MultiValue> argumentValues, out MultiValue methodReturnValue, out IntrinsicId intrinsicId)
 		{
@@ -1198,7 +1198,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		IEnumerable<MultiValue> ProcessGetMethodByName (TypeProxy type, string methodName, BindingFlags? bindingFlags)
+		private IEnumerable<MultiValue> ProcessGetMethodByName (TypeProxy type, string methodName, BindingFlags? bindingFlags)
 		{
 			bool foundAny = false;
 			foreach (var method in GetMethodsOnTypeHierarchy (type, methodName, bindingFlags)) {
@@ -1215,7 +1215,7 @@ namespace ILLink.Shared.TrimAnalysis
 				yield return NullValue.Instance;
 		}
 
-		bool AnalyzeGenericInstantiationTypeArray (in MultiValue arrayParam, in MethodProxy calledMethod, ImmutableArray<GenericParameterValue> genericParameters)
+		private bool AnalyzeGenericInstantiationTypeArray (in MultiValue arrayParam, in MethodProxy calledMethod, ImmutableArray<GenericParameterValue> genericParameters)
 		{
 			bool hasRequirements = false;
 			foreach (var genericParameter in genericParameters) {
@@ -1278,7 +1278,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		void ValidateGenericMethodInstantiation (
+		private void ValidateGenericMethodInstantiation (
 			MethodProxy genericMethod,
 			in MultiValue genericParametersArray,
 			MethodProxy reflectionMethod)
@@ -1293,7 +1293,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		ImmutableArray<GenericParameterValue> GetGenericParameterValues (ImmutableArray<GenericParameterProxy> genericParameters)
+		private ImmutableArray<GenericParameterValue> GetGenericParameterValues (ImmutableArray<GenericParameterProxy> genericParameters)
 		{
 			if (genericParameters.IsEmpty)
 				return ImmutableArray<GenericParameterValue>.Empty;
@@ -1305,7 +1305,7 @@ namespace ILLink.Shared.TrimAnalysis
 			return builder.ToImmutableArray ();
 		}
 
-		void ProcessCreateInstanceByName (MethodProxy calledMethod, IReadOnlyList<MultiValue> argumentValues)
+		private void ProcessCreateInstanceByName (MethodProxy calledMethod, IReadOnlyList<MultiValue> argumentValues)
 		{
 			BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 			bool parameterlessConstructor = true;

--- a/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
+++ b/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
@@ -7,7 +7,7 @@
 namespace ILLink.Shared.TrimAnalysis
 {
 	[StaticCs.Closed]
-	enum IntrinsicId
+	internal enum IntrinsicId
 	{
 		None = 0,
 		IntrospectionExtensions_GetTypeInfo,

--- a/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
+++ b/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
@@ -8,7 +8,7 @@ using ILLink.Shared.TypeSystemProxy;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	static class Intrinsics
+	internal static class Intrinsics
 	{
 		public static IntrinsicId GetIntrinsicIdForMethod (MethodProxy calledMethod)
 		{

--- a/src/ILLink.Shared/TrimAnalysis/KnownStringValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/KnownStringValue.cs
@@ -11,7 +11,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// A known string - such as the result of a ldstr.
 	/// </summary>
-	sealed partial record KnownStringValue : SingleValue
+	internal sealed partial record KnownStringValue : SingleValue
 	{
 		public KnownStringValue (string contents) => Contents = contents;
 

--- a/src/ILLink.Shared/TrimAnalysis/MethodParameterValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/MethodParameterValue.cs
@@ -6,5 +6,5 @@
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed partial record MethodParameterValue : ValueWithDynamicallyAccessedMembers;
+	internal sealed partial record MethodParameterValue : ValueWithDynamicallyAccessedMembers;
 }

--- a/src/ILLink.Shared/TrimAnalysis/MethodReturnValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/MethodReturnValue.cs
@@ -6,5 +6,5 @@
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed partial record class MethodReturnValue : ValueWithDynamicallyAccessedMembers;
+	internal sealed partial record class MethodReturnValue : ValueWithDynamicallyAccessedMembers;
 }

--- a/src/ILLink.Shared/TrimAnalysis/MethodThisParameterValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/MethodThisParameterValue.cs
@@ -6,5 +6,5 @@
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed partial record MethodThisParameterValue : ValueWithDynamicallyAccessedMembers;
+	internal sealed partial record MethodThisParameterValue : ValueWithDynamicallyAccessedMembers;
 }

--- a/src/ILLink.Shared/TrimAnalysis/NullValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/NullValue.cs
@@ -8,7 +8,7 @@ using ILLink.Shared.DataFlow;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed record NullValue : SingleValue
+	internal sealed record NullValue : SingleValue
 	{
 		private NullValue ()
 		{

--- a/src/ILLink.Shared/TrimAnalysis/NullableSystemTypeValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/NullableSystemTypeValue.cs
@@ -14,7 +14,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// This represents a Nullable<T> where T is a known SystemTypeValue.
 	/// It is necessary to track the underlying type to propagate DynamicallyAccessedMembers annotations to the underlying type when applied to a Nullable.
 	/// </summary>
-	sealed record NullableSystemTypeValue : SingleValue
+	internal sealed record NullableSystemTypeValue : SingleValue
 	{
 		public NullableSystemTypeValue (in TypeProxy nullableType, in SystemTypeValue underlyingTypeValue)
 		{

--- a/src/ILLink.Shared/TrimAnalysis/NullableValueWithDynamicallyAccessedMembers.cs
+++ b/src/ILLink.Shared/TrimAnalysis/NullableValueWithDynamicallyAccessedMembers.cs
@@ -13,10 +13,10 @@ using ILLink.Shared.TypeSystemProxy;
 namespace ILLink.Shared.TrimAnalysis
 {
 	/// <summary>
-	/// This represents a Nullable<T> where T is an unknown value with DynamicallyAccessedMembers annotations. 
+	/// This represents a Nullable<T> where T is an unknown value with DynamicallyAccessedMembers annotations.
 	/// It is necessary to track the underlying type to ensure DynamicallyAccessedMembers annotations on the underlying type match the target parameters where the Nullable is used.
 	/// </summary>
-	sealed record NullableValueWithDynamicallyAccessedMembers : ValueWithDynamicallyAccessedMembers
+	internal sealed record NullableValueWithDynamicallyAccessedMembers : ValueWithDynamicallyAccessedMembers
 	{
 		public NullableValueWithDynamicallyAccessedMembers (in TypeProxy nullableType, in ValueWithDynamicallyAccessedMembers underlyingTypeValue)
 		{

--- a/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -14,9 +14,9 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 namespace ILLink.Shared.TrimAnalysis
 {
 	[StructLayout (LayoutKind.Auto)]
-	partial struct RequireDynamicallyAccessedMembersAction
+	internal partial struct RequireDynamicallyAccessedMembersAction
 	{
-		readonly DiagnosticContext _diagnosticContext;
+		private readonly DiagnosticContext _diagnosticContext;
 
 		public void Invoke (in MultiValue value, ValueWithDynamicallyAccessedMembers targetValue)
 		{

--- a/src/ILLink.Shared/TrimAnalysis/RuntimeMethodHandleValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/RuntimeMethodHandleValue.cs
@@ -12,7 +12,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// This is the System.RuntimeMethodHandle equivalent to a <see cref="SystemReflectionMethodBaseValue"/> node.
 	/// </summary>
-	sealed partial record RuntimeMethodHandleValue : SingleValue
+	internal sealed partial record RuntimeMethodHandleValue : SingleValue
 	{
 		public RuntimeMethodHandleValue (in MethodProxy representedMethod)
 		{

--- a/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleForGenericParameterValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleForGenericParameterValue.cs
@@ -12,7 +12,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// This is the System.RuntimeTypeHandle equivalent to a <see cref="GenericParameterValue"/> node.
 	/// </summary>
-	sealed record RuntimeTypeHandleForGenericParameterValue : SingleValue
+	internal sealed record RuntimeTypeHandleForGenericParameterValue : SingleValue
 	{
 		public readonly GenericParameterProxy GenericParameter;
 

--- a/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleForNullableSystemTypeValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleForNullableSystemTypeValue.cs
@@ -14,7 +14,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// This represents a type handle Nullable<T> where T is a known SystemTypeValue.
 	/// It is necessary to track the underlying type to propagate DynamicallyAccessedMembers annotations to the underlying type when applied to a Nullable.
 	/// </summary>
-	sealed record RuntimeTypeHandleForNullableSystemTypeValue : SingleValue
+	internal sealed record RuntimeTypeHandleForNullableSystemTypeValue : SingleValue
 	{
 		public RuntimeTypeHandleForNullableSystemTypeValue (in TypeProxy nullableType, in SystemTypeValue underlyingTypeValue)
 		{

--- a/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleForNullableValueWithDynamicallyAccessedMembers.cs
+++ b/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleForNullableValueWithDynamicallyAccessedMembers.cs
@@ -11,10 +11,10 @@ using ILLink.Shared.TypeSystemProxy;
 namespace ILLink.Shared.TrimAnalysis
 {
 	/// <summary>
-	/// This represents a type handle of a Nullable<T> where T is an unknown value with DynamicallyAccessedMembers annotations. 
+	/// This represents a type handle of a Nullable<T> where T is an unknown value with DynamicallyAccessedMembers annotations.
 	/// It is necessary to track the underlying type to ensure DynamicallyAccessedMembers annotations on the underlying type match the target parameters where the Nullable is used.
 	/// </summary>
-	sealed record RuntimeTypeHandleForNullableValueWithDynamicallyAccessedMembers : SingleValue
+	internal sealed record RuntimeTypeHandleForNullableValueWithDynamicallyAccessedMembers : SingleValue
 	{
 		public RuntimeTypeHandleForNullableValueWithDynamicallyAccessedMembers (in TypeProxy nullableType, in SingleValue underlyingTypeValue)
 		{
@@ -26,7 +26,7 @@ namespace ILLink.Shared.TrimAnalysis
 		public readonly TypeProxy NullableType;
 		public readonly SingleValue UnderlyingTypeValue;
 
-		public override SingleValue DeepCopy () => this; // This value is immutable	}
+		public override SingleValue DeepCopy () => this; // This value is immutable
 
 		public override string ToString () => this.ValueToString (UnderlyingTypeValue, NullableType);
 	}

--- a/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/RuntimeTypeHandleValue.cs
@@ -12,7 +12,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// This is the System.RuntimeTypeHandle equivalent to a <see cref="SystemTypeValue"/> node.
 	/// </summary>
-	sealed record RuntimeTypeHandleValue : SingleValue
+	internal sealed record RuntimeTypeHandleValue : SingleValue
 	{
 		public RuntimeTypeHandleValue (in TypeProxy representedType)
 		{

--- a/src/ILLink.Shared/TrimAnalysis/SystemReflectionMethodBaseValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/SystemReflectionMethodBaseValue.cs
@@ -12,7 +12,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// This is a known System.Reflection.MethodBase value.  MethodRepresented is the 'value' of the MethodBase.
 	/// </summary>
-	sealed partial record SystemReflectionMethodBaseValue : SingleValue
+	internal sealed partial record SystemReflectionMethodBaseValue : SingleValue
 	{
 		public SystemReflectionMethodBaseValue (MethodProxy representedMethod) => RepresentedMethod = representedMethod;
 

--- a/src/ILLink.Shared/TrimAnalysis/SystemTypeValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/SystemTypeValue.cs
@@ -12,7 +12,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// This is a known System.Type value. TypeRepresented is the 'value' of the System.Type.
 	/// </summary>
-	sealed record SystemTypeValue : SingleValue
+	internal sealed record SystemTypeValue : SingleValue
 	{
 		public SystemTypeValue (in TypeProxy representedType)
 		{

--- a/src/ILLink.Shared/TrimAnalysis/UnknownValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/UnknownValue.cs
@@ -8,7 +8,7 @@ using ILLink.Shared.DataFlow;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed record UnknownValue : SingleValue
+	internal sealed record UnknownValue : SingleValue
 	{
 		private UnknownValue ()
 		{

--- a/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
+++ b/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
@@ -11,7 +11,7 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	static partial class ValueExtensions
+	internal static partial class ValueExtensions
 	{
 		internal static string ValueToString (this SingleValue value, params object[] args)
 		{
@@ -20,15 +20,15 @@ namespace ILLink.Shared.TrimAnalysis
 
 			StringBuilder sb = new ();
 			sb.Append (value.GetType ().Name);
-			sb.Append ("(");
+			sb.Append ('(');
 			if (args != null) {
 				for (int i = 0; i < args.Length; i++) {
 					if (i > 0)
-						sb.Append (",");
+						sb.Append (',');
 					sb.Append (args[i] == null ? "<null>" : args[i].ToString ());
 				}
 			}
-			sb.Append (")");
+			sb.Append (')');
 			return sb.ToString ();
 		}
 

--- a/src/ILLink.Shared/TypeSystemProxy/IMemberProxy.cs
+++ b/src/ILLink.Shared/TypeSystemProxy/IMemberProxy.cs
@@ -6,7 +6,7 @@
 
 namespace ILLink.Shared.TypeSystemProxy
 {
-	interface IMemberProxy
+	internal interface IMemberProxy
 	{
 		public string Name { get; }
 

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -76,14 +76,14 @@ namespace ILLink.Tasks
 		/// Maps to '--warnaserror' if true, '--warnaserror-' if false.
 		/// </summary>
 		public bool TreatWarningsAsErrors { set => _treatWarningsAsErrors = value; }
-		bool? _treatWarningsAsErrors;
+		private bool? _treatWarningsAsErrors;
 
 		/// <summary>
 		/// Produce at most one trim analysis warning per assembly.
 		/// Maps to '--singlewarn' if true, '--singlewarn-' if false.
 		/// </summary>
 		public bool SingleWarn { set => _singleWarn = value; }
-		bool? _singleWarn;
+		private bool? _singleWarn;
 
 		/// <summary>
 		/// The list of warnings to report as errors.
@@ -110,35 +110,35 @@ namespace ILLink.Tasks
 		///   Maps to '--enable-opt beforefieldinit' or '--disable-opt beforefieldinit'.
 		/// </summary>
 		public bool BeforeFieldInit { set => _beforeFieldInit = value; }
-		bool? _beforeFieldInit;
+		private bool? _beforeFieldInit;
 
 		/// <summary>
 		///   Boolean specifying whether to enable overrideremoval optimization globally.
 		///   Maps to '--enable-opt overrideremoval' or '--disable-opt overrideremoval'.
 		/// </summary>
 		public bool OverrideRemoval { set => _overrideRemoval = value; }
-		bool? _overrideRemoval;
+		private bool? _overrideRemoval;
 
 		/// <summary>
 		///   Boolean specifying whether to enable unreachablebodies optimization globally.
 		///   Maps to '--enable-opt unreachablebodies' or '--disable-opt unreachablebodies'.
 		/// </summary>
 		public bool UnreachableBodies { set => _unreachableBodies = value; }
-		bool? _unreachableBodies;
+		private bool? _unreachableBodies;
 
 		/// <summary>
 		///   Boolean specifying whether to enable unusedinterfaces optimization globally.
 		///   Maps to '--enable-opt unusedinterfaces' or '--disable-opt unusedinterfaces'.
 		/// </summary>
 		public bool UnusedInterfaces { set => _unusedInterfaces = value; }
-		bool? _unusedInterfaces;
+		private bool? _unusedInterfaces;
 
 		/// <summary>
 		///   Boolean specifying whether to enable ipconstprop optimization globally.
 		///   Maps to '--enable-opt ipconstprop' or '--disable-opt ipconstprop'.
 		/// </summary>
 		public bool IPConstProp { set => _iPConstProp = value; }
-		bool? _iPConstProp;
+		private bool? _iPConstProp;
 
 		/// <summary>
 		///   A list of feature names used by the body substitution logic.
@@ -153,9 +153,9 @@ namespace ILLink.Tasks
 		///   Maps to '--enable-opt sealer' or '--disable-opt sealer'.
 		/// </summary>
 		public bool Sealer { set => _sealer = value; }
-		bool? _sealer;
+		private bool? _sealer;
 
-		static readonly string[] _optimizationNames = new string[] {
+		private static readonly string[] _optimizationNames = new string[] {
 			"BeforeFieldInit",
 			"OverrideRemoval",
 			"UnreachableBodies",
@@ -195,7 +195,7 @@ namespace ILLink.Tasks
 		///   the command-line. (Target files will likely set their own defaults to keep symbols.)
 		/// </summary>
 		public bool RemoveSymbols { set => _removeSymbols = value; }
-		bool? _removeSymbols;
+		private bool? _removeSymbols;
 
 		/// <summary>
 		///   Sets the default action for trimmable assemblies.
@@ -234,11 +234,11 @@ namespace ILLink.Tasks
 
 		private string DotNetPath {
 			get {
-				if (!String.IsNullOrEmpty (_dotnetPath))
+				if (!string.IsNullOrEmpty (_dotnetPath))
 					return _dotnetPath;
 
 				_dotnetPath = Environment.GetEnvironmentVariable (DotNetHostPathEnvironmentName);
-				if (String.IsNullOrEmpty (_dotnetPath))
+				if (string.IsNullOrEmpty (_dotnetPath))
 					throw new InvalidOperationException ($"{DotNetHostPathEnvironmentName} is not set");
 
 				return _dotnetPath;
@@ -258,7 +258,7 @@ namespace ILLink.Tasks
 
 		public string ILLinkPath {
 			get {
-				if (!String.IsNullOrEmpty (_illinkPath))
+				if (!string.IsNullOrEmpty (_illinkPath))
 					return _illinkPath;
 
 				var taskDirectory = Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
@@ -367,10 +367,10 @@ namespace ILLink.Tasks
 				// Add per-assembly optimization arguments
 				foreach (var optimization in _optimizationNames) {
 					string optimizationValue = assembly.GetMetadata (optimization);
-					if (String.IsNullOrEmpty (optimizationValue))
+					if (string.IsNullOrEmpty (optimizationValue))
 						continue;
 
-					if (!Boolean.TryParse (optimizationValue, out bool enabled))
+					if (!bool.TryParse (optimizationValue, out bool enabled))
 						throw new ArgumentException ($"optimization metadata {optimization} must be True or False");
 
 					SetOpt (args, optimization, assemblyName, enabled);
@@ -378,8 +378,8 @@ namespace ILLink.Tasks
 
 				// Add per-assembly verbosity arguments
 				string singleWarn = assembly.GetMetadata ("TrimmerSingleWarn");
-				if (!String.IsNullOrEmpty (singleWarn)) {
-					if (!Boolean.TryParse (singleWarn, out bool value))
+				if (!string.IsNullOrEmpty (singleWarn)) {
+					if (!bool.TryParse (singleWarn, out bool value))
 						throw new ArgumentException ($"TrimmerSingleWarn metadata must be True or False");
 
 					if (value)
@@ -451,7 +451,7 @@ namespace ILLink.Tasks
 				foreach (var customData in CustomData) {
 					var key = customData.ItemSpec;
 					var value = customData.GetMetadata ("Value");
-					if (String.IsNullOrEmpty (value))
+					if (string.IsNullOrEmpty (value))
 						throw new ArgumentException ("custom data requires \"Value\" metadata");
 					args.Append ("--custom-data ").Append (' ').Append (key).Append ('=').AppendLine (Quote (value));
 				}
@@ -461,7 +461,7 @@ namespace ILLink.Tasks
 				foreach (var featureSetting in FeatureSettings) {
 					var feature = featureSetting.ItemSpec;
 					var featureValue = featureSetting.GetMetadata ("Value");
-					if (String.IsNullOrEmpty (featureValue))
+					if (string.IsNullOrEmpty (featureValue))
 						throw new ArgumentException ("feature settings require \"Value\" metadata");
 					args.Append ("--feature ").Append (feature).Append (' ').AppendLine (featureValue);
 				}
@@ -487,11 +487,11 @@ namespace ILLink.Tasks
 					// handle optional before/aftersteps
 					var beforeStep = customStep.GetMetadata ("BeforeStep");
 					var afterStep = customStep.GetMetadata ("AfterStep");
-					if (!String.IsNullOrEmpty (beforeStep) && !String.IsNullOrEmpty (afterStep))
+					if (!string.IsNullOrEmpty (beforeStep) && !string.IsNullOrEmpty (afterStep))
 						throw new ArgumentException ("custom step may not have both \"BeforeStep\" and \"AfterStep\" metadata");
-					if (!String.IsNullOrEmpty (beforeStep))
+					if (!string.IsNullOrEmpty (beforeStep))
 						customStepString = $"-{beforeStep}:{customStepString}";
-					if (!String.IsNullOrEmpty (afterStep))
+					if (!string.IsNullOrEmpty (afterStep))
 						customStepString = $"+{afterStep}:{customStepString}";
 
 					args.AppendLine (Quote (customStepString));

--- a/src/analyzer/ConsoleDependencyGraph.cs
+++ b/src/analyzer/ConsoleDependencyGraph.cs
@@ -44,7 +44,7 @@ namespace LinkerAnalyzer
 				ShowDependencies (vertex);
 		}
 
-		void ShowFlatDependencies (VertexData vertex)
+		private void ShowFlatDependencies (VertexData vertex)
 		{
 			bool first = true;
 			var flatDeps = GetAllDependencies (vertex);
@@ -65,7 +65,7 @@ namespace LinkerAnalyzer
 			}
 		}
 
-		string SizeString (VertexData vertex)
+		private string SizeString (VertexData vertex)
 		{
 			return SpaceAnalyzer == null ?
 				"" : string.Format (" size: {0}", SpaceAnalyzer.GetSize (vertex));
@@ -137,7 +137,7 @@ namespace LinkerAnalyzer
 				ShowDependencies (type);
 		}
 
-		static string Tabs (string key)
+		private static string Tabs (string key)
 		{
 			int count = Math.Max (1, 2 - key.Length / 8);
 
@@ -193,9 +193,9 @@ namespace LinkerAnalyzer
 			ShowDependencies ("TypeDef:" + raw, Types, raw);
 		}
 
-		static readonly string line = new string ('-', 72);
+		private static readonly string line = new string ('-', 72);
 
-		static void Line ()
+		private static void Line ()
 		{
 			Console.Write (line);
 			Console.WriteLine ();

--- a/src/analyzer/LinkerAnalyzerCore/DependencyGraph.cs
+++ b/src/analyzer/LinkerAnalyzerCore/DependencyGraph.cs
@@ -36,7 +36,7 @@ namespace LinkerAnalyzer.Core
 	{
 		protected List<VertexData> vertices = new List<VertexData> ();
 		public List<VertexData> Types = new List<VertexData> ();
-		readonly Dictionary<string, int> indexes = new Dictionary<string, int> ();
+		private readonly Dictionary<string, int> indexes = new Dictionary<string, int> ();
 		protected Dictionary<string, int> counts = new Dictionary<string, int> ();
 		internal SpaceAnalyzer SpaceAnalyzer { get; set; }
 
@@ -54,7 +54,7 @@ namespace LinkerAnalyzer.Core
 			}
 		}
 
-		void Load (FileStream fileStream)
+		private void Load (FileStream fileStream)
 		{
 			using (XmlReader reader = XmlReader.Create (fileStream)) {
 				while (reader.Read ()) {
@@ -117,7 +117,7 @@ namespace LinkerAnalyzer.Core
 			return vertices[index];
 		}
 
-		IEnumerable<Tuple<VertexData, int>> AddDependencies (VertexData vertex, HashSet<int> reachedVertices, int depth)
+		private IEnumerable<Tuple<VertexData, int>> AddDependencies (VertexData vertex, HashSet<int> reachedVertices, int depth)
 		{
 			reachedVertices.Add (vertex.index);
 			yield return new Tuple<VertexData, int> (vertex, depth);

--- a/src/analyzer/LinkerAnalyzerCore/SpaceAnalyzer.cs
+++ b/src/analyzer/LinkerAnalyzerCore/SpaceAnalyzer.cs
@@ -36,16 +36,16 @@ namespace LinkerAnalyzer.Core
 {
 	public class SpaceAnalyzer
 	{
-		readonly string assembliesDirectory;
-		readonly List<AssemblyDefinition> assemblies = new List<AssemblyDefinition> ();
-		readonly Dictionary<string, int> sizes = new Dictionary<string, int> ();
+		private readonly string assembliesDirectory;
+		private readonly List<AssemblyDefinition> assemblies = new List<AssemblyDefinition> ();
+		private readonly Dictionary<string, int> sizes = new Dictionary<string, int> ();
 
 		public SpaceAnalyzer (string assembliesDirectory)
 		{
 			this.assembliesDirectory = assembliesDirectory;
 		}
 
-		static bool IsAssemblyBound (TypeDefinition td)
+		private static bool IsAssemblyBound (TypeDefinition td)
 		{
 			do {
 				if (td.IsNestedPrivate || td.IsNestedAssembly || td.IsNestedFamilyAndAssembly)
@@ -57,7 +57,7 @@ namespace LinkerAnalyzer.Core
 			return false;
 		}
 
-		static string GetTypeKey (TypeDefinition td)
+		private static string GetTypeKey (TypeDefinition td)
 		{
 			if (td == null)
 				return "";
@@ -68,12 +68,12 @@ namespace LinkerAnalyzer.Core
 			return $"{td.MetadataToken.TokenType}:{td}{addition}";
 		}
 
-		static string GetKey (IMetadataTokenProvider provider)
+		private static string GetKey (IMetadataTokenProvider provider)
 		{
 			return $"{provider.MetadataToken.TokenType}:{provider}";
 		}
 
-		int GetMethodSize (MethodDefinition method)
+		private int GetMethodSize (MethodDefinition method)
 		{
 			var key = GetKey (method);
 			int msize;
@@ -89,7 +89,7 @@ namespace LinkerAnalyzer.Core
 			return msize;
 		}
 
-		int ProcessType (TypeDefinition type)
+		private int ProcessType (TypeDefinition type)
 		{
 			int size = type.Name.Length;
 

--- a/src/analyzer/Main.cs
+++ b/src/analyzer/Main.cs
@@ -16,9 +16,9 @@ using Mono.Options;
 
 namespace LinkerAnalyzer
 {
-	static class MainClass
+	internal static class MainClass
 	{
-		static void Main (string[] args)
+		private static void Main (string[] args)
 		{
 			bool showUsage = true;
 			bool showAllDeps = false;

--- a/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -12,7 +12,7 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial record ArrayValue
+	internal partial record ArrayValue
 	{
 		public static MultiValue Create (MultiValue size, TypeReference elementType)
 		{
@@ -32,7 +32,7 @@ namespace ILLink.Shared.TrimAnalysis
 		/// <summary>
 		/// Constructs an array value of the given size
 		/// </summary>
-		ArrayValue (SingleValue size, TypeReference elementType)
+		private ArrayValue (SingleValue size, TypeReference elementType)
 		{
 			Size = size;
 			ElementType = elementType;
@@ -95,17 +95,17 @@ namespace ILLink.Shared.TrimAnalysis
 			bool first = true;
 			foreach (var element in IndexValues) {
 				if (!first) {
-					result.Append (",");
+					result.Append (',');
 					first = false;
 				}
 
-				result.Append ("(");
+				result.Append ('(');
 				result.Append (element.Key);
 				result.Append (",(");
 				bool firstValue = true;
 				foreach (var v in element.Value.Value) {
 					if (firstValue) {
-						result.Append (",");
+						result.Append (',');
 						firstValue = false;
 					}
 

--- a/src/linker/Linker.Dataflow/AttributeDataFlow.cs
+++ b/src/linker/Linker.Dataflow/AttributeDataFlow.cs
@@ -14,9 +14,9 @@ namespace Mono.Linker.Dataflow
 {
 	public readonly struct AttributeDataFlow
 	{
-		readonly LinkContext _context;
-		readonly MarkStep _markStep;
-		readonly MessageOrigin _origin;
+		private readonly LinkContext _context;
+		private readonly MarkStep _markStep;
+		private readonly MessageOrigin _origin;
 
 		public AttributeDataFlow (LinkContext context, MarkStep markStep, in MessageOrigin origin)
 		{
@@ -48,7 +48,7 @@ namespace Mono.Linker.Dataflow
 			RequireDynamicallyAccessedMembers (diagnosticContext, valueNode, fieldValue);
 		}
 
-		MultiValue GetValueForCustomAttributeArgument (CustomAttributeArgument argument)
+		private MultiValue GetValueForCustomAttributeArgument (CustomAttributeArgument argument)
 		{
 			if (argument.Type.Name == "Type") {
 				if (argument.Value is null)
@@ -67,7 +67,7 @@ namespace Mono.Linker.Dataflow
 			throw new InvalidOperationException ();
 		}
 
-		void RequireDynamicallyAccessedMembers (in DiagnosticContext diagnosticContext, in MultiValue value, ValueWithDynamicallyAccessedMembers targetValue)
+		private void RequireDynamicallyAccessedMembers (in DiagnosticContext diagnosticContext, in MultiValue value, ValueWithDynamicallyAccessedMembers targetValue)
 		{
 			var reflectionMarker = new ReflectionMarker (_context, _markStep, enabled: true);
 			var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction (reflectionMarker, diagnosticContext);

--- a/src/linker/Linker.Dataflow/CompilerGeneratedCallGraph.cs
+++ b/src/linker/Linker.Dataflow/CompilerGeneratedCallGraph.cs
@@ -7,13 +7,13 @@ using Mono.Cecil;
 
 namespace Mono.Linker.Dataflow
 {
-	sealed class CompilerGeneratedCallGraph
+	internal sealed class CompilerGeneratedCallGraph
 	{
-		readonly Dictionary<IMemberDefinition, HashSet<IMemberDefinition>> _callGraph;
+		private readonly Dictionary<IMemberDefinition, HashSet<IMemberDefinition>> _callGraph;
 
 		public CompilerGeneratedCallGraph () => _callGraph = new Dictionary<IMemberDefinition, HashSet<IMemberDefinition>> ();
 
-		void TrackCallInternal (IMemberDefinition fromMember, IMemberDefinition toMember)
+		private void TrackCallInternal (IMemberDefinition fromMember, IMemberDefinition toMember)
 		{
 			if (!_callGraph.TryGetValue (fromMember, out HashSet<IMemberDefinition>? toMembers)) {
 				toMembers = new HashSet<IMemberDefinition> ();

--- a/src/linker/Linker.Dataflow/CompilerGeneratedNames.cs
+++ b/src/linker/Linker.Dataflow/CompilerGeneratedNames.cs
@@ -3,7 +3,7 @@
 
 namespace Mono.Linker.Dataflow
 {
-	sealed class CompilerGeneratedNames
+	internal sealed class CompilerGeneratedNames
 	{
 		internal static bool IsGeneratedMemberName (string memberName)
 		{

--- a/src/linker/Linker.Dataflow/CompilerGeneratedState.cs
+++ b/src/linker/Linker.Dataflow/CompilerGeneratedState.cs
@@ -15,21 +15,21 @@ namespace Mono.Linker.Dataflow
 	// Currently this is implemented using heuristics
 	public class CompilerGeneratedState
 	{
-		readonly LinkContext _context;
-		readonly Dictionary<TypeDefinition, MethodDefinition> _compilerGeneratedTypeToUserCodeMethod;
-		readonly Dictionary<TypeDefinition, TypeArgumentInfo> _generatedTypeToTypeArgumentInfo;
-		readonly record struct TypeArgumentInfo (
+		private readonly LinkContext _context;
+		private readonly Dictionary<TypeDefinition, MethodDefinition> _compilerGeneratedTypeToUserCodeMethod;
+		private readonly Dictionary<TypeDefinition, TypeArgumentInfo> _generatedTypeToTypeArgumentInfo;
+		private readonly record struct TypeArgumentInfo (
 			/// <summary>The method which calls the ctor for the given type</summary>
 			MethodDefinition CreatingMethod,
 			/// <summary>Attributes for the type, pulled from the creators type arguments</summary>
 			IReadOnlyList<ICustomAttributeProvider>? OriginalAttributes);
 
-		readonly Dictionary<MethodDefinition, MethodDefinition> _compilerGeneratedMethodToUserCodeMethod;
+		private readonly Dictionary<MethodDefinition, MethodDefinition> _compilerGeneratedMethodToUserCodeMethod;
 
 		// For each type that has had its cache populated, stores a map of methods which have corresponding
 		// compiler-generated members (either methods or state machine types) to those compiler-generated members,
 		// or null if the type has no methods with compiler-generated members.
-		readonly Dictionary<TypeDefinition, Dictionary<MethodDefinition, List<IMemberDefinition>>?> _cachedTypeToCompilerGeneratedMembers;
+		private readonly Dictionary<TypeDefinition, Dictionary<MethodDefinition, List<IMemberDefinition>>?> _cachedTypeToCompilerGeneratedMembers;
 
 		public CompilerGeneratedState (LinkContext context)
 		{
@@ -40,7 +40,7 @@ namespace Mono.Linker.Dataflow
 			_cachedTypeToCompilerGeneratedMembers = new Dictionary<TypeDefinition, Dictionary<MethodDefinition, List<IMemberDefinition>>?> ();
 		}
 
-		static IEnumerable<TypeDefinition> GetCompilerGeneratedNestedTypes (TypeDefinition type)
+		private static IEnumerable<TypeDefinition> GetCompilerGeneratedNestedTypes (TypeDefinition type)
 		{
 			foreach (var nestedType in type.NestedTypes) {
 				if (!CompilerGeneratedNames.IsGeneratedMemberName (nestedType.Name))
@@ -108,7 +108,7 @@ namespace Mono.Linker.Dataflow
 		/// up and find the nearest containing user type. Returns the nearest user type,
 		/// or null if none was found.
 		/// </summary>
-		TypeDefinition? GetCompilerGeneratedStateForType (TypeDefinition type)
+		private TypeDefinition? GetCompilerGeneratedStateForType (TypeDefinition type)
 		{
 			// Look in the declaring type if this is a compiler-generated type (state machine or display class).
 			// State machines can be emitted into display classes, so we may also need to go one more level up.
@@ -392,7 +392,7 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
-		static TypeDefinition? GetFirstConstructorArgumentAsType (CustomAttribute attribute)
+		private static TypeDefinition? GetFirstConstructorArgumentAsType (CustomAttribute attribute)
 		{
 			if (!attribute.HasConstructorArguments)
 				return null;

--- a/src/linker/Linker.Dataflow/DiagnosticContext.cs
+++ b/src/linker/Linker.Dataflow/DiagnosticContext.cs
@@ -9,7 +9,7 @@ namespace ILLink.Shared.TrimAnalysis
 	{
 		public readonly MessageOrigin Origin;
 		public readonly bool DiagnosticsEnabled;
-		readonly LinkContext _context;
+		private readonly LinkContext _context;
 
 		public DiagnosticContext (in MessageOrigin origin, bool diagnosticsEnabled, LinkContext context)
 			=> (Origin, DiagnosticsEnabled, _context) = (origin, diagnosticsEnabled, context);

--- a/src/linker/Linker.Dataflow/DiagnosticUtilities.cs
+++ b/src/linker/Linker.Dataflow/DiagnosticUtilities.cs
@@ -6,7 +6,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker.Dataflow
 {
-	static class DiagnosticUtilities
+	internal static class DiagnosticUtilities
 	{
 		internal static IMetadataTokenProvider GetMethodParameterFromIndex (MethodDefinition method, int parameterIndex)
 		{

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -366,7 +366,7 @@ namespace Mono.Linker
 		// required by this type (but not members of these interfaces, or interfaces required only by base types).
 		public static void GetAllOnType (this TypeDefinition type, LinkContext context, bool declaredOnly, List<IMetadataTokenProvider> members) => GetAllOnType (type, context, declaredOnly, members, new HashSet<TypeDefinition> ());
 
-		static void GetAllOnType (TypeDefinition type, LinkContext context, bool declaredOnly, List<IMetadataTokenProvider> members, HashSet<TypeDefinition> types)
+		private static void GetAllOnType (TypeDefinition type, LinkContext context, bool declaredOnly, List<IMetadataTokenProvider> members, HashSet<TypeDefinition> types)
 		{
 			if (!types.Add (type))
 				return;

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -10,10 +10,10 @@ using Mono.Linker.Steps;
 
 namespace Mono.Linker.Dataflow
 {
-	sealed class DynamicallyAccessedMembersTypeHierarchy
+	internal sealed class DynamicallyAccessedMembersTypeHierarchy
 	{
-		readonly LinkContext _context;
-		readonly MarkStep _markStep;
+		private readonly LinkContext _context;
+		private readonly MarkStep _markStep;
 
 		// Cache of DynamicallyAccessedMembers annotations applied to types and their hierarchies
 		// Values
@@ -36,7 +36,7 @@ namespace Mono.Linker.Dataflow
 		// because interfaces are marked late and in effectively random order.
 		// For this cache to be effective we need to be able to fill it for all base types and interfaces
 		// of a type which is currently being marked - at which point the interfaces are not yet marked.
-		readonly Dictionary<TypeDefinition, (DynamicallyAccessedMemberTypes annotation, bool applied)> _typesInDynamicallyAccessedMembersHierarchy;
+		private readonly Dictionary<TypeDefinition, (DynamicallyAccessedMemberTypes annotation, bool applied)> _typesInDynamicallyAccessedMembersHierarchy;
 
 		public DynamicallyAccessedMembersTypeHierarchy (LinkContext context, MarkStep markStep)
 		{
@@ -65,7 +65,7 @@ namespace Mono.Linker.Dataflow
 			}
 
 			// For the purposes of the DynamicallyAccessedMembers type hierarchies
-			// we consider interfaces of marked types to be also "marked" in that 
+			// we consider interfaces of marked types to be also "marked" in that
 			// their annotations will be applied to the type regardless if later on
 			// we decide to remove the interface. This is to keep the complexity of the implementation
 			// relatively low. In the future it could be possibly optimized.
@@ -168,7 +168,7 @@ namespace Mono.Linker.Dataflow
 			return annotation;
 		}
 
-		bool ApplyDynamicallyAccessedMembersToTypeHierarchyInner (
+		private bool ApplyDynamicallyAccessedMembersToTypeHierarchyInner (
 			in ReflectionMarker reflectionMarker,
 			TypeDefinition type)
 		{
@@ -206,7 +206,7 @@ namespace Mono.Linker.Dataflow
 			return applied;
 		}
 
-		void ApplyDynamicallyAccessedMembersToType (in ReflectionMarker reflectionMarker, in MessageOrigin origin, TypeDefinition type, DynamicallyAccessedMemberTypes annotation)
+		private void ApplyDynamicallyAccessedMembersToType (in ReflectionMarker reflectionMarker, in MessageOrigin origin, TypeDefinition type, DynamicallyAccessedMemberTypes annotation)
 		{
 			Debug.Assert (annotation != DynamicallyAccessedMemberTypes.None);
 
@@ -249,7 +249,7 @@ namespace Mono.Linker.Dataflow
 			reflectionMarker.MarkTypeForDynamicallyAccessedMembers (origin, type, annotation, DependencyKind.DynamicallyAccessedMemberOnType, declaredOnly: true);
 		}
 
-		(DynamicallyAccessedMemberTypes annotation, bool applied) GetCachedInfoForTypeInHierarchy (TypeDefinition type)
+		private (DynamicallyAccessedMemberTypes annotation, bool applied) GetCachedInfoForTypeInHierarchy (TypeDefinition type)
 		{
 			// The type should be in our cache already
 			if (!_typesInDynamicallyAccessedMembersHierarchy.TryGetValue (type, out var existingValue)) {

--- a/src/linker/Linker.Dataflow/FieldValue.cs
+++ b/src/linker/Linker.Dataflow/FieldValue.cs
@@ -16,7 +16,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// A representation of a field. Typically a result of ldfld.
 	/// </summary>
-	sealed partial record FieldValue : IValueWithStaticType
+	internal sealed partial record FieldValue : IValueWithStaticType
 	{
 		public FieldValue (TypeDefinition? staticType, FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -15,11 +15,11 @@ using Mono.Linker.Dataflow;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	sealed partial class FlowAnnotations
+	internal sealed partial class FlowAnnotations
 	{
-		readonly LinkContext _context;
-		readonly Dictionary<TypeDefinition, TypeAnnotations> _annotations = new Dictionary<TypeDefinition, TypeAnnotations> ();
-		readonly TypeHierarchyCache _hierarchyInfo;
+		private readonly LinkContext _context;
+		private readonly Dictionary<TypeDefinition, TypeAnnotations> _annotations = new Dictionary<TypeDefinition, TypeAnnotations> ();
+		private readonly TypeHierarchyCache _hierarchyInfo;
 
 		public FlowAnnotations (LinkContext context)
 		{
@@ -174,7 +174,7 @@ namespace ILLink.Shared.TrimAnalysis
 				_hierarchyInfo.IsSystemReflectionIReflect (type));
 		}
 
-		TypeAnnotations GetAnnotations (TypeDefinition type)
+		private TypeAnnotations GetAnnotations (TypeDefinition type)
 		{
 			if (!_annotations.TryGetValue (type, out TypeAnnotations value)) {
 				value = BuildTypeAnnotations (type);
@@ -184,13 +184,13 @@ namespace ILLink.Shared.TrimAnalysis
 			return value;
 		}
 
-		static bool IsDynamicallyAccessedMembersAttribute (CustomAttribute attribute)
+		private static bool IsDynamicallyAccessedMembersAttribute (CustomAttribute attribute)
 		{
 			var attributeType = attribute.AttributeType;
 			return attributeType.Name == "DynamicallyAccessedMembersAttribute" && attributeType.Namespace == "System.Diagnostics.CodeAnalysis";
 		}
 
-		DynamicallyAccessedMemberTypes GetMemberTypesForDynamicallyAccessedMembersAttribute (IMemberDefinition member, ICustomAttributeProvider? providerIfNotMember = null)
+		private DynamicallyAccessedMemberTypes GetMemberTypesForDynamicallyAccessedMembersAttribute (IMemberDefinition member, ICustomAttributeProvider? providerIfNotMember = null)
 		{
 			ICustomAttributeProvider provider = providerIfNotMember ?? member;
 			if (!_context.CustomAttributes.HasAny (provider))
@@ -206,12 +206,12 @@ namespace ILLink.Shared.TrimAnalysis
 			return DynamicallyAccessedMemberTypes.None;
 		}
 
-		TypeAnnotations BuildTypeAnnotations (TypeDefinition type)
+		private TypeAnnotations BuildTypeAnnotations (TypeDefinition type)
 		{
 			// class, interface, struct can have annotations
 			DynamicallyAccessedMemberTypes typeAnnotation = GetMemberTypesForDynamicallyAccessedMembersAttribute (type);
 
-			var annotatedFields = new ArrayBuilder<FieldAnnotation> ();
+			var annotatedFields = default (ArrayBuilder<FieldAnnotation>);
 
 			// First go over all fields with an explicit annotation
 			if (type.HasFields) {
@@ -231,7 +231,7 @@ namespace ILLink.Shared.TrimAnalysis
 				}
 			}
 
-			var annotatedMethods = new ArrayBuilder<MethodAnnotations> ();
+			var annotatedMethods = default (ArrayBuilder<MethodAnnotations>);
 
 			// Next go over all methods with an explicit annotation
 			if (type.HasMethods) {
@@ -426,7 +426,7 @@ namespace ILLink.Shared.TrimAnalysis
 			return attrs;
 		}
 
-		bool ScanMethodBodyForFieldAccess (MethodBody body, bool write, out FieldDefinition? found)
+		private bool ScanMethodBodyForFieldAccess (MethodBody body, bool write, out FieldDefinition? found)
 		{
 			// Tries to find the backing field for a property getter/setter.
 			// Returns true if this is a method body that we can unambiguously analyze.
@@ -528,7 +528,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		void ValidateMethodParametersHaveNoAnnotations (DynamicallyAccessedMemberTypes[] parameterAnnotations, MethodDefinition method, MethodDefinition baseMethod, IMemberDefinition origin)
+		private void ValidateMethodParametersHaveNoAnnotations (DynamicallyAccessedMemberTypes[] parameterAnnotations, MethodDefinition method, MethodDefinition baseMethod, IMemberDefinition origin)
 		{
 			for (int parameterIndex = 0; parameterIndex < parameterAnnotations.Length; parameterIndex++) {
 				var annotation = parameterAnnotations[parameterIndex];
@@ -540,7 +540,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		void ValidateMethodGenericParametersHaveNoAnnotations (DynamicallyAccessedMemberTypes[] genericParameterAnnotations, MethodDefinition method, MethodDefinition baseMethod, IMemberDefinition origin)
+		private void ValidateMethodGenericParametersHaveNoAnnotations (DynamicallyAccessedMemberTypes[] genericParameterAnnotations, MethodDefinition method, MethodDefinition baseMethod, IMemberDefinition origin)
 		{
 			for (int genericParameterIndex = 0; genericParameterIndex < genericParameterAnnotations.Length; genericParameterIndex++) {
 				if (genericParameterAnnotations[genericParameterIndex] != DynamicallyAccessedMemberTypes.None) {
@@ -552,7 +552,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		void LogValidationWarning (IMetadataTokenProvider provider, IMetadataTokenProvider baseProvider, IMemberDefinition origin)
+		private void LogValidationWarning (IMetadataTokenProvider provider, IMetadataTokenProvider baseProvider, IMemberDefinition origin)
 		{
 			Debug.Assert (provider.GetType () == baseProvider.GetType ());
 			Debug.Assert (!(provider is GenericParameter genericParameter) || genericParameter.DeclaringMethod != null);
@@ -583,13 +583,13 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		readonly struct TypeAnnotations
+		private readonly struct TypeAnnotations
 		{
-			readonly TypeDefinition _type;
-			readonly DynamicallyAccessedMemberTypes _typeAnnotation;
-			readonly MethodAnnotations[]? _annotatedMethods;
-			readonly FieldAnnotation[]? _annotatedFields;
-			readonly DynamicallyAccessedMemberTypes[]? _genericParameterAnnotations;
+			private readonly TypeDefinition _type;
+			private readonly DynamicallyAccessedMemberTypes _typeAnnotation;
+			private readonly MethodAnnotations[]? _annotatedMethods;
+			private readonly FieldAnnotation[]? _annotatedFields;
+			private readonly DynamicallyAccessedMemberTypes[]? _genericParameterAnnotations;
 
 			public TypeAnnotations (
 				TypeDefinition type,
@@ -656,7 +656,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		readonly struct MethodAnnotations
+		private readonly struct MethodAnnotations
 		{
 			public readonly MethodDefinition Method;
 			public readonly DynamicallyAccessedMemberTypes[]? ParameterAnnotations;
@@ -689,7 +689,7 @@ namespace ILLink.Shared.TrimAnalysis
 			}
 		}
 
-		readonly struct FieldAnnotation
+		private readonly struct FieldAnnotation
 		{
 			public readonly FieldDefinition Field;
 			public readonly DynamicallyAccessedMemberTypes Annotation;

--- a/src/linker/Linker.Dataflow/GenericArgumentDataFlow.cs
+++ b/src/linker/Linker.Dataflow/GenericArgumentDataFlow.cs
@@ -12,9 +12,9 @@ namespace Mono.Linker.Dataflow
 {
 	public readonly struct GenericArgumentDataFlow
 	{
-		readonly LinkContext _context;
-		readonly MarkStep _markStep;
-		readonly MessageOrigin _origin;
+		private readonly LinkContext _context;
+		private readonly MarkStep _markStep;
+		private readonly MessageOrigin _origin;
 
 		public GenericArgumentDataFlow (LinkContext context, MarkStep markStep, in MessageOrigin origin)
 		{
@@ -34,7 +34,7 @@ namespace Mono.Linker.Dataflow
 			RequireDynamicallyAccessedMembers (diagnosticContext, genericArgumentValue, genericParameterValue);
 		}
 
-		void RequireDynamicallyAccessedMembers (in DiagnosticContext diagnosticContext, in MultiValue value, ValueWithDynamicallyAccessedMembers targetValue)
+		private void RequireDynamicallyAccessedMembers (in DiagnosticContext diagnosticContext, in MultiValue value, ValueWithDynamicallyAccessedMembers targetValue)
 		{
 			var reflectionMarker = new ReflectionMarker (_context, _markStep, enabled: true);
 			var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction (reflectionMarker, diagnosticContext);

--- a/src/linker/Linker.Dataflow/GenericParameterValue.cs
+++ b/src/linker/Linker.Dataflow/GenericParameterValue.cs
@@ -13,7 +13,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// This is a System.Type value which represents generic parameter (basically result of typeof(T))
 	/// Its actual type is unknown, but it can have annotations.
 	/// </summary>
-	partial record GenericParameterValue
+	internal partial record GenericParameterValue
 	{
 		public GenericParameterValue (GenericParameter genericParameter, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{

--- a/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -10,13 +10,13 @@ using Mono.Linker.Dataflow;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial struct HandleCallAction
+	internal partial struct HandleCallAction
 	{
 #pragma warning disable CA1822 // Mark members as static - the other partial implementations might need to be instance methods
 
-		readonly LinkContext _context;
-		readonly ReflectionMarker _reflectionMarker;
-		readonly MethodDefinition _callingMethodDefinition;
+		private readonly LinkContext _context;
+		private readonly ReflectionMarker _reflectionMarker;
+		private readonly MethodDefinition _callingMethodDefinition;
 
 		public HandleCallAction (
 			LinkContext context,

--- a/src/linker/Linker.Dataflow/HoistedLocalKey.cs
+++ b/src/linker/Linker.Dataflow/HoistedLocalKey.cs
@@ -13,7 +13,7 @@ namespace Mono.Linker.Dataflow
 	// or local functions).
 	public readonly struct HoistedLocalKey : IEquatable<HoistedLocalKey>
 	{
-		readonly FieldDefinition Field;
+		private readonly FieldDefinition Field;
 
 		public HoistedLocalKey (FieldDefinition field)
 		{

--- a/src/linker/Linker.Dataflow/IValueWithStaticType.cs
+++ b/src/linker/Linker.Dataflow/IValueWithStaticType.cs
@@ -5,7 +5,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker.Dataflow
 {
-	interface IValueWithStaticType
+	internal interface IValueWithStaticType
 	{
 		/// <summary>
 		/// The IL type of the value, represented as closely as possible, but not always exact.  It can be null, for

--- a/src/linker/Linker.Dataflow/InterproceduralState.cs
+++ b/src/linker/Linker.Dataflow/InterproceduralState.cs
@@ -15,15 +15,17 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 namespace Mono.Linker.Dataflow
 {
 	// Wrapper that implements IEquatable for MethodBody.
-	readonly record struct MethodBodyValue (MethodBody MethodBody);
+	internal readonly record struct MethodBodyValue (MethodBody MethodBody);
 
 	// Tracks the set of methods which get analyzer together during interprocedural analysis,
 	// and the possible states of hoisted locals in state machine methods and lambdas/local functions.
-	struct InterproceduralState : IEquatable<InterproceduralState>
+#pragma warning disable CA1067 // Struct has its own Equals method
+	internal struct InterproceduralState : IEquatable<InterproceduralState>
+#pragma warning restore CA1067 // Override Object.Equals(object) when implementing IEquatable<T>
 	{
 		public ValueSet<MethodBodyValue> MethodBodies;
 		public HoistedLocalState HoistedLocals;
-		readonly InterproceduralStateLattice lattice;
+		private readonly InterproceduralStateLattice lattice;
 
 		public InterproceduralState (ValueSet<MethodBodyValue> methodBodies, HoistedLocalState hoistedLocals, InterproceduralStateLattice lattice)
 			=> (MethodBodies, HoistedLocals, this.lattice) = (methodBodies, hoistedLocals, lattice);
@@ -74,9 +76,14 @@ namespace Mono.Linker.Dataflow
 
 		public MultiValue GetHoistedLocal (HoistedLocalKey key)
 			=> HoistedLocals.Get (key);
+
+		public override int GetHashCode ()
+		{
+			throw new NotImplementedException ();
+		}
 	}
 
-	struct InterproceduralStateLattice : ILattice<InterproceduralState>
+	internal struct InterproceduralStateLattice : ILattice<InterproceduralState>
 	{
 		public readonly ValueSetLattice<MethodBodyValue> MethodBodyLattice;
 		public readonly DictionaryLattice<HoistedLocalKey, MultiValue, ValueSetLattice<SingleValue>> HoistedLocalsLattice;

--- a/src/linker/Linker.Dataflow/MethodParameterValue.cs
+++ b/src/linker/Linker.Dataflow/MethodParameterValue.cs
@@ -15,7 +15,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// A value that came from a method parameter - such as the result of a ldarg.
 	/// </summary>
-	partial record MethodParameterValue : IValueWithStaticType
+	internal partial record MethodParameterValue : IValueWithStaticType
 	{
 		public MethodParameterValue (TypeDefinition? staticType, MethodDefinition method, int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{

--- a/src/linker/Linker.Dataflow/MethodProxy.cs
+++ b/src/linker/Linker.Dataflow/MethodProxy.cs
@@ -8,7 +8,7 @@ using Mono.Linker;
 
 namespace ILLink.Shared.TypeSystemProxy
 {
-	readonly partial struct MethodProxy : IEquatable<MethodProxy>
+	internal readonly partial struct MethodProxy : IEquatable<MethodProxy>
 	{
 		public MethodProxy (MethodDefinition method) => Method = method;
 

--- a/src/linker/Linker.Dataflow/MethodReturnValue.cs
+++ b/src/linker/Linker.Dataflow/MethodReturnValue.cs
@@ -14,7 +14,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// Return value from a method
 	/// </summary>
-	partial record MethodReturnValue : IValueWithStaticType
+	internal partial record MethodReturnValue : IValueWithStaticType
 	{
 		public MethodReturnValue (TypeDefinition? staticType, MethodDefinition method, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{

--- a/src/linker/Linker.Dataflow/MethodThisParameterValue.cs
+++ b/src/linker/Linker.Dataflow/MethodThisParameterValue.cs
@@ -16,7 +16,7 @@ namespace ILLink.Shared.TrimAnalysis
 	/// <summary>
 	/// A value that came from the implicit this parameter of a method
 	/// </summary>
-	partial record MethodThisParameterValue : IValueWithStaticType
+	internal partial record MethodThisParameterValue : IValueWithStaticType
 	{
 		public MethodThisParameterValue (MethodDefinition method, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{

--- a/src/linker/Linker.Dataflow/ReflectionMarker.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMarker.cs
@@ -13,9 +13,9 @@ namespace Mono.Linker.Dataflow
 {
 	public readonly struct ReflectionMarker
 	{
-		readonly LinkContext _context;
-		readonly MarkStep _markStep;
-		readonly bool _enabled;
+		private readonly LinkContext _context;
+		private readonly MarkStep _markStep;
+		private readonly bool _enabled;
 
 		public ReflectionMarker (LinkContext context, MarkStep markStep, bool enabled)
 		{
@@ -84,7 +84,7 @@ namespace Mono.Linker.Dataflow
 			return true;
 		}
 
-		void MarkResolvedType (
+		private void MarkResolvedType (
 			in DiagnosticContext diagnosticContext,
 			TypeReference typeReference,
 			TypeDefinition typeDefinition,
@@ -120,7 +120,7 @@ namespace Mono.Linker.Dataflow
 			_markStep.MarkMethodVisibleToReflection (method, new DependencyInfo (dependencyKind, origin.Provider), origin);
 		}
 
-		void MarkField (in MessageOrigin origin, FieldDefinition field, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		private void MarkField (in MessageOrigin origin, FieldDefinition field, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
 		{
 			if (!_enabled)
 				return;
@@ -136,7 +136,7 @@ namespace Mono.Linker.Dataflow
 			_markStep.MarkPropertyVisibleToReflection (property, new DependencyInfo (dependencyKind, origin.Provider), origin);
 		}
 
-		void MarkEvent (in MessageOrigin origin, EventDefinition @event, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		private void MarkEvent (in MessageOrigin origin, EventDefinition @event, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
 		{
 			if (!_enabled)
 				return;
@@ -144,7 +144,7 @@ namespace Mono.Linker.Dataflow
 			_markStep.MarkEventVisibleToReflection (@event, new DependencyInfo (dependencyKind, origin.Provider), origin);
 		}
 
-		void MarkInterfaceImplementation (in MessageOrigin origin, InterfaceImplementation interfaceImplementation, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
+		private void MarkInterfaceImplementation (in MessageOrigin origin, InterfaceImplementation interfaceImplementation, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
 		{
 			if (!_enabled)
 				return;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -16,12 +16,12 @@ using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.Single
 
 namespace Mono.Linker.Dataflow
 {
-	sealed class ReflectionMethodBodyScanner : MethodBodyScanner
+	internal sealed class ReflectionMethodBodyScanner : MethodBodyScanner
 	{
-		readonly MarkStep _markStep;
-		MessageOrigin _origin;
-		readonly FlowAnnotations _annotations;
-		readonly ReflectionMarker _reflectionMarker;
+		private readonly MarkStep _markStep;
+		private MessageOrigin _origin;
+		private readonly FlowAnnotations _annotations;
+		private readonly ReflectionMarker _reflectionMarker;
 		public readonly TrimAnalysisPatternStore TrimAnalysisPatterns;
 
 		public static bool RequiresReflectionMethodBodyScannerForCallSite (LinkContext context, MethodReference calledMethod)
@@ -99,7 +99,7 @@ namespace Mono.Linker.Dataflow
 		protected override ValueWithDynamicallyAccessedMembers GetMethodParameterValue (MethodDefinition method, SourceParameterIndex parameterIndex)
 			=> GetMethodParameterValue (method, parameterIndex, _annotations.GetParameterAnnotation (method, parameterIndex));
 
-		ValueWithDynamicallyAccessedMembers GetMethodParameterValue (MethodDefinition method, SourceParameterIndex parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+		private ValueWithDynamicallyAccessedMembers GetMethodParameterValue (MethodDefinition method, SourceParameterIndex parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			return _annotations.GetMethodParameterValue (method, parameterIndex, dynamicallyAccessedMemberTypes);
 		}
@@ -128,7 +128,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool HandleCall (MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams, out MultiValue methodReturnValue)
 		{
-			methodReturnValue = new ();
+			methodReturnValue = default (MultiValue);
 
 			var reflectionProcessed = _markStep.ProcessReflectionDependency (callingMethodBody, operation);
 			if (reflectionProcessed)
@@ -375,7 +375,7 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
-		static bool IsComInterop (IMarshalInfoProvider marshalInfoProvider, TypeReference parameterType, LinkContext context)
+		private static bool IsComInterop (IMarshalInfoProvider marshalInfoProvider, TypeReference parameterType, LinkContext context)
 		{
 			// This is best effort. One can likely find ways how to get COM without triggering these alarms.
 			// AsAny marshalling of a struct with an object-typed field would be one, for example.
@@ -433,7 +433,7 @@ namespace Mono.Linker.Dataflow
 			return false;
 		}
 
-		void HandleAssignmentPattern (
+		private void HandleAssignmentPattern (
 			in MessageOrigin origin,
 			in MultiValue value,
 			ValueWithDynamicallyAccessedMembers targetValue)

--- a/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/linker/Linker.Dataflow/RequireDynamicallyAccessedMembersAction.cs
@@ -9,9 +9,9 @@ using Mono.Linker.Dataflow;
 
 namespace ILLink.Shared.TrimAnalysis
 {
-	partial struct RequireDynamicallyAccessedMembersAction
+	internal partial struct RequireDynamicallyAccessedMembersAction
 	{
-		readonly ReflectionMarker _reflectionMarker;
+		private readonly ReflectionMarker _reflectionMarker;
 
 		public RequireDynamicallyAccessedMembersAction (
 			ReflectionMarker reflectionMarker,

--- a/src/linker/Linker.Dataflow/ScannerExtensions.cs
+++ b/src/linker/Linker.Dataflow/ScannerExtensions.cs
@@ -7,7 +7,7 @@ using Mono.Cecil.Cil;
 
 namespace Mono.Linker.Dataflow
 {
-	static class ScannerExtensions
+	internal static class ScannerExtensions
 	{
 		public static bool IsControlFlowInstruction (in this OpCode opcode)
 		{
@@ -22,7 +22,7 @@ namespace Mono.Linker.Dataflow
 			foreach (Instruction operation in methodBody.Instructions) {
 				if (!operation.OpCode.IsControlFlowInstruction ())
 					continue;
-				Object value = operation.Operand;
+				object value = operation.Operand;
 				if (value is Instruction inst) {
 					branchTargets.Add (inst.Offset);
 				} else if (value is Instruction[] instructions) {

--- a/src/linker/Linker.Dataflow/SingleValueExtensions.cs
+++ b/src/linker/Linker.Dataflow/SingleValueExtensions.cs
@@ -77,7 +77,7 @@ namespace ILLink.Shared.TrimAnalysis
 				break;
 
 			default:
-				throw new Exception (String.Format ("Unknown node type: {0}", node.GetType ().Name));
+				throw new Exception (string.Format ("Unknown node type: {0}", node.GetType ().Name));
 			}
 			seenNodes.Remove (node);
 

--- a/src/linker/Linker.Dataflow/TrimAnalysisPatternStore.cs
+++ b/src/linker/Linker.Dataflow/TrimAnalysisPatternStore.cs
@@ -10,10 +10,10 @@ namespace Mono.Linker.Dataflow
 {
 	public readonly struct TrimAnalysisPatternStore
 	{
-		readonly Dictionary<(MessageOrigin, bool), TrimAnalysisAssignmentPattern> AssignmentPatterns;
-		readonly Dictionary<MessageOrigin, TrimAnalysisMethodCallPattern> MethodCallPatterns;
-		readonly ValueSetLattice<SingleValue> Lattice;
-		readonly LinkContext _context;
+		private readonly Dictionary<(MessageOrigin, bool), TrimAnalysisAssignmentPattern> AssignmentPatterns;
+		private readonly Dictionary<MessageOrigin, TrimAnalysisMethodCallPattern> MethodCallPatterns;
+		private readonly ValueSetLattice<SingleValue> Lattice;
+		private readonly LinkContext _context;
 
 		public TrimAnalysisPatternStore (ValueSetLattice<SingleValue> lattice, LinkContext context)
 		{

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -26,7 +26,7 @@ namespace Mono.Linker.Dataflow
 
 		public override int GetHashCode ()
 		{
-			HashCode hashCode = new HashCode ();
+			HashCode hashCode = default (HashCode);
 			foreach (var item in this)
 				hashCode.Add (item.GetHashCode ());
 			return hashCode.ToHashCode ();

--- a/src/linker/Linker.Steps/AddBypassNGenStep.cs
+++ b/src/linker/Linker.Steps/AddBypassNGenStep.cs
@@ -12,8 +12,8 @@ namespace Mono.Linker.Steps
 	public class AddBypassNGenStep : BaseStep
 	{
 
-		AssemblyDefinition? coreLibAssembly;
-		CustomAttribute? bypassNGenAttribute;
+		private AssemblyDefinition? coreLibAssembly;
+		private CustomAttribute? bypassNGenAttribute;
 
 		protected override void ProcessAssembly (AssemblyDefinition assembly)
 		{
@@ -31,7 +31,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessType (TypeDefinition type)
+		private void ProcessType (TypeDefinition type)
 		{
 			if (type.HasMethods)
 				ProcessMethods (type.Methods, type.Module);
@@ -40,7 +40,7 @@ namespace Mono.Linker.Steps
 				ProcessNestedTypes (type);
 		}
 
-		void ProcessMethods (Collection<MethodDefinition> methods, ModuleDefinition module)
+		private void ProcessMethods (Collection<MethodDefinition> methods, ModuleDefinition module)
 		{
 			foreach (var method in methods)
 				if (!Annotations.IsMarked (method)) {
@@ -49,7 +49,7 @@ namespace Mono.Linker.Steps
 				}
 		}
 
-		void ProcessNestedTypes (TypeDefinition type)
+		private void ProcessNestedTypes (TypeDefinition type)
 		{
 			for (int i = 0; i < type.NestedTypes.Count; i++) {
 				var nested = type.NestedTypes[i];

--- a/src/linker/Linker.Steps/BaseSubStep.cs
+++ b/src/linker/Linker.Steps/BaseSubStep.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Steps
 	{
 		protected AnnotationStore Annotations => Context.Annotations;
 
-		LinkContext? _context { get; set; }
+		private LinkContext? _context { get; set; }
 		protected LinkContext Context {
 			get {
 				Debug.Assert (_context != null);

--- a/src/linker/Linker.Steps/BodySubstitutionParser.cs
+++ b/src/linker/Linker.Steps/BodySubstitutionParser.cs
@@ -13,7 +13,7 @@ namespace Mono.Linker.Steps
 {
 	public class BodySubstitutionParser : ProcessLinkerXmlBase
 	{
-		SubstitutionInfo? _substitutionInfo;
+		private SubstitutionInfo? _substitutionInfo;
 
 		public BodySubstitutionParser (LinkContext context, Stream documentStream, string xmlDocumentLocation)
 			: base (context, documentStream, xmlDocumentLocation)
@@ -121,14 +121,14 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessResources (AssemblyDefinition assembly, XPathNavigator nav)
+		private void ProcessResources (AssemblyDefinition assembly, XPathNavigator nav)
 		{
 			foreach (XPathNavigator resourceNav in nav.SelectChildren ("resource", "")) {
 				if (!ShouldProcessElement (resourceNav))
 					continue;
 
 				string name = GetAttribute (resourceNav, "name");
-				if (String.IsNullOrEmpty (name)) {
+				if (string.IsNullOrEmpty (name)) {
 					LogWarning (resourceNav, DiagnosticId.XmlMissingNameAttributeInResource);
 					continue;
 				}
@@ -149,7 +149,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static MethodDefinition? FindMethod (TypeDefinition type, string signature)
+		private static MethodDefinition? FindMethod (TypeDefinition type, string signature)
 		{
 			if (!type.HasMethods)
 				return null;

--- a/src/linker/Linker.Steps/CheckSuppressionsStep.cs
+++ b/src/linker/Linker.Steps/CheckSuppressionsStep.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Steps
 
 		public override bool IsActiveFor (AssemblyDefinition assembly)
 		{
-			// Only process assemblies which went through marking. 
+			// Only process assemblies which went through marking.
 			// The code relies on MarkStep to identify the useful suppressions.
 			// Assemblies which didn't go through marking would not produce any warnings and thus would report all suppressions as redundant.
 			var assemblyAction = Annotations.GetAction (assembly);

--- a/src/linker/Linker.Steps/CleanStep.cs
+++ b/src/linker/Linker.Steps/CleanStep.cs
@@ -43,13 +43,13 @@ namespace Mono.Linker.Steps
 				CleanAssembly (assembly);
 		}
 
-		static void CleanAssembly (AssemblyDefinition asm)
+		private static void CleanAssembly (AssemblyDefinition asm)
 		{
 			foreach (TypeDefinition type in asm.MainModule.Types)
 				CleanType (type);
 		}
 
-		static void CleanType (TypeDefinition type)
+		private static void CleanType (TypeDefinition type)
 		{
 			if (type.HasProperties)
 				CleanProperties (type);
@@ -61,7 +61,7 @@ namespace Mono.Linker.Steps
 					CleanType (nested);
 		}
 
-		static MethodDefinition? CheckMethod (TypeDefinition type, MethodDefinition method)
+		private static MethodDefinition? CheckMethod (TypeDefinition type, MethodDefinition method)
 		{
 			if (method == null)
 				return null;
@@ -69,7 +69,7 @@ namespace Mono.Linker.Steps
 			return type.Methods.Contains (method) ? method : null;
 		}
 
-		static void CleanEvents (TypeDefinition type)
+		private static void CleanEvents (TypeDefinition type)
 		{
 			var events = type.Events;
 
@@ -84,12 +84,12 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static bool IsEventUsed (EventDefinition evt)
+		private static bool IsEventUsed (EventDefinition evt)
 		{
 			return evt.AddMethod != null || evt.InvokeMethod != null || evt.RemoveMethod != null;
 		}
 
-		static void CleanProperties (TypeDefinition type)
+		private static void CleanProperties (TypeDefinition type)
 		{
 			var properties = type.Properties;
 
@@ -103,7 +103,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static bool IsPropertyUsed (PropertyDefinition prop)
+		private static bool IsPropertyUsed (PropertyDefinition prop)
 		{
 			return prop.GetMethod != null || prop.SetMethod != null;
 		}

--- a/src/linker/Linker.Steps/CodeRewriterStep.cs
+++ b/src/linker/Linker.Steps/CodeRewriterStep.cs
@@ -11,8 +11,8 @@ namespace Mono.Linker.Steps
 {
 	public class CodeRewriterStep : BaseStep
 	{
-		AssemblyDefinition? assembly;
-		AssemblyDefinition Assembly {
+		private AssemblyDefinition? assembly;
+		private AssemblyDefinition Assembly {
 			get {
 				Debug.Assert (assembly != null);
 				return assembly;
@@ -30,7 +30,7 @@ namespace Mono.Linker.Steps
 				ProcessType (type);
 		}
 
-		void ProcessType (TypeDefinition type)
+		private void ProcessType (TypeDefinition type)
 		{
 			foreach (var method in type.Methods) {
 				if (method.HasBody)
@@ -45,7 +45,7 @@ namespace Mono.Linker.Steps
 				ProcessType (nested);
 		}
 
-		void AddFieldsInitializations (TypeDefinition type)
+		private void AddFieldsInitializations (TypeDefinition type)
 		{
 			Instruction ret;
 			LinkerILProcessor processor;
@@ -96,7 +96,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessMethod (MethodDefinition method)
+		private void ProcessMethod (MethodDefinition method)
 		{
 			switch (Annotations.GetAction (method)) {
 			case MethodAction.ConvertToStub:
@@ -128,7 +128,7 @@ namespace Mono.Linker.Steps
 			method.ClearDebugInformation ();
 		}
 
-		MethodBody CreateThrowLinkedAwayBody (MethodDefinition method)
+		private MethodBody CreateThrowLinkedAwayBody (MethodDefinition method)
 		{
 			var body = new MethodBody (method);
 			var il = body.GetLinkerILProcessor ();
@@ -153,7 +153,7 @@ namespace Mono.Linker.Steps
 			return body;
 		}
 
-		MethodBody CreateStubBody (MethodDefinition method)
+		private MethodBody CreateStubBody (MethodDefinition method)
 		{
 			var body = new MethodBody (method);
 
@@ -193,7 +193,7 @@ namespace Mono.Linker.Steps
 			return body;
 		}
 
-		static void StubComplexBody (MethodDefinition method, MethodBody body, LinkerILProcessor il)
+		private static void StubComplexBody (MethodDefinition method, MethodBody body, LinkerILProcessor il)
 		{
 			switch (method.ReturnType.MetadataType) {
 			case MetadataType.MVar:

--- a/src/linker/Linker.Steps/DescriptorMarker.cs
+++ b/src/linker/Linker.Steps/DescriptorMarker.cs
@@ -14,14 +14,14 @@ namespace Mono.Linker.Steps
 {
 	public class DescriptorMarker : ProcessLinkerXmlBase
 	{
-		const string NamespaceElementName = "namespace";
+		private const string NamespaceElementName = "namespace";
 
-		const string _required = "required";
-		const string _preserve = "preserve";
-		const string _accessors = "accessors";
+		private const string _required = "required";
+		private const string _preserve = "preserve";
+		private const string _accessors = "accessors";
 
-		static readonly string[] _accessorsAll = new string[] { "all" };
-		static readonly char[] _accessorsSep = new char[] { ';' };
+		private static readonly string[] _accessorsAll = new string[] { "all" };
+		private static readonly char[] _accessorsSep = new char[] { ';' };
 
 		public DescriptorMarker (LinkContext context, Stream documentStream, string xmlDocumentLocation)
 			: base (context, documentStream, xmlDocumentLocation)
@@ -55,7 +55,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessNamespaces (AssemblyDefinition assembly, XPathNavigator nav)
+		private void ProcessNamespaces (AssemblyDefinition assembly, XPathNavigator nav)
 		{
 			foreach (XPathNavigator namespaceNav in nav.SelectChildren (NamespaceElementName, XmlNamespace)) {
 				if (!ShouldProcessElement (namespaceNav))
@@ -77,7 +77,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkAndPreserveAll (TypeDefinition type, XPathNavigator nav)
+		private void MarkAndPreserveAll (TypeDefinition type, XPathNavigator nav)
 		{
 			_context.Annotations.Mark (type, new DependencyInfo (DependencyKind.XmlDescriptor, _xmlDocumentLocation), GetMessageOriginForPosition (nav));
 			_context.Annotations.SetPreserve (type, TypePreserve.All);
@@ -168,7 +168,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessMethodIfNotNull (TypeDefinition type, MethodDefinition method, XPathNavigator nav, object? customData)
+		private void ProcessMethodIfNotNull (TypeDefinition type, MethodDefinition method, XPathNavigator nav, object? customData)
 		{
 			if (method == null)
 				return;
@@ -190,23 +190,23 @@ namespace Mono.Linker.Steps
 		{
 			StringBuilder sb = new StringBuilder ();
 			sb.Append (meth.ReturnType.FullName);
-			sb.Append (" ");
+			sb.Append (' ');
 			sb.Append (meth.Name);
 			if (includeGenericParameters && meth.HasGenericParameters) {
-				sb.Append ("`");
+				sb.Append ('`');
 				sb.Append (meth.GenericParameters.Count);
 			}
 
-			sb.Append ("(");
+			sb.Append ('(');
 			if (meth.HasParameters) {
 				for (int i = 0; i < meth.Parameters.Count; i++) {
 					if (i > 0)
-						sb.Append (",");
+						sb.Append (',');
 
 					sb.Append (meth.Parameters[i].ParameterType.FullName);
 				}
 			}
-			sb.Append (")");
+			sb.Append (')');
 			return sb.ToString ();
 		}
 
@@ -244,7 +244,7 @@ namespace Mono.Linker.Steps
 				LogWarning (nav, DiagnosticId.XmlCouldNotFindSetAccesorOfPropertyOnType, property.Name, type.FullName);
 		}
 
-		static bool IsRequired (XPathNavigator nav)
+		private static bool IsRequired (XPathNavigator nav)
 		{
 			string attribute = GetAttribute (nav, _required);
 			if (attribute == null || attribute.Length == 0)
@@ -263,7 +263,7 @@ namespace Mono.Linker.Steps
 
 				if (accessors.Length > 0) {
 					for (int i = 0; i < accessors.Length; ++i)
-						accessors[i] = accessors[i].ToLower ();
+						accessors[i] = accessors[i].ToLowerInvariant ();
 
 					return accessors;
 				}

--- a/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
+++ b/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
@@ -10,19 +10,19 @@ namespace Mono.Linker.Steps
 {
 	public class DiscoverOperatorsHandler : IMarkHandler
 	{
-		LinkContext? _context;
-		LinkContext Context {
+		private LinkContext? _context;
+		private LinkContext Context {
 			get {
 				Debug.Assert (_context != null);
 				return _context;
 			}
 		}
 
-		bool _seenLinqExpressions;
-		readonly HashSet<TypeDefinition> _trackedTypesWithOperators;
-		Dictionary<TypeDefinition, List<MethodDefinition>>? _pendingOperatorsForType;
+		private bool _seenLinqExpressions;
+		private readonly HashSet<TypeDefinition> _trackedTypesWithOperators;
+		private Dictionary<TypeDefinition, List<MethodDefinition>>? _pendingOperatorsForType;
 
-		Dictionary<TypeDefinition, List<MethodDefinition>> PendingOperatorsForType {
+		private Dictionary<TypeDefinition, List<MethodDefinition>> PendingOperatorsForType {
 			get {
 				if (_pendingOperatorsForType == null)
 					_pendingOperatorsForType = new Dictionary<TypeDefinition, List<MethodDefinition>> ();
@@ -41,7 +41,7 @@ namespace Mono.Linker.Steps
 			markContext.RegisterMarkTypeAction (ProcessType);
 		}
 
-		void ProcessType (TypeDefinition type)
+		private void ProcessType (TypeDefinition type)
 		{
 			CheckForLinqExpressions (type);
 
@@ -64,7 +64,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void CheckForLinqExpressions (TypeDefinition type)
+		private void CheckForLinqExpressions (TypeDefinition type)
 		{
 			if (_seenLinqExpressions)
 				return;
@@ -80,12 +80,12 @@ namespace Mono.Linker.Steps
 			_trackedTypesWithOperators.Clear ();
 		}
 
-		void MarkOperator (MethodDefinition method)
+		private void MarkOperator (MethodDefinition method)
 		{
 			Context.Annotations.Mark (method, new DependencyInfo (DependencyKind.PreservedOperator, method.DeclaringType), new MessageOrigin (method.DeclaringType));
 		}
 
-		bool ProcessCustomOperators (TypeDefinition type, bool mark)
+		private bool ProcessCustomOperators (TypeDefinition type, bool mark)
 		{
 			if (!type.HasMethods)
 				return false;
@@ -116,8 +116,8 @@ namespace Mono.Linker.Steps
 			return hasCustomOperators;
 		}
 
-		TypeDefinition? _nullableOfT;
-		TypeDefinition? NullableOfT {
+		private TypeDefinition? _nullableOfT;
+		private TypeDefinition? NullableOfT {
 			get {
 				if (_nullableOfT == null)
 					_nullableOfT = BCL.FindPredefinedType (WellKnownType.System_Nullable_T, Context);
@@ -125,7 +125,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		TypeDefinition? NonNullableType (TypeReference type)
+		private TypeDefinition? NonNullableType (TypeReference type)
 		{
 			var typeDef = Context.TryResolve (type);
 			if (typeDef == null)
@@ -145,7 +145,7 @@ namespace Mono.Linker.Steps
 			return Context.TryResolve (nullableType.GenericArguments[0]);
 		}
 
-		bool IsOperator (MethodDefinition method, out TypeDefinition? otherType)
+		private bool IsOperator (MethodDefinition method, out TypeDefinition? otherType)
 		{
 			otherType = null;
 

--- a/src/linker/Linker.Steps/DiscoverSerializationHandler.cs
+++ b/src/linker/Linker.Steps/DiscoverSerializationHandler.cs
@@ -13,8 +13,8 @@ namespace Mono.Linker.Steps
 	// - this will discover types in non-"link" assemblies as well
 	public class DiscoverSerializationHandler : IMarkHandler
 	{
-		LinkContext? _context;
-		LinkContext Context {
+		private LinkContext? _context;
+		private LinkContext Context {
 			get {
 				Debug.Assert (_context != null);
 				return _context;
@@ -28,7 +28,7 @@ namespace Mono.Linker.Steps
 			markContext.RegisterMarkMethodAction (CheckForSerializerActivation);
 		}
 
-		void CheckForSerializerActivation (MethodDefinition method)
+		private void CheckForSerializerActivation (MethodDefinition method)
 		{
 			var type = method.DeclaringType;
 
@@ -49,7 +49,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessType (TypeDefinition type)
+		private void ProcessType (TypeDefinition type)
 		{
 			ProcessAttributeProvider (type);
 
@@ -75,7 +75,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessAttributeProvider (ICustomAttributeProvider provider)
+		private void ProcessAttributeProvider (ICustomAttributeProvider provider)
 		{
 			if (!provider.HasCustomAttributes)
 				return;
@@ -96,7 +96,7 @@ namespace Mono.Linker.Steps
 				Context.SerializationMarker.TrackForSerialization (provider, SerializerKind.XmlSerializer);
 		}
 
-		static bool IsPreservedSerializationAttribute (ICustomAttributeProvider provider, CustomAttribute attribute, out SerializerKind serializerKind)
+		private static bool IsPreservedSerializationAttribute (ICustomAttributeProvider provider, CustomAttribute attribute, out SerializerKind serializerKind)
 		{
 			TypeReference attributeType = attribute.Constructor.DeclaringType;
 			serializerKind = SerializerKind.None;

--- a/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
+++ b/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
@@ -17,7 +17,7 @@ namespace Mono.Linker.Steps
 				InitializeExportedType (type, context, assembly);
 		}
 
-		static void InitializeExportedType (ExportedType exportedType, LinkContext context, AssemblyDefinition assembly)
+		private static void InitializeExportedType (ExportedType exportedType, LinkContext context, AssemblyDefinition assembly)
 		{
 			if (!context.Annotations.IsMarked (exportedType))
 				return;

--- a/src/linker/Linker.Steps/MarkScopeStack.cs
+++ b/src/linker/Linker.Steps/MarkScopeStack.cs
@@ -20,12 +20,12 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		readonly Stack<Scope> _scopeStack;
+		private readonly Stack<Scope> _scopeStack;
 
-		readonly struct LocalScope : IDisposable
+		private readonly struct LocalScope : IDisposable
 		{
-			readonly MessageOrigin _origin;
-			readonly MarkScopeStack _scopeStack;
+			private readonly MessageOrigin _origin;
+			private readonly MarkScopeStack _scopeStack;
 
 			public LocalScope (in MessageOrigin origin, MarkScopeStack scopeStack)
 			{
@@ -51,11 +51,11 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		readonly struct ParentScope : IDisposable
+		private readonly struct ParentScope : IDisposable
 		{
-			readonly Scope _parentScope;
-			readonly Scope _childScope;
-			readonly MarkScopeStack _scopeStack;
+			private readonly Scope _parentScope;
+			private readonly Scope _childScope;
+			private readonly MarkScopeStack _scopeStack;
 
 			public ParentScope (MarkScopeStack scopeStack)
 			{
@@ -111,12 +111,12 @@ namespace Mono.Linker.Steps
 			_scopeStack.Push (new Scope (new MessageOrigin (scope.Origin.Provider, offset)));
 		}
 
-		void Push (in Scope scope)
+		private void Push (in Scope scope)
 		{
 			_scopeStack.Push (scope);
 		}
 
-		Scope Pop ()
+		private Scope Pop ()
 		{
 			if (!_scopeStack.TryPop (out var result))
 				throw new InternalErrorException ($"Scope stack imbalance - trying to pop empty stack.");

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -50,7 +50,7 @@ namespace Mono.Linker.Steps
 
 	public partial class MarkStep : IStep
 	{
-		LinkContext? _context;
+		private LinkContext? _context;
 		protected LinkContext Context {
 			get {
 				Debug.Assert (_context != null);
@@ -61,7 +61,7 @@ namespace Mono.Linker.Steps
 		protected Queue<(MethodDefinition, DependencyInfo, MessageOrigin)> _methods;
 		protected HashSet<(MethodDefinition, MarkScopeStack.Scope)> _virtual_methods;
 		protected Queue<AttributeProviderPair> _assemblyLevelAttributes;
-		readonly List<AttributeProviderPair> _ivt_attributes;
+		private readonly List<AttributeProviderPair> _ivt_attributes;
 		protected Queue<(AttributeProviderPair, DependencyInfo, MarkScopeStack.Scope)> _lateMarkedAttributes;
 		protected List<(TypeDefinition, MarkScopeStack.Scope)> _typesWithInterfaces;
 		protected HashSet<(OverrideInformation, MarkScopeStack.Scope)> _interfaceOverrides;
@@ -69,30 +69,30 @@ namespace Mono.Linker.Steps
 		protected List<TypeDefinition> _dynamicInterfaceCastableImplementationTypes;
 		protected List<(MethodBody, MarkScopeStack.Scope)> _unreachableBodies;
 
-		readonly List<(TypeDefinition Type, MethodBody Body, Instruction Instr)> _pending_isinst_instr;
+		private readonly List<(TypeDefinition Type, MethodBody Body, Instruction Instr)> _pending_isinst_instr;
 
 		// Stores, for compiler-generated methods only, whether they require the reflection
 		// method body scanner.
-		readonly Dictionary<MethodBody, bool> _compilerGeneratedMethodRequiresScanner;
+		private readonly Dictionary<MethodBody, bool> _compilerGeneratedMethodRequiresScanner;
 
-		UnreachableBlocksOptimizer? _unreachableBlocksOptimizer;
-		UnreachableBlocksOptimizer UnreachableBlocksOptimizer {
+		private UnreachableBlocksOptimizer? _unreachableBlocksOptimizer;
+		private UnreachableBlocksOptimizer UnreachableBlocksOptimizer {
 			get {
 				Debug.Assert (_unreachableBlocksOptimizer != null);
 				return _unreachableBlocksOptimizer;
 			}
 		}
-		MarkStepContext? _markContext;
-		MarkStepContext MarkContext {
+		private MarkStepContext? _markContext;
+		private MarkStepContext MarkContext {
 			get {
 				Debug.Assert (_markContext != null);
 				return _markContext;
 			}
 		}
-		readonly HashSet<TypeDefinition> _entireTypesMarked;
-		DynamicallyAccessedMembersTypeHierarchy? _dynamicallyAccessedMembersTypeHierarchy;
-		MarkScopeStack? _scopeStack;
-		MarkScopeStack ScopeStack {
+		private readonly HashSet<TypeDefinition> _entireTypesMarked;
+		private DynamicallyAccessedMembersTypeHierarchy? _dynamicallyAccessedMembersTypeHierarchy;
+		private MarkScopeStack? _scopeStack;
+		private MarkScopeStack ScopeStack {
 			get {
 				Debug.Assert (_scopeStack != null);
 				return _scopeStack;
@@ -107,7 +107,7 @@ namespace Mono.Linker.Steps
 		}
 
 #if DEBUG
-		static readonly DependencyKind[] _entireTypeReasons = new DependencyKind[] {
+		private static readonly DependencyKind[] _entireTypeReasons = new DependencyKind[] {
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.BaseType,
 			DependencyKind.PreservedDependency,
@@ -116,7 +116,7 @@ namespace Mono.Linker.Steps
 			DependencyKind.Unspecified,
 		};
 
-		static readonly DependencyKind[] _fieldReasons = new DependencyKind[] {
+		private static readonly DependencyKind[] _fieldReasons = new DependencyKind[] {
 			DependencyKind.Unspecified,
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.AlreadyMarked,
@@ -136,7 +136,7 @@ namespace Mono.Linker.Steps
 			DependencyKind.XmlDescriptor,
 		};
 
-		static readonly DependencyKind[] _typeReasons = new DependencyKind[] {
+		private static readonly DependencyKind[] _typeReasons = new DependencyKind[] {
 			DependencyKind.Unspecified,
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.AlreadyMarked,
@@ -172,7 +172,7 @@ namespace Mono.Linker.Steps
 			DependencyKind.XmlDescriptor,
 		};
 
-		static readonly DependencyKind[] _methodReasons = new DependencyKind[] {
+		private static readonly DependencyKind[] _methodReasons = new DependencyKind[] {
 			DependencyKind.Unspecified,
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.AlreadyMarked,
@@ -255,7 +255,7 @@ namespace Mono.Linker.Steps
 			Complete ();
 		}
 
-		void Initialize ()
+		private void Initialize ()
 		{
 			InitializeCorelibAttributeXml ();
 			Context.Pipeline.InitializeMarkHandlers (Context, MarkContext);
@@ -263,7 +263,7 @@ namespace Mono.Linker.Steps
 			ProcessMarkedPending ();
 		}
 
-		void InitializeCorelibAttributeXml ()
+		private void InitializeCorelibAttributeXml ()
 		{
 			// Pre-load corelib and process its attribute XML first. This is necessary because the
 			// corelib attribute XML can contain modifications to other assemblies.
@@ -286,14 +286,14 @@ namespace Mono.Linker.Steps
 				Context.CustomAttributes.PrimaryAttributeInfo.CustomAttributesOrigins.Add (ca, origin);
 		}
 
-		void Complete ()
+		private void Complete ()
 		{
 			foreach ((var body, var _) in _unreachableBodies) {
 				Annotations.SetAction (body.Method, MethodAction.ConvertToThrow);
 			}
 		}
 
-		bool ProcessInternalsVisibleAttributes ()
+		private bool ProcessInternalsVisibleAttributes ()
 		{
 			bool marked_any = false;
 			foreach (var attr in _ivt_attributes) {
@@ -329,7 +329,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static bool TypeIsDynamicInterfaceCastableImplementation (TypeDefinition type)
+		private static bool TypeIsDynamicInterfaceCastableImplementation (TypeDefinition type)
 		{
 			if (!type.IsInterface || !type.HasInterfaces || !type.HasCustomAttributes)
 				return false;
@@ -414,7 +414,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void Process ()
+		private void Process ()
 		{
 			while (ProcessPrimaryQueue () ||
 				ProcessMarkedPending () ||
@@ -426,9 +426,9 @@ namespace Mono.Linker.Steps
 			ProcessPendingTypeChecks ();
 		}
 
-		static bool IsFullyPreservedAction (AssemblyAction action) => action == AssemblyAction.Copy || action == AssemblyAction.Save;
+		private static bool IsFullyPreservedAction (AssemblyAction action) => action == AssemblyAction.Copy || action == AssemblyAction.Save;
 
-		bool MarkFullyPreservedAssemblies ()
+		private bool MarkFullyPreservedAssemblies ()
 		{
 			// Fully mark any assemblies with copy/save action.
 
@@ -473,7 +473,7 @@ namespace Mono.Linker.Steps
 			return markedNewAssembly;
 		}
 
-		bool ProcessPrimaryQueue ()
+		private bool ProcessPrimaryQueue ()
 		{
 			if (QueueIsEmpty ())
 				return false;
@@ -490,7 +490,7 @@ namespace Mono.Linker.Steps
 			return true;
 		}
 
-		bool ProcessMarkedPending ()
+		private bool ProcessMarkedPending ()
 		{
 			using var emptyScope = ScopeStack.PushScope (new MessageOrigin (null as ICustomAttributeProvider));
 
@@ -536,7 +536,7 @@ namespace Mono.Linker.Steps
 			return marked;
 		}
 
-		void ProcessPendingTypeChecks ()
+		private void ProcessPendingTypeChecks ()
 		{
 			for (int i = 0; i < _pending_isinst_instr.Count; ++i) {
 				var item = _pending_isinst_instr[i];
@@ -555,7 +555,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessQueue ()
+		private void ProcessQueue ()
 		{
 			while (!QueueIsEmpty ()) {
 				(MethodDefinition method, DependencyInfo reason, MessageOrigin origin) = _methods.Dequeue ();
@@ -563,7 +563,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		bool QueueIsEmpty ()
+		private bool QueueIsEmpty ()
 		{
 			return _methods.Count == 0;
 		}
@@ -573,7 +573,7 @@ namespace Mono.Linker.Steps
 			_methods.Enqueue ((method, reason, origin));
 		}
 
-		void ProcessVirtualMethods ()
+		private void ProcessVirtualMethods ()
 		{
 			foreach ((MethodDefinition method, MarkScopeStack.Scope scope) in _virtual_methods) {
 				using (ScopeStack.PushScope (scope))
@@ -586,7 +586,7 @@ namespace Mono.Linker.Steps
 		/// once the linker knows whether a type is instantiated or relevant to variant casting,
 		/// and after interfaces and interface methods have been marked.
 		/// </summary>
-		void ProcessMarkedTypesWithInterfaces ()
+		private void ProcessMarkedTypesWithInterfaces ()
 		{
 			// We may mark an interface type later on.  Which means we need to reprocess any time with one or more interface implementations that have not been marked
 			// and if an interface type is found to be marked and implementation is not marked, then we need to mark that implementation
@@ -627,7 +627,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void DiscoverDynamicCastableImplementationInterfaces ()
+		private void DiscoverDynamicCastableImplementationInterfaces ()
 		{
 			// We could potentially avoid loading all references here: https://github.com/dotnet/linker/issues/1788
 			foreach (var assembly in Context.GetReferencedAssemblies ().ToArray ()) {
@@ -659,7 +659,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessDynamicCastableImplementationInterfaces ()
+		private void ProcessDynamicCastableImplementationInterfaces ()
 		{
 			DiscoverDynamicCastableImplementationInterfaces ();
 
@@ -690,7 +690,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessPendingBodies ()
+		private void ProcessPendingBodies ()
 		{
 			for (int i = 0; i < _unreachableBodies.Count; i++) {
 				(var body, var scope) = _unreachableBodies[i];
@@ -703,7 +703,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessVirtualMethod (MethodDefinition method)
+		private void ProcessVirtualMethod (MethodDefinition method)
 		{
 			Annotations.EnqueueVirtualMethod (method);
 
@@ -721,7 +721,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessOverride (OverrideInformation overrideInformation)
+		private void ProcessOverride (OverrideInformation overrideInformation)
 		{
 			var method = overrideInformation.Override;
 			var @base = overrideInformation.Base;
@@ -764,7 +764,7 @@ namespace Mono.Linker.Steps
 		/// Returns true if <paramref name="type"/> implements <paramref name="interfaceType"/> and the interface implementation is marked,
 		/// or if any marked interface implementations on <paramref name="type"/> are interfaces that implement <paramref name="interfaceType"/> and that interface implementation is marked
 		/// </summary>
-		bool IsInterfaceImplementationMarkedRecursively (TypeDefinition type, TypeDefinition interfaceType)
+		private bool IsInterfaceImplementationMarkedRecursively (TypeDefinition type, TypeDefinition interfaceType)
 		{
 			if (type.HasInterfaces) {
 				foreach (var intf in type.Interfaces) {
@@ -780,7 +780,7 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
-		bool RequiresInterfaceRecursively (TypeDefinition typeToExamine, TypeDefinition interfaceType)
+		private bool RequiresInterfaceRecursively (TypeDefinition typeToExamine, TypeDefinition interfaceType)
 		{
 			if (typeToExamine == interfaceType)
 				return true;
@@ -799,7 +799,7 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
-		void ProcessDefaultImplementation (TypeDefinition typeWithDefaultImplementedInterfaceMethod, InterfaceImplementation implementation)
+		private void ProcessDefaultImplementation (TypeDefinition typeWithDefaultImplementedInterfaceMethod, InterfaceImplementation implementation)
 		{
 			if (!Annotations.IsInstantiated (typeWithDefaultImplementedInterfaceMethod))
 				return;
@@ -807,7 +807,7 @@ namespace Mono.Linker.Steps
 			MarkInterfaceImplementation (implementation);
 		}
 
-		void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason)
+		private void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason)
 		{
 			if (!spec.HasMarshalInfo)
 				return;
@@ -822,7 +822,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkCustomAttributes (ICustomAttributeProvider provider, in DependencyInfo reason)
+		private void MarkCustomAttributes (ICustomAttributeProvider provider, in DependencyInfo reason)
 		{
 			if (provider.HasCustomAttributes) {
 				bool providerInLinkedAssembly = Annotations.GetAction (CustomAttributeSource.GetAssemblyFromCustomAttributeProvider (provider)) == AssemblyAction.Link;
@@ -858,7 +858,7 @@ namespace Mono.Linker.Steps
 					MarkDynamicDependency (dynamicDependency, providerMember);
 		}
 
-		bool IsAttributeRemoved (CustomAttribute ca, TypeDefinition attributeType)
+		private bool IsAttributeRemoved (CustomAttribute ca, TypeDefinition attributeType)
 		{
 			foreach (var attr in Annotations.GetLinkerAttributes<RemoveAttributeInstancesAttribute> (attributeType)) {
 				var args = attr.Arguments;
@@ -905,7 +905,7 @@ namespace Mono.Linker.Steps
 			return true;
 		}
 
-		void MarkDynamicDependency (DynamicDependency dynamicDependency, IMemberDefinition context)
+		private void MarkDynamicDependency (DynamicDependency dynamicDependency, IMemberDefinition context)
 		{
 			Debug.Assert (context is MethodDefinition || context is FieldDefinition);
 			AssemblyDefinition? assembly;
@@ -962,7 +962,7 @@ namespace Mono.Linker.Steps
 			MarkMembersVisibleToReflection (members, new DependencyInfo (DependencyKind.DynamicDependency, dynamicDependency.OriginalAttribute));
 		}
 
-		void MarkMembersVisibleToReflection (IEnumerable<IMetadataTokenProvider> members, in DependencyInfo reason)
+		private void MarkMembersVisibleToReflection (IEnumerable<IMetadataTokenProvider> members, in DependencyInfo reason)
 		{
 			foreach (var member in members) {
 				switch (member) {
@@ -1058,7 +1058,7 @@ namespace Mono.Linker.Steps
 			Context.LogWarning (context, DiagnosticId.CouldNotResolveDependencyMember, member ?? "", td.GetDisplayName ());
 		}
 
-		bool MarkDependencyMethod (TypeDefinition type, string name, string[]? signature, in DependencyInfo reason)
+		private bool MarkDependencyMethod (TypeDefinition type, string name, string[]? signature, in DependencyInfo reason)
 		{
 			bool marked = false;
 
@@ -1104,7 +1104,7 @@ namespace Mono.Linker.Steps
 			return marked;
 		}
 
-		void LazyMarkCustomAttributes (ICustomAttributeProvider provider)
+		private void LazyMarkCustomAttributes (ICustomAttributeProvider provider)
 		{
 			Debug.Assert (provider is ModuleDefinition or AssemblyDefinition);
 			if (!provider.HasCustomAttributes)
@@ -1261,7 +1261,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		PropertyDefinition? GetProperty (TypeDefinition inputType, string propertyname)
+		private PropertyDefinition? GetProperty (TypeDefinition inputType, string propertyname)
 		{
 			TypeDefinition? type = inputType;
 			while (type != null) {
@@ -1298,7 +1298,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		FieldDefinition? GetField (TypeDefinition inputType, string fieldname)
+		private FieldDefinition? GetField (TypeDefinition inputType, string fieldname)
 		{
 			TypeDefinition? type = inputType;
 			while (type != null) {
@@ -1312,7 +1312,7 @@ namespace Mono.Linker.Steps
 			return null;
 		}
 
-		MethodDefinition? GetMethodWithNoParameters (TypeDefinition inputType, string methodname)
+		private MethodDefinition? GetMethodWithNoParameters (TypeDefinition inputType, string methodname)
 		{
 			TypeDefinition? type = inputType;
 			while (type != null) {
@@ -1326,7 +1326,7 @@ namespace Mono.Linker.Steps
 			return null;
 		}
 
-		void MarkCustomAttributeArguments (CustomAttribute ca)
+		private void MarkCustomAttributeArguments (CustomAttribute ca)
 		{
 			if (!ca.HasConstructorArguments)
 				return;
@@ -1341,7 +1341,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkCustomAttributeArgument (CustomAttributeArgument argument, ICustomAttribute ca)
+		private void MarkCustomAttributeArgument (CustomAttributeArgument argument, ICustomAttribute ca)
 		{
 			var at = argument.Type;
 
@@ -1417,7 +1417,7 @@ namespace Mono.Linker.Steps
 				LazyMarkCustomAttributes (module);
 		}
 
-		void MarkEntireAssembly (AssemblyDefinition assembly)
+		private void MarkEntireAssembly (AssemblyDefinition assembly)
 		{
 			Debug.Assert (Annotations.IsProcessed (assembly));
 
@@ -1433,12 +1433,12 @@ namespace Mono.Linker.Steps
 			TypeReferenceMarker.MarkTypeReferences (assembly, MarkingHelpers);
 		}
 
-		sealed class TypeReferenceMarker : TypeReferenceWalker
+		private sealed class TypeReferenceMarker : TypeReferenceWalker
 		{
 
-			readonly MarkingHelpers markingHelpers;
+			private readonly MarkingHelpers markingHelpers;
 
-			TypeReferenceMarker (AssemblyDefinition assembly, MarkingHelpers markingHelpers)
+			private TypeReferenceMarker (AssemblyDefinition assembly, MarkingHelpers markingHelpers)
 				: base (assembly)
 			{
 				this.markingHelpers = markingHelpers;
@@ -1471,7 +1471,7 @@ namespace Mono.Linker.Steps
 				}
 			}
 
-			TypeReference CreateTypeReferenceForExportedTypeTarget (ExportedType exportedType)
+			private TypeReference CreateTypeReferenceForExportedTypeTarget (ExportedType exportedType)
 			{
 				TypeReference? declaringTypeReference = null;
 				if (exportedType.DeclaringType != null) {
@@ -1484,7 +1484,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessModuleType (AssemblyDefinition assembly)
+		private void ProcessModuleType (AssemblyDefinition assembly)
 		{
 			// The <Module> type may have an initializer, in which case we want to keep it.
 			TypeDefinition? moduleType = assembly.MainModule.Types.FirstOrDefault (t => t.MetadataToken.RID == 1);
@@ -1492,7 +1492,7 @@ namespace Mono.Linker.Steps
 				MarkType (moduleType, new DependencyInfo (DependencyKind.TypeInAssembly, assembly));
 		}
 
-		bool ProcessLazyAttributes ()
+		private bool ProcessLazyAttributes ()
 		{
 			if (Annotations.HasMarkedAnyIndirectlyCalledMethods () && MarkDisablePrivateReflectionAttribute ())
 				return true;
@@ -1557,7 +1557,7 @@ namespace Mono.Linker.Steps
 			return markOccurred;
 		}
 
-		bool ProcessLateMarkedAttributes ()
+		private bool ProcessLateMarkedAttributes ()
 		{
 			var startingQueueCount = _lateMarkedAttributes.Count;
 			if (startingQueueCount == 0)
@@ -1615,7 +1615,7 @@ namespace Mono.Linker.Steps
 			MarkField (field, reason, origin);
 		}
 
-		void ReportWarningsForTypeHierarchyReflectionAccess (IMemberDefinition member, MessageOrigin origin)
+		private void ReportWarningsForTypeHierarchyReflectionAccess (IMemberDefinition member, MessageOrigin origin)
 		{
 			Debug.Assert (member is MethodDefinition or FieldDefinition);
 
@@ -1679,7 +1679,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkField (FieldDefinition field, in DependencyInfo reason, in MessageOrigin origin)
+		private void MarkField (FieldDefinition field, in DependencyInfo reason, in MessageOrigin origin)
 		{
 #if DEBUG
 			if (!_fieldReasons.Contains (reason.Kind))
@@ -1740,7 +1740,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		bool ShouldWarnForReflectionAccessToCompilerGeneratedCode (FieldDefinition field, bool isCoveredByAnnotations)
+		private bool ShouldWarnForReflectionAccessToCompilerGeneratedCode (FieldDefinition field, bool isCoveredByAnnotations)
 		{
 			// No need to warn if it's already covered by the Requires attribute or explicit annotations on the field.
 			if (isCoveredByAnnotations)
@@ -1758,7 +1758,7 @@ namespace Mono.Linker.Steps
 			return Annotations.FlowAnnotations.IsTypeInterestingForDataflow (field.FieldType);
 		}
 
-		void ProcessAnalysisAnnotationsForField (FieldDefinition field, DependencyKind dependencyKind, in MessageOrigin origin)
+		private void ProcessAnalysisAnnotationsForField (FieldDefinition field, DependencyKind dependencyKind, in MessageOrigin origin)
 		{
 			if (origin.Provider != ScopeStack.CurrentScope.Origin.Provider) {
 				Debug.Assert (dependencyKind == DependencyKind.DynamicallyAccessedMemberOnType ||
@@ -1808,7 +1808,7 @@ namespace Mono.Linker.Steps
 			return assembly != null && Annotations.GetAction (assembly) != AssemblyAction.Link;
 		}
 
-		void MarkModule (ModuleDefinition module, DependencyInfo reason)
+		private void MarkModule (ModuleDefinition module, DependencyInfo reason)
 		{
 			if (reason.Kind == DependencyKind.AlreadyMarked) {
 				Debug.Assert (Annotations.IsMarked (module));
@@ -2078,7 +2078,7 @@ namespace Mono.Linker.Steps
 		{
 		}
 
-		TypeDefinition? GetDebuggerAttributeTargetType (CustomAttribute ca, AssemblyDefinition asm)
+		private TypeDefinition? GetDebuggerAttributeTargetType (CustomAttribute ca, AssemblyDefinition asm)
 		{
 			foreach (var property in ca.Properties) {
 				if (property.Name == "Target")
@@ -2099,7 +2099,7 @@ namespace Mono.Linker.Steps
 			return null;
 		}
 
-		void MarkTypeSpecialCustomAttributes (TypeDefinition type)
+		private void MarkTypeSpecialCustomAttributes (TypeDefinition type)
 		{
 			if (!type.HasCustomAttributes)
 				return;
@@ -2133,7 +2133,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkMethodSpecialCustomAttributes (MethodDefinition method)
+		private void MarkMethodSpecialCustomAttributes (MethodDefinition method)
 		{
 			if (!method.HasCustomAttributes)
 				return;
@@ -2147,7 +2147,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkXmlSchemaProvider (TypeDefinition type, CustomAttribute attribute)
+		private void MarkXmlSchemaProvider (TypeDefinition type, CustomAttribute attribute)
 		{
 			if (TryGetStringArgument (attribute, out string? name)) {
 				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
@@ -2155,9 +2155,9 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static readonly Regex DebuggerDisplayAttributeValueRegex = new Regex ("{[^{}]+}", RegexOptions.Compiled);
+		private static readonly Regex DebuggerDisplayAttributeValueRegex = new Regex ("{[^{}]+}", RegexOptions.Compiled);
 
-		void MarkTypeWithDebuggerDisplayAttribute (TypeDefinition type, CustomAttribute attribute)
+		private void MarkTypeWithDebuggerDisplayAttribute (TypeDefinition type, CustomAttribute attribute)
 		{
 			if (Context.KeepMembersForDebugger) {
 
@@ -2227,7 +2227,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkTypeWithDebuggerTypeProxyAttribute (TypeDefinition type, CustomAttribute attribute)
+		private void MarkTypeWithDebuggerTypeProxyAttribute (TypeDefinition type, CustomAttribute attribute)
 		{
 			if (Context.KeepMembersForDebugger) {
 				object constructorArgument = attribute.ConstructorArguments[0].Value;
@@ -2252,7 +2252,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static bool TryGetStringArgument (CustomAttribute attribute, [NotNullWhen (true)] out string? argument)
+		private static bool TryGetStringArgument (CustomAttribute attribute, [NotNullWhen (true)] out string? argument)
 		{
 			argument = null;
 
@@ -2281,7 +2281,7 @@ namespace Mono.Linker.Steps
 			return count;
 		}
 
-		void MarkSoapHeader (MethodDefinition method, CustomAttribute attribute)
+		private void MarkSoapHeader (MethodDefinition method, CustomAttribute attribute)
 		{
 			if (!TryGetStringArgument (attribute, out string? member_name))
 				return;
@@ -2290,7 +2290,7 @@ namespace Mono.Linker.Steps
 			MarkNamedProperty (method.DeclaringType, member_name, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 		}
 
-		bool MarkNamedField (TypeDefinition type, string field_name, in DependencyInfo reason)
+		private bool MarkNamedField (TypeDefinition type, string field_name, in DependencyInfo reason)
 		{
 			if (!type.HasFields)
 				return false;
@@ -2306,7 +2306,7 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
-		void MarkNamedProperty (TypeDefinition type, string property_name, in DependencyInfo reason)
+		private void MarkNamedProperty (TypeDefinition type, string property_name, in DependencyInfo reason)
 		{
 			if (!type.HasProperties)
 				return;
@@ -2323,7 +2323,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkInterfaceImplementations (TypeDefinition type)
+		private void MarkInterfaceImplementations (TypeDefinition type)
 		{
 			if (!type.HasInterfaces)
 				return;
@@ -2336,7 +2336,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkGenericParameterProvider (IGenericParameterProvider provider)
+		private void MarkGenericParameterProvider (IGenericParameterProvider provider)
 		{
 			if (!provider.HasGenericParameters)
 				return;
@@ -2345,7 +2345,7 @@ namespace Mono.Linker.Steps
 				MarkGenericParameter (parameter);
 		}
 
-		void MarkGenericParameter (GenericParameter parameter)
+		private void MarkGenericParameter (GenericParameter parameter)
 		{
 			MarkCustomAttributes (parameter, new DependencyInfo (DependencyKind.GenericParameterCustomAttribute, parameter.Owner));
 			if (!parameter.HasConstraints)
@@ -2366,7 +2366,7 @@ namespace Mono.Linker.Steps
 		/// When the unusedinterfaces optimization is off, this will do the same as when on but will also mark interface methods from interfaces defined in a non-link assembly.
 		/// If the containing type is instantiated, the caller should also use <see cref="IsMethodNeededByInstantiatedTypeDueToPreservedScope (MethodDefinition)" />
 		/// </remarks>
-		bool IsMethodNeededByTypeDueToPreservedScope (MethodDefinition method)
+		private bool IsMethodNeededByTypeDueToPreservedScope (MethodDefinition method)
 		{
 			if (Annotations.IsMarked (method))
 				return false;
@@ -2402,7 +2402,7 @@ namespace Mono.Linker.Steps
 		/// <summary>
 		/// Returns true if the override method is required due to the interface that the base method is declared on. See doc at <see href="docs/methods-kept-by-interface.md"/> for explanation of logic.
 		/// </summary>
-		bool IsInterfaceImplementationMethodNeededByTypeDueToInterface (OverrideInformation overrideInformation)
+		private bool IsInterfaceImplementationMethodNeededByTypeDueToInterface (OverrideInformation overrideInformation)
 		{
 			var @base = overrideInformation.Base;
 			var method = overrideInformation.Override;
@@ -2446,9 +2446,9 @@ namespace Mono.Linker.Steps
 		/// </summary>
 		/// <remarks>
 		/// This is very similar to <see cref="IsMethodNeededByTypeDueToPreservedScope (MethodDefinition)"/>,
-		///	but will mark methods from an interface defined in a non-link assembly regardless of the optimization, and does not handle static interface methods.
+		/// but will mark methods from an interface defined in a non-link assembly regardless of the optimization, and does not handle static interface methods.
 		/// </remarks>
-		bool IsMethodNeededByInstantiatedTypeDueToPreservedScope (MethodDefinition method)
+		private bool IsMethodNeededByInstantiatedTypeDueToPreservedScope (MethodDefinition method)
 		{
 			// Any static interface methods are captured by <see cref="IsVirtualNeededByTypeDueToPreservedScope">, which should be called on all relevant methods so no need to check again here.
 			if (!method.IsVirtual)
@@ -2469,7 +2469,7 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
-		static bool IsSpecialSerializationConstructor (MethodDefinition method)
+		private static bool IsSpecialSerializationConstructor (MethodDefinition method)
 		{
 			if (!method.IsInstanceConstructor ())
 				return false;
@@ -2513,7 +2513,7 @@ namespace Mono.Linker.Steps
 			return MarkMethodIf (type.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason, ScopeStack.CurrentScope.Origin) != null;
 		}
 
-		void MarkCustomMarshalerGetInstance (TypeDefinition type, in DependencyInfo reason)
+		private void MarkCustomMarshalerGetInstance (TypeDefinition type, in DependencyInfo reason)
 		{
 			if (!type.HasMethods)
 				return;
@@ -2524,7 +2524,7 @@ namespace Mono.Linker.Steps
 				ScopeStack.CurrentScope.Origin);
 		}
 
-		void MarkICustomMarshalerMethods (TypeDefinition inputType, in DependencyInfo reason)
+		private void MarkICustomMarshalerMethods (TypeDefinition inputType, in DependencyInfo reason)
 		{
 			TypeDefinition? type = inputType;
 			do {
@@ -2553,7 +2553,7 @@ namespace Mono.Linker.Steps
 			} while ((type = Context.TryResolve (type.BaseType)) != null);
 		}
 
-		static bool IsNonEmptyStaticConstructor (MethodDefinition method)
+		private static bool IsNonEmptyStaticConstructor (MethodDefinition method)
 		{
 			if (!method.IsStaticConstructor ())
 				return false;
@@ -2567,7 +2567,7 @@ namespace Mono.Linker.Steps
 			return method.Body.Instructions[0].OpCode.Code != Code.Ret;
 		}
 
-		static bool HasOnSerializeOrDeserializeAttribute (MethodDefinition method)
+		private static bool HasOnSerializeOrDeserializeAttribute (MethodDefinition method)
 		{
 			if (!method.HasCustomAttributes)
 				return false;
@@ -2602,7 +2602,7 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
-		void MarkEventSourceProviders (TypeDefinition td)
+		private void MarkEventSourceProviders (TypeDefinition td)
 		{
 			Debug.Assert (Context.GetTargetRuntimeVersion () < TargetRuntimeVersion.NET6 || !Context.DisableEventSourceSpecialHandling);
 			foreach (var nestedType in td.NestedTypes) {
@@ -2642,7 +2642,7 @@ namespace Mono.Linker.Steps
 			return (type, reason);
 		}
 
-		void MarkParameters (FunctionPointerType fnptr)
+		private void MarkParameters (FunctionPointerType fnptr)
 		{
 			if (!fnptr.HasParameters)
 				return;
@@ -2652,12 +2652,12 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkModifierType (IModifierType mod)
+		private void MarkModifierType (IModifierType mod)
 		{
 			MarkType (mod.ModifierType, new DependencyInfo (DependencyKind.ModifierType, mod));
 		}
 
-		void MarkGenericArguments (IGenericInstance instance)
+		private void MarkGenericArguments (IGenericInstance instance)
 		{
 			var arguments = instance.GenericArguments;
 
@@ -2695,7 +2695,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		IGenericParameterProvider? GetGenericProviderFromInstance (IGenericInstance instance)
+		private IGenericParameterProvider? GetGenericProviderFromInstance (IGenericInstance instance)
 		{
 			if (instance is GenericInstanceMethod method)
 				return Context.TryResolve (method.ElementMethod);
@@ -2706,7 +2706,7 @@ namespace Mono.Linker.Steps
 			return null;
 		}
 
-		void ApplyPreserveInfo (TypeDefinition type)
+		private void ApplyPreserveInfo (TypeDefinition type)
 		{
 			using var typeScope = ScopeStack.PushScope (new MessageOrigin (type));
 
@@ -2773,27 +2773,27 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static bool IsMethodVisible (MethodDefinition method)
+		private static bool IsMethodVisible (MethodDefinition method)
 		{
 			return method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly;
 		}
 
-		static bool IsMethodInternal (MethodDefinition method)
+		private static bool IsMethodInternal (MethodDefinition method)
 		{
 			return method.IsAssembly || method.IsFamilyAndAssembly;
 		}
 
-		static bool IsFieldVisible (FieldDefinition field)
+		private static bool IsFieldVisible (FieldDefinition field)
 		{
 			return field.IsPublic || field.IsFamily || field.IsFamilyOrAssembly;
 		}
 
-		static bool IsFieldInternal (FieldDefinition field)
+		private static bool IsFieldInternal (FieldDefinition field)
 		{
 			return field.IsAssembly || field.IsFamilyAndAssembly;
 		}
 
-		void ApplyPreserveMethods (TypeDefinition type)
+		private void ApplyPreserveMethods (TypeDefinition type)
 		{
 			var list = Annotations.GetPreservedMethods (type);
 			if (list == null)
@@ -2803,7 +2803,7 @@ namespace Mono.Linker.Steps
 			MarkMethodCollection (list, new DependencyInfo (DependencyKind.PreservedMethod, type));
 		}
 
-		void ApplyPreserveMethods (MethodDefinition method)
+		private void ApplyPreserveMethods (MethodDefinition method)
 		{
 			var list = Annotations.GetPreservedMethods (method);
 			if (list == null)
@@ -2840,7 +2840,7 @@ namespace Mono.Linker.Steps
 			return true;
 		}
 
-		static PropertyDefinition? SearchPropertiesForMatchingFieldDefinition (FieldDefinition field)
+		private static PropertyDefinition? SearchPropertiesForMatchingFieldDefinition (FieldDefinition field)
 		{
 			foreach (var property in field.DeclaringType.Properties) {
 				var instr = property.GetMethod?.Body?.Instructions;
@@ -2876,7 +2876,7 @@ namespace Mono.Linker.Steps
 			return true;
 		}
 
-		void MarkMethodCollection (IList<MethodDefinition> methods, in DependencyInfo reason)
+		private void MarkMethodCollection (IList<MethodDefinition> methods, in DependencyInfo reason)
 		{
 			foreach (MethodDefinition method in methods)
 				MarkMethod (method, reason, ScopeStack.CurrentScope.Origin);
@@ -2926,7 +2926,7 @@ namespace Mono.Linker.Steps
 			return method;
 		}
 
-		bool ShouldWarnForReflectionAccessToCompilerGeneratedCode (MethodDefinition method, bool isCoveredByAnnotations)
+		private bool ShouldWarnForReflectionAccessToCompilerGeneratedCode (MethodDefinition method, bool isCoveredByAnnotations)
 		{
 			// No need to warn if it's already covered by the Requires attribute or explicit annotations on the method.
 			if (isCoveredByAnnotations)
@@ -2942,7 +2942,7 @@ namespace Mono.Linker.Steps
 			return CheckRequiresReflectionMethodBodyScanner (method.Body);
 		}
 
-		void ProcessAnalysisAnnotationsForMethod (MethodDefinition method, DependencyKind dependencyKind, in MessageOrigin origin)
+		private void ProcessAnalysisAnnotationsForMethod (MethodDefinition method, DependencyKind dependencyKind, in MessageOrigin origin)
 		{
 			// There are only two ways to get there such that the origin isn't the same as the top of the scopestack.
 			// - For DAM on type, the current scope is the caller of GetType, while the origin is the type itself.
@@ -3211,7 +3211,7 @@ namespace Mono.Linker.Steps
 		{
 		}
 
-		void MarkImplicitlyUsedFields (TypeDefinition type)
+		private void MarkImplicitlyUsedFields (TypeDefinition type)
 		{
 			if (type?.HasFields != true)
 				return;
@@ -3255,7 +3255,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkExplicitInterfaceImplementation (MethodDefinition method, MethodReference ov)
+		private void MarkExplicitInterfaceImplementation (MethodDefinition method, MethodReference ov)
 		{
 			if (Context.Resolve (ov) is not MethodDefinition resolvedOverride)
 				return;
@@ -3275,7 +3275,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkNewCodeDependencies (MethodDefinition method)
+		private void MarkNewCodeDependencies (MethodDefinition method)
 		{
 			switch (Annotations.GetAction (method)) {
 			case MethodAction.ConvertToStub:
@@ -3322,7 +3322,7 @@ namespace Mono.Linker.Steps
 					throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage (null, DiagnosticId.CouldNotFindConstructor, objectType.GetDisplayName ()));
 		}
 
-		bool MarkDisablePrivateReflectionAttribute ()
+		private bool MarkDisablePrivateReflectionAttribute ()
 		{
 			if (Context.MarkedKnownMembers.DisablePrivateReflectionAttributeCtor != null)
 				return false;
@@ -3342,7 +3342,7 @@ namespace Mono.Linker.Steps
 			return true;
 		}
 
-		void MarkBaseMethods (MethodDefinition method)
+		private void MarkBaseMethods (MethodDefinition method)
 		{
 			var base_methods = Annotations.GetBaseMethods (method);
 			if (base_methods == null)
@@ -3363,7 +3363,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessInteropMethod (MethodDefinition method)
+		private void ProcessInteropMethod (MethodDefinition method)
 		{
 			if (method.IsPInvokeImpl && method.PInvokeInfo != null) {
 				var pii = method.PInvokeInfo;
@@ -3495,7 +3495,7 @@ namespace Mono.Linker.Steps
 			MarkReflectionLikeDependencies (body, requiresReflectionMethodBodyScanner);
 		}
 
-		bool CheckRequiresReflectionMethodBodyScanner (MethodBody body)
+		private bool CheckRequiresReflectionMethodBodyScanner (MethodBody body)
 		{
 			// This method is only called on reflection access to compiler-generated methods.
 			// This should be uncommon, so don't cache the result.
@@ -3522,7 +3522,7 @@ namespace Mono.Linker.Steps
 		// It computes the same value, while also marking as it goes, as an optimization.
 		// This should only be called behind a check to IsProcessed for the method or corresponding user method,
 		// to avoid recursion.
-		bool MarkAndCheckRequiresReflectionMethodBodyScanner (MethodBody body)
+		private bool MarkAndCheckRequiresReflectionMethodBodyScanner (MethodBody body)
 		{
 #if DEBUG
 			if (!Annotations.IsProcessed (body.Method)) {
@@ -3564,7 +3564,7 @@ namespace Mono.Linker.Steps
 			return requiresReflectionMethodBodyScanner;
 		}
 
-		bool IsUnreachableBody (MethodBody body)
+		private bool IsUnreachableBody (MethodBody body)
 		{
 			return !body.Method.IsStatic
 				&& !Annotations.IsInstantiated (body.Method.DeclaringType)
@@ -3574,7 +3574,7 @@ namespace Mono.Linker.Steps
 
 		partial void PostMarkMethodBody (MethodBody body);
 
-		void MarkInterfacesNeededByBodyStack (MethodBody body)
+		private void MarkInterfacesNeededByBodyStack (MethodBody body)
 		{
 			// If a type could be on the stack in the body and an interface it implements could be on the stack on the body
 			// then we need to mark that interface implementation.  When this occurs it is not safe to remove the interface implementation from the type
@@ -3587,7 +3587,7 @@ namespace Mono.Linker.Steps
 				MarkInterfaceImplementation (implementation, new MessageOrigin (type));
 		}
 
-		bool InstructionRequiresReflectionMethodBodyScannerForFieldAccess (Instruction instruction)
+		private bool InstructionRequiresReflectionMethodBodyScannerForFieldAccess (Instruction instruction)
 			=> instruction.OpCode.Code switch {
 				// Field stores (Storing value to annotated field must be checked)
 				Code.Stfld or

--- a/src/linker/Linker.Steps/MarkSubStepsDispatcher.cs
+++ b/src/linker/Linker.Steps/MarkSubStepsDispatcher.cs
@@ -18,10 +18,10 @@ namespace Mono.Linker.Steps
 	//
 	public class MarkSubStepsDispatcher : IMarkHandler
 	{
-		readonly List<ISubStep> substeps;
+		private readonly List<ISubStep> substeps;
 
-		CategorizedSubSteps? categorized;
-		CategorizedSubSteps Categorized {
+		private CategorizedSubSteps? categorized;
+		private CategorizedSubSteps Categorized {
 			get {
 				Debug.Assert (categorized.HasValue);
 				return categorized.Value;
@@ -39,9 +39,9 @@ namespace Mono.Linker.Steps
 			markContext.RegisterMarkAssemblyAction (assembly => BrowseAssembly (assembly));
 		}
 
-		static bool HasSubSteps (List<ISubStep> substeps) => substeps?.Count > 0;
+		private static bool HasSubSteps (List<ISubStep> substeps) => substeps?.Count > 0;
 
-		void BrowseAssembly (AssemblyDefinition assembly)
+		private void BrowseAssembly (AssemblyDefinition assembly)
 		{
 			CategorizeSubSteps (assembly);
 
@@ -54,7 +54,7 @@ namespace Mono.Linker.Steps
 			BrowseTypes (assembly.MainModule.Types);
 		}
 
-		bool ShouldDispatchTypes ()
+		private bool ShouldDispatchTypes ()
 		{
 			return HasSubSteps (Categorized.on_types)
 				|| HasSubSteps (Categorized.on_fields)
@@ -63,7 +63,7 @@ namespace Mono.Linker.Steps
 				|| HasSubSteps (Categorized.on_events);
 		}
 
-		void BrowseTypes (Collection<TypeDefinition> types)
+		private void BrowseTypes (Collection<TypeDefinition> types)
 		{
 			foreach (TypeDefinition type in types) {
 				DispatchType (type);
@@ -93,55 +93,55 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void DispatchAssembly (AssemblyDefinition assembly)
+		private void DispatchAssembly (AssemblyDefinition assembly)
 		{
 			foreach (var substep in Categorized.on_assemblies) {
 				substep.ProcessAssembly (assembly);
 			}
 		}
 
-		void DispatchType (TypeDefinition type)
+		private void DispatchType (TypeDefinition type)
 		{
 			foreach (var substep in Categorized.on_types) {
 				substep.ProcessType (type);
 			}
 		}
 
-		void DispatchField (FieldDefinition field)
+		private void DispatchField (FieldDefinition field)
 		{
 			foreach (var substep in Categorized.on_fields) {
 				substep.ProcessField (field);
 			}
 		}
 
-		void DispatchMethod (MethodDefinition method)
+		private void DispatchMethod (MethodDefinition method)
 		{
 			foreach (var substep in Categorized.on_methods) {
 				substep.ProcessMethod (method);
 			}
 		}
 
-		void DispatchProperty (PropertyDefinition property)
+		private void DispatchProperty (PropertyDefinition property)
 		{
 			foreach (var substep in Categorized.on_properties) {
 				substep.ProcessProperty (property);
 			}
 		}
 
-		void DispatchEvent (EventDefinition @event)
+		private void DispatchEvent (EventDefinition @event)
 		{
 			foreach (var substep in Categorized.on_events) {
 				substep.ProcessEvent (@event);
 			}
 		}
 
-		void InitializeSubSteps (LinkContext context)
+		private void InitializeSubSteps (LinkContext context)
 		{
 			foreach (var substep in substeps)
 				substep.Initialize (context);
 		}
 
-		void CategorizeSubSteps (AssemblyDefinition assembly)
+		private void CategorizeSubSteps (AssemblyDefinition assembly)
 		{
 			categorized = new CategorizedSubSteps {
 				on_assemblies = new List<ISubStep> (),
@@ -156,7 +156,7 @@ namespace Mono.Linker.Steps
 				CategorizeSubStep (substep, assembly);
 		}
 
-		void CategorizeSubStep (ISubStep substep, AssemblyDefinition assembly)
+		private void CategorizeSubStep (ISubStep substep, AssemblyDefinition assembly)
 		{
 			if (!substep.IsActiveFor (assembly))
 				return;
@@ -169,7 +169,7 @@ namespace Mono.Linker.Steps
 			CategorizeTarget (substep, SubStepTargets.Event, Categorized.on_events);
 		}
 
-		static void CategorizeTarget (ISubStep substep, SubStepTargets target, List<ISubStep> list)
+		private static void CategorizeTarget (ISubStep substep, SubStepTargets target, List<ISubStep> list)
 		{
 			if (!Targets (substep, target))
 				return;
@@ -177,6 +177,6 @@ namespace Mono.Linker.Steps
 			list.Add (substep);
 		}
 
-		static bool Targets (ISubStep substep, SubStepTargets target) => (substep.Targets & target) == target;
+		private static bool Targets (ISubStep substep, SubStepTargets target) => (substep.Targets & target) == target;
 	}
 }

--- a/src/linker/Linker.Steps/OutputStep.cs
+++ b/src/linker/Linker.Steps/OutputStep.cs
@@ -42,7 +42,7 @@ namespace Mono.Linker.Steps
 
 	public class OutputStep : BaseStep
 	{
-		private Dictionary<UInt16, TargetArchitecture>? architectureMap;
+		private Dictionary<ushort, TargetArchitecture>? architectureMap;
 
 		private enum NativeOSOverride
 		{
@@ -53,17 +53,17 @@ namespace Mono.Linker.Steps
 			Default = 0
 		}
 
-		readonly List<string> assembliesWritten;
+		private readonly List<string> assembliesWritten;
 
 		public OutputStep ()
 		{
 			assembliesWritten = new List<string> ();
 		}
 
-		TargetArchitecture CalculateArchitecture (TargetArchitecture readyToRunArch)
+		private TargetArchitecture CalculateArchitecture (TargetArchitecture readyToRunArch)
 		{
 			if (architectureMap == null) {
-				architectureMap = new Dictionary<UInt16, TargetArchitecture> ();
+				architectureMap = new Dictionary<ushort, TargetArchitecture> ();
 				foreach (var os in Enum.GetValues (typeof (NativeOSOverride))) {
 					ushort osVal = (ushort) (NativeOSOverride) os;
 					foreach (var arch in Enum.GetValues (typeof (TargetArchitecture))) {
@@ -95,12 +95,12 @@ namespace Mono.Linker.Steps
 		{
 			if (Context.AssemblyListFile != null) {
 				using (var w = File.CreateText (Context.AssemblyListFile)) {
-					w.WriteLine ("[" + String.Join (", ", assembliesWritten.Select (a => "\"" + a + "\"").ToArray ()) + "]");
+					w.WriteLine ("[" + string.Join (", ", assembliesWritten.Select (a => "\"" + a + "\"").ToArray ()) + "]");
 				}
 			}
 		}
 
-		void CheckOutputDirectory ()
+		private void CheckOutputDirectory ()
 		{
 			if (Directory.Exists (Context.OutputDirectory))
 				return;
@@ -138,7 +138,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void OutputAssembly (AssemblyDefinition assembly)
+		private void OutputAssembly (AssemblyDefinition assembly)
 		{
 			string directory = Context.OutputDirectory;
 
@@ -197,12 +197,12 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void CloseSymbols (AssemblyDefinition assembly)
+		private void CloseSymbols (AssemblyDefinition assembly)
 		{
 			Annotations.CloseSymbolReader (assembly);
 		}
 
-		WriterParameters SaveSymbols (AssemblyDefinition assembly)
+		private WriterParameters SaveSymbols (AssemblyDefinition assembly)
 		{
 			var parameters = new WriterParameters {
 				DeterministicMvid = Context.DeterministicOutput
@@ -223,7 +223,7 @@ namespace Mono.Linker.Steps
 		}
 
 
-		void CopySatelliteAssembliesIfNeeded (AssemblyDefinition assembly, string directory)
+		private void CopySatelliteAssembliesIfNeeded (AssemblyDefinition assembly, string directory)
 		{
 			if (!Annotations.ProcessSatelliteAssemblies)
 				return;
@@ -244,7 +244,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void CopyConfigFileIfNeeded (AssemblyDefinition assembly, string directory)
+		private void CopyConfigFileIfNeeded (AssemblyDefinition assembly, string directory)
 		{
 			string config = GetConfigFile (GetOriginalAssemblyFileInfo (assembly).FullName);
 			if (!File.Exists (config))
@@ -258,17 +258,17 @@ namespace Mono.Linker.Steps
 			File.Copy (config, GetConfigFile (GetAssemblyFileName (assembly, directory)), true);
 		}
 
-		static string GetAssemblyResourceFileName (string assembly)
+		private static string GetAssemblyResourceFileName (string assembly)
 		{
 			return Path.GetFileNameWithoutExtension (assembly) + ".resources.dll";
 		}
 
-		static string GetConfigFile (string assembly)
+		private static string GetConfigFile (string assembly)
 		{
 			return assembly + ".config";
 		}
 
-		FileInfo GetOriginalAssemblyFileInfo (AssemblyDefinition assembly)
+		private FileInfo GetOriginalAssemblyFileInfo (AssemblyDefinition assembly)
 		{
 			return new FileInfo (Context.GetAssemblyLocation (assembly));
 		}

--- a/src/linker/Linker.Steps/OutputWarningSuppressions.cs
+++ b/src/linker/Linker.Steps/OutputWarningSuppressions.cs
@@ -18,7 +18,7 @@ namespace Mono.Linker.Steps
 			Context.WarningSuppressionWriter?.OutputSuppressions (Context.OutputDirectory);
 		}
 
-		void CheckOutputDirectory ()
+		private void CheckOutputDirectory ()
 		{
 			if (Directory.Exists (Context.OutputDirectory))
 				return;

--- a/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -26,20 +26,20 @@ namespace Mono.Linker.Steps
 
 	public abstract class ProcessLinkerXmlBase
 	{
-		const string FullNameAttributeName = "fullname";
-		const string LinkerElementName = "linker";
-		const string TypeElementName = "type";
-		const string SignatureAttributeName = "signature";
-		const string NameAttributeName = "name";
-		const string FieldElementName = "field";
-		const string MethodElementName = "method";
-		const string EventElementName = "event";
-		const string PropertyElementName = "property";
-		const string AllAssembliesFullName = "*";
+		private const string FullNameAttributeName = "fullname";
+		private const string LinkerElementName = "linker";
+		private const string TypeElementName = "type";
+		private const string SignatureAttributeName = "signature";
+		private const string NameAttributeName = "name";
+		private const string FieldElementName = "field";
+		private const string MethodElementName = "method";
+		private const string EventElementName = "event";
+		private const string PropertyElementName = "property";
+		private const string AllAssembliesFullName = "*";
 		protected const string XmlNamespace = "";
 
 		protected readonly string _xmlDocumentLocation;
-		readonly XPathNavigator _document;
+		private readonly XPathNavigator _document;
 		protected readonly (EmbeddedResource Resource, AssemblyDefinition Assembly)? _resource;
 		protected readonly LinkContext _context;
 
@@ -98,7 +98,7 @@ namespace Mono.Linker.Steps
 
 		protected virtual AllowedAssemblies AllowedAssemblySelector { get => _resource != null ? AllowedAssemblies.ContainingAssembly : AllowedAssemblies.AnyAssembly; }
 
-		bool ShouldProcessAllAssemblies (XPathNavigator nav, [NotNullWhen (false)] out AssemblyNameReference? assemblyName)
+		private bool ShouldProcessAllAssemblies (XPathNavigator nav, [NotNullWhen (false)] out AssemblyNameReference? assemblyName)
 		{
 			assemblyName = null;
 			if (GetFullName (nav) == AllAssembliesFullName)
@@ -193,7 +193,7 @@ namespace Mono.Linker.Steps
 
 		protected virtual TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly, XPathNavigator nav) => exported.Resolve ();
 
-		void MatchType (TypeDefinition type, Regex regex, XPathNavigator nav)
+		private void MatchType (TypeDefinition type, Regex regex, XPathNavigator nav)
 		{
 			if (regex.Match (type.FullName).Success)
 				ProcessType (type, nav);
@@ -239,7 +239,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessSelectedFields (XPathNavigator nav, TypeDefinition type)
+		private void ProcessSelectedFields (XPathNavigator nav, TypeDefinition type)
 		{
 			foreach (XPathNavigator fieldNav in nav.SelectChildren (FieldElementName, XmlNamespace)) {
 				if (!ShouldProcessElement (fieldNav))
@@ -251,7 +251,7 @@ namespace Mono.Linker.Steps
 		protected virtual void ProcessField (TypeDefinition type, XPathNavigator nav)
 		{
 			string signature = GetSignature (nav);
-			if (!String.IsNullOrEmpty (signature)) {
+			if (!string.IsNullOrEmpty (signature)) {
 				FieldDefinition? field = GetField (type, signature);
 				if (field == null) {
 					LogWarning (nav, DiagnosticId.XmlCouldNotFindFieldOnType, signature, type.GetDisplayName ());
@@ -262,7 +262,7 @@ namespace Mono.Linker.Steps
 			}
 
 			string name = GetName (nav);
-			if (!String.IsNullOrEmpty (name)) {
+			if (!string.IsNullOrEmpty (name)) {
 				bool foundMatch = false;
 				if (type.HasFields) {
 					foreach (FieldDefinition field in type.Fields) {
@@ -293,7 +293,7 @@ namespace Mono.Linker.Steps
 
 		protected virtual void ProcessField (TypeDefinition type, FieldDefinition field, XPathNavigator nav) { }
 
-		void ProcessSelectedMethods (XPathNavigator nav, TypeDefinition type, object? customData)
+		private void ProcessSelectedMethods (XPathNavigator nav, TypeDefinition type, object? customData)
 		{
 			foreach (XPathNavigator methodNav in nav.SelectChildren (MethodElementName, XmlNamespace)) {
 				if (!ShouldProcessElement (methodNav))
@@ -305,7 +305,7 @@ namespace Mono.Linker.Steps
 		protected virtual void ProcessMethod (TypeDefinition type, XPathNavigator nav, object? customData)
 		{
 			string signature = GetSignature (nav);
-			if (!String.IsNullOrEmpty (signature)) {
+			if (!string.IsNullOrEmpty (signature)) {
 				MethodDefinition? method = GetMethod (type, signature);
 				if (method == null) {
 					LogWarning (nav, DiagnosticId.XmlCouldNotFindMethodOnType, signature, type.GetDisplayName ());
@@ -316,7 +316,7 @@ namespace Mono.Linker.Steps
 			}
 
 			string name = GetAttribute (nav, NameAttributeName);
-			if (!String.IsNullOrEmpty (name)) {
+			if (!string.IsNullOrEmpty (name)) {
 				bool foundMatch = false;
 				if (type.HasMethods) {
 					foreach (MethodDefinition method in type.Methods) {
@@ -337,7 +337,7 @@ namespace Mono.Linker.Steps
 
 		protected virtual void ProcessMethod (TypeDefinition type, MethodDefinition method, XPathNavigator nav, object? customData) { }
 
-		void ProcessSelectedEvents (XPathNavigator nav, TypeDefinition type, object? customData)
+		private void ProcessSelectedEvents (XPathNavigator nav, TypeDefinition type, object? customData)
 		{
 			foreach (XPathNavigator eventNav in nav.SelectChildren (EventElementName, XmlNamespace)) {
 				if (!ShouldProcessElement (eventNav))
@@ -349,7 +349,7 @@ namespace Mono.Linker.Steps
 		protected virtual void ProcessEvent (TypeDefinition type, XPathNavigator nav, object? customData)
 		{
 			string signature = GetSignature (nav);
-			if (!String.IsNullOrEmpty (signature)) {
+			if (!string.IsNullOrEmpty (signature)) {
 				EventDefinition? @event = GetEvent (type, signature);
 				if (@event == null) {
 					LogWarning (nav, DiagnosticId.XmlCouldNotFindEventOnType, signature, type.GetDisplayName ());
@@ -360,7 +360,7 @@ namespace Mono.Linker.Steps
 			}
 
 			string name = GetAttribute (nav, NameAttributeName);
-			if (!String.IsNullOrEmpty (name)) {
+			if (!string.IsNullOrEmpty (name)) {
 				bool foundMatch = false;
 				foreach (EventDefinition @event in type.Events) {
 					if (@event.Name == name) {
@@ -389,7 +389,7 @@ namespace Mono.Linker.Steps
 
 		protected virtual void ProcessEvent (TypeDefinition type, EventDefinition @event, XPathNavigator nav, object? customData) { }
 
-		void ProcessSelectedProperties (XPathNavigator nav, TypeDefinition type, object? customData)
+		private void ProcessSelectedProperties (XPathNavigator nav, TypeDefinition type, object? customData)
 		{
 			foreach (XPathNavigator propertyNav in nav.SelectChildren (PropertyElementName, XmlNamespace)) {
 				if (!ShouldProcessElement (propertyNav))
@@ -401,7 +401,7 @@ namespace Mono.Linker.Steps
 		protected virtual void ProcessProperty (TypeDefinition type, XPathNavigator nav, object? customData)
 		{
 			string signature = GetSignature (nav);
-			if (!String.IsNullOrEmpty (signature)) {
+			if (!string.IsNullOrEmpty (signature)) {
 				PropertyDefinition? property = GetProperty (type, signature);
 				if (property == null) {
 					LogWarning (nav, DiagnosticId.XmlCouldNotFindPropertyOnType, signature, type.GetDisplayName ());
@@ -412,7 +412,7 @@ namespace Mono.Linker.Steps
 			}
 
 			string name = GetAttribute (nav, NameAttributeName);
-			if (!String.IsNullOrEmpty (name)) {
+			if (!string.IsNullOrEmpty (name)) {
 				bool foundMatch = false;
 				foreach (PropertyDefinition property in type.Properties) {
 					if (property.Name == name) {

--- a/src/linker/Linker.Steps/ProcessReferencesStep.cs
+++ b/src/linker/Linker.Steps/ProcessReferencesStep.cs
@@ -49,7 +49,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		IEnumerable<string> GetInputAssemblyPaths ()
+		private IEnumerable<string> GetInputAssemblyPaths ()
 		{
 			var assemblies = new HashSet<string> ();
 			foreach (var referencePath in Context.Resolver.GetReferencePaths ()) {
@@ -64,7 +64,7 @@ namespace Mono.Linker.Steps
 			return action == AssemblyAction.Copy || action == AssemblyAction.Save;
 		}
 
-		bool MaybeIsFullyPreservedAssembly (string assemblyName)
+		private bool MaybeIsFullyPreservedAssembly (string assemblyName)
 		{
 			if (Context.Actions.TryGetValue (assemblyName, out AssemblyAction action))
 				return IsFullyPreservedAction (action);

--- a/src/linker/Linker.Steps/ProcessWarningsStep.cs
+++ b/src/linker/Linker.Steps/ProcessWarningsStep.cs
@@ -7,7 +7,7 @@ namespace Mono.Linker.Steps
 	{
 		protected override void Process ()
 		{
-			// Flush all cached messages before the sweep and clean steps are run to be confident 
+			// Flush all cached messages before the sweep and clean steps are run to be confident
 			// that we have all the information needed to gracefully generate the string.
 			Context.FlushCachedWarnings ();
 		}

--- a/src/linker/Linker.Steps/ReflectionBlockedStep.cs
+++ b/src/linker/Linker.Steps/ReflectionBlockedStep.cs
@@ -9,8 +9,8 @@ namespace Mono.Linker.Steps
 {
 	public class ReflectionBlockedStep : BaseStep
 	{
-		AssemblyDefinition? assembly;
-		AssemblyDefinition Assembly {
+		private AssemblyDefinition? assembly;
+		private AssemblyDefinition Assembly {
 			get {
 				Debug.Assert (assembly != null);
 				return assembly;
@@ -25,7 +25,7 @@ namespace Mono.Linker.Steps
 				ProcessType (type);
 		}
 
-		void ProcessType (TypeDefinition type)
+		private void ProcessType (TypeDefinition type)
 		{
 			if (!HasIndirectCallers (type)) {
 				AddCustomAttribute (type);
@@ -46,7 +46,7 @@ namespace Mono.Linker.Steps
 				ProcessType (nested);
 		}
 
-		bool HasIndirectCallers (TypeDefinition type)
+		private bool HasIndirectCallers (TypeDefinition type)
 		{
 			foreach (var method in type.Methods) {
 				if (Annotations.IsIndirectlyCalled (method))
@@ -63,7 +63,7 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
-		void AddCustomAttribute (ICustomAttributeProvider caProvider)
+		private void AddCustomAttribute (ICustomAttributeProvider caProvider)
 		{
 			// We are using DisableReflectionAttribute which is not exact match but it's quite
 			// close to what we need and it already exists in the BCL

--- a/src/linker/Linker.Steps/RegenerateGuidStep.cs
+++ b/src/linker/Linker.Steps/RegenerateGuidStep.cs
@@ -45,7 +45,7 @@ namespace Mono.Linker.Steps
 				RegenerateGuid (assembly);
 		}
 
-		static void RegenerateGuid (AssemblyDefinition asm)
+		private static void RegenerateGuid (AssemblyDefinition asm)
 		{
 			asm.MainModule.Mvid = Guid.NewGuid ();
 		}

--- a/src/linker/Linker.Steps/RemoveSecurityStep.cs
+++ b/src/linker/Linker.Steps/RemoveSecurityStep.cs
@@ -21,7 +21,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static void ProcessType (TypeDefinition type)
+		private static void ProcessType (TypeDefinition type)
 		{
 			ClearSecurityDeclarations (type);
 			RemoveCustomAttributesThatAreForSecurity (type);
@@ -40,7 +40,7 @@ namespace Mono.Linker.Steps
 				ProcessType (nested);
 		}
 
-		static void ClearSecurityDeclarations (ISecurityDeclarationProvider provider)
+		private static void ClearSecurityDeclarations (ISecurityDeclarationProvider provider)
 		{
 			if (provider.HasSecurityDeclarations)
 				provider.SecurityDeclarations.Clear ();
@@ -50,7 +50,7 @@ namespace Mono.Linker.Steps
 		/// We have to remove some security attributes, otherwise pe verify will complain that a type has HasSecurity = false
 		/// </summary>
 		/// <param name="provider"></param>
-		static void RemoveCustomAttributesThatAreForSecurity (ICustomAttributeProvider provider)
+		private static void RemoveCustomAttributesThatAreForSecurity (ICustomAttributeProvider provider)
 		{
 			if (!provider.HasCustomAttributes)
 				return;
@@ -60,7 +60,7 @@ namespace Mono.Linker.Steps
 				provider.CustomAttributes.Remove (remove);
 		}
 
-		static bool IsCustomAttributeForSecurity (CustomAttribute attr)
+		private static bool IsCustomAttributeForSecurity (CustomAttribute attr)
 		{
 			var attr_type = attr.AttributeType;
 			if (attr_type.Namespace == "System.Security") {

--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -9,8 +9,8 @@ namespace Mono.Linker.Steps
 {
 	public class RootAssemblyInput : BaseStep
 	{
-		readonly string fileName;
-		readonly AssemblyRootMode rootMode;
+		private readonly string fileName;
+		private readonly AssemblyRootMode rootMode;
 
 		public RootAssemblyInput (string fileName, AssemblyRootMode rootMode)
 		{
@@ -97,7 +97,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		AssemblyDefinition? LoadAssemblyFile ()
+		private AssemblyDefinition? LoadAssemblyFile ()
 		{
 			AssemblyDefinition? assembly;
 
@@ -123,7 +123,7 @@ namespace Mono.Linker.Steps
 			return assembly;
 		}
 
-		void MarkAndPreserve (AssemblyDefinition assembly, TypePreserveMembers preserve)
+		private void MarkAndPreserve (AssemblyDefinition assembly, TypePreserveMembers preserve)
 		{
 			var module = assembly.MainModule;
 			if (module.HasExportedTypes)
@@ -134,7 +134,7 @@ namespace Mono.Linker.Steps
 				MarkAndPreserve (type, preserve);
 		}
 
-		void MarkAndPreserve (TypeDefinition type, TypePreserveMembers preserve)
+		private void MarkAndPreserve (TypeDefinition type, TypePreserveMembers preserve)
 		{
 			TypePreserveMembers preserve_anything = preserve;
 			if ((preserve & TypePreserveMembers.Visible) != 0 && !IsTypeVisible (type))
@@ -173,7 +173,7 @@ namespace Mono.Linker.Steps
 				MarkAndPreserve (nested, preserve);
 		}
 
-		void MarkAndPreserve (AssemblyDefinition assembly, ExportedType type, TypePreserveMembers preserve)
+		private void MarkAndPreserve (AssemblyDefinition assembly, ExportedType type, TypePreserveMembers preserve)
 		{
 			var di = new DependencyInfo (DependencyKind.RootAssembly, assembly);
 			var origin = new MessageOrigin (assembly);
@@ -182,17 +182,17 @@ namespace Mono.Linker.Steps
 			Annotations.SetMembersPreserve (type, preserve);
 		}
 
-		static bool IsTypeVisible (TypeDefinition type)
+		private static bool IsTypeVisible (TypeDefinition type)
 		{
 			return type.IsPublic || type.IsNestedPublic || type.IsNestedFamily || type.IsNestedFamilyOrAssembly;
 		}
 
-		static bool IsTypePrivate (TypeDefinition type)
+		private static bool IsTypePrivate (TypeDefinition type)
 		{
 			return type.IsNestedPrivate;
 		}
 
-		bool MarkInternalsVisibleTo (AssemblyDefinition assembly)
+		private bool MarkInternalsVisibleTo (AssemblyDefinition assembly)
 		{
 			foreach (CustomAttribute attribute in assembly.CustomAttributes) {
 				if (attribute.Constructor.DeclaringType.IsTypeOf ("System.Runtime.CompilerServices", "InternalsVisibleToAttribute")) {

--- a/src/linker/Linker.Steps/SealerStep.cs
+++ b/src/linker/Linker.Steps/SealerStep.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Steps
 {
 	public class SealerStep : BaseStep
 	{
-		HashSet<TypeDefinition>? referencedBaseTypeCache;
+		private HashSet<TypeDefinition>? referencedBaseTypeCache;
 
 		public SealerStep ()
 		{
@@ -30,7 +30,7 @@ namespace Mono.Linker.Steps
 			referencedBaseTypeCache = null;
 		}
 
-		bool IsSubclassed (TypeDefinition type)
+		private bool IsSubclassed (TypeDefinition type)
 		{
 			if (referencedBaseTypeCache == null) {
 				referencedBaseTypeCache = new HashSet<TypeDefinition> ();
@@ -59,7 +59,7 @@ namespace Mono.Linker.Steps
 			return bt != null && referencedBaseTypeCache.Contains (bt);
 		}
 
-		void ProcessType (TypeDefinition type)
+		private void ProcessType (TypeDefinition type)
 		{
 			if (type.HasNestedTypes) {
 				foreach (var nt in type.NestedTypes) {
@@ -123,7 +123,7 @@ namespace Mono.Linker.Steps
 			method.IsFinal = true;
 		}
 
-		bool IsAnyMarked (IEnumerable<OverrideInformation>? list)
+		private bool IsAnyMarked (IEnumerable<OverrideInformation>? list)
 		{
 			if (list == null)
 				return false;
@@ -135,7 +135,7 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
-		bool IsAnyMarked (List<MethodDefinition>? list)
+		private bool IsAnyMarked (List<MethodDefinition>? list)
 		{
 			if (list == null)
 				return false;

--- a/src/linker/Linker.Steps/SubStepsDispatcher.cs
+++ b/src/linker/Linker.Steps/SubStepsDispatcher.cs
@@ -9,7 +9,7 @@ using Mono.Collections.Generic;
 
 namespace Mono.Linker.Steps
 {
-	struct CategorizedSubSteps
+	internal struct CategorizedSubSteps
 	{
 		public List<ISubStep> on_assemblies;
 		public List<ISubStep> on_types;
@@ -26,10 +26,10 @@ namespace Mono.Linker.Steps
 	//
 	public abstract class SubStepsDispatcher : IStep
 	{
-		readonly List<ISubStep> substeps;
+		private readonly List<ISubStep> substeps;
 
-		CategorizedSubSteps? categorized;
-		CategorizedSubSteps Categorized {
+		private CategorizedSubSteps? categorized;
+		private CategorizedSubSteps Categorized {
 			get {
 				Debug.Assert (categorized.HasValue);
 				return categorized.Value;
@@ -58,9 +58,9 @@ namespace Mono.Linker.Steps
 			BrowseAssemblies (context.GetAssemblies ());
 		}
 
-		static bool HasSubSteps (List<ISubStep> substeps) => substeps?.Count > 0;
+		private static bool HasSubSteps (List<ISubStep> substeps) => substeps?.Count > 0;
 
-		void BrowseAssemblies (IEnumerable<AssemblyDefinition> assemblies)
+		private void BrowseAssemblies (IEnumerable<AssemblyDefinition> assemblies)
 		{
 			foreach (var assembly in assemblies) {
 				CategorizeSubSteps (assembly);
@@ -75,7 +75,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		bool ShouldDispatchTypes ()
+		private bool ShouldDispatchTypes ()
 		{
 			return HasSubSteps (Categorized.on_types)
 				|| HasSubSteps (Categorized.on_fields)
@@ -84,7 +84,7 @@ namespace Mono.Linker.Steps
 				|| HasSubSteps (Categorized.on_events);
 		}
 
-		void BrowseTypes (Collection<TypeDefinition> types)
+		private void BrowseTypes (Collection<TypeDefinition> types)
 		{
 			foreach (TypeDefinition type in types) {
 				DispatchType (type);
@@ -114,55 +114,55 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void DispatchAssembly (AssemblyDefinition assembly)
+		private void DispatchAssembly (AssemblyDefinition assembly)
 		{
 			foreach (var substep in Categorized.on_assemblies) {
 				substep.ProcessAssembly (assembly);
 			}
 		}
 
-		void DispatchType (TypeDefinition type)
+		private void DispatchType (TypeDefinition type)
 		{
 			foreach (var substep in Categorized.on_types) {
 				substep.ProcessType (type);
 			}
 		}
 
-		void DispatchField (FieldDefinition field)
+		private void DispatchField (FieldDefinition field)
 		{
 			foreach (var substep in Categorized.on_fields) {
 				substep.ProcessField (field);
 			}
 		}
 
-		void DispatchMethod (MethodDefinition method)
+		private void DispatchMethod (MethodDefinition method)
 		{
 			foreach (var substep in Categorized.on_methods) {
 				substep.ProcessMethod (method);
 			}
 		}
 
-		void DispatchProperty (PropertyDefinition property)
+		private void DispatchProperty (PropertyDefinition property)
 		{
 			foreach (var substep in Categorized.on_properties) {
 				substep.ProcessProperty (property);
 			}
 		}
 
-		void DispatchEvent (EventDefinition @event)
+		private void DispatchEvent (EventDefinition @event)
 		{
 			foreach (var substep in Categorized.on_events) {
 				substep.ProcessEvent (@event);
 			}
 		}
 
-		void InitializeSubSteps (LinkContext context)
+		private void InitializeSubSteps (LinkContext context)
 		{
 			foreach (var substep in substeps)
 				substep.Initialize (context);
 		}
 
-		void CategorizeSubSteps (AssemblyDefinition assembly)
+		private void CategorizeSubSteps (AssemblyDefinition assembly)
 		{
 			categorized = new CategorizedSubSteps {
 				on_assemblies = new List<ISubStep> (),
@@ -177,7 +177,7 @@ namespace Mono.Linker.Steps
 				CategorizeSubStep (substep, assembly);
 		}
 
-		void CategorizeSubStep (ISubStep substep, AssemblyDefinition assembly)
+		private void CategorizeSubStep (ISubStep substep, AssemblyDefinition assembly)
 		{
 			if (!substep.IsActiveFor (assembly))
 				return;
@@ -190,7 +190,7 @@ namespace Mono.Linker.Steps
 			CategorizeTarget (substep, SubStepTargets.Event, Categorized.on_events);
 		}
 
-		static void CategorizeTarget (ISubStep substep, SubStepTargets target, List<ISubStep> list)
+		private static void CategorizeTarget (ISubStep substep, SubStepTargets target, List<ISubStep> list)
 		{
 			if (!Targets (substep, target))
 				return;
@@ -198,6 +198,6 @@ namespace Mono.Linker.Steps
 			list.Add (substep);
 		}
 
-		static bool Targets (ISubStep substep, SubStepTargets target) => (substep.Targets & target) == target;
+		private static bool Targets (ISubStep substep, SubStepTargets target) => (substep.Targets & target) == target;
 	}
 }

--- a/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
+++ b/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
@@ -37,7 +37,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ValidateMethodRequiresUnreferencedCodeAreSame (MethodDefinition method, MethodDefinition baseMethod)
+		private void ValidateMethodRequiresUnreferencedCodeAreSame (MethodDefinition method, MethodDefinition baseMethod)
 		{
 			var annotations = Context.Annotations;
 			bool methodHasAttribute = annotations.IsInRequiresUnreferencedCodeScope (method);

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -61,15 +61,15 @@ namespace Mono.Linker
 		protected readonly Dictionary<IMemberDefinition, List<MethodDefinition>> preserved_methods = new Dictionary<IMemberDefinition, List<MethodDefinition>> ();
 		protected readonly HashSet<IMetadataTokenProvider> public_api = new HashSet<IMetadataTokenProvider> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
-		readonly Dictionary<IMemberDefinition, LinkerAttributesInformation> linker_attributes = new Dictionary<IMemberDefinition, LinkerAttributesInformation> ();
-		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
+		private readonly Dictionary<IMemberDefinition, LinkerAttributesInformation> linker_attributes = new Dictionary<IMemberDefinition, LinkerAttributesInformation> ();
+		private readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		protected readonly Dictionary<AssemblyDefinition, HashSet<EmbeddedResource>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<EmbeddedResource>> ();
 		protected readonly HashSet<CustomAttribute> marked_attributes = new HashSet<CustomAttribute> ();
-		readonly HashSet<TypeDefinition> marked_types_with_cctor = new HashSet<TypeDefinition> ();
+		private readonly HashSet<TypeDefinition> marked_types_with_cctor = new HashSet<TypeDefinition> ();
 		protected readonly HashSet<TypeDefinition> marked_instantiated = new HashSet<TypeDefinition> ();
 		protected readonly HashSet<MethodDefinition> indirectly_called = new HashSet<MethodDefinition> ();
 		protected readonly HashSet<TypeDefinition> types_relevant_to_variant_casting = new HashSet<TypeDefinition> ();
-		readonly HashSet<IMemberDefinition> reflection_used = new ();
+		private readonly HashSet<IMemberDefinition> reflection_used = new ();
 
 		public AnnotationStore (LinkContext context)
 		{
@@ -92,7 +92,7 @@ namespace Mono.Linker
 
 		internal HashSet<MethodDefinition> VirtualMethodsWithAnnotationsToValidate { get; }
 
-		TypeMapInfo TypeMapInfo { get; }
+		private TypeMapInfo TypeMapInfo { get; }
 
 		public MemberActionStore MemberActions { get; }
 
@@ -377,7 +377,7 @@ namespace Mono.Linker
 				preserved_type_members.Add (type, preserve);
 		}
 
-		static TypePreserveMembers CombineMembers (TypePreserveMembers left, TypePreserveMembers right)
+		private static TypePreserveMembers CombineMembers (TypePreserveMembers left, TypePreserveMembers right)
 		{
 			return left | right;
 		}
@@ -481,7 +481,7 @@ namespace Mono.Linker
 			AddPreservedMethod (key as IMemberDefinition, method);
 		}
 
-		List<MethodDefinition>? GetPreservedMethods (IMemberDefinition definition)
+		private List<MethodDefinition>? GetPreservedMethods (IMemberDefinition definition)
 		{
 			if (preserved_methods.TryGetValue (definition, out List<MethodDefinition>? preserved))
 				return preserved;
@@ -489,7 +489,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		void AddPreservedMethod (IMemberDefinition definition, MethodDefinition method)
+		private void AddPreservedMethod (IMemberDefinition definition, MethodDefinition method)
 		{
 			if (IsMarked (definition)) {
 				Mark (method, new DependencyInfo (DependencyKind.PreservedMethod, definition), new MessageOrigin (definition));

--- a/src/linker/Linker/ArrayBuilder.cs
+++ b/src/linker/Linker/ArrayBuilder.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Mono.Linker
 {
-	struct ArrayBuilder<T>
+	internal struct ArrayBuilder<T>
 	{
 		private List<T> _list;
 

--- a/src/linker/Linker/AssemblyAction.cs
+++ b/src/linker/Linker/AssemblyAction.cs
@@ -47,8 +47,8 @@ namespace Mono.Linker
 		Link,
 		// Remove the assembly from the output
 		Delete,
-		// Save the assembly/symbols in memory without trimming it. 
-		// E.g. useful to remove unneeded assembly references (as done in SweepStep), 
+		// Save the assembly/symbols in memory without trimming it.
+		// E.g. useful to remove unneeded assembly references (as done in SweepStep),
 		//  resolving [TypeForwardedTo] attributes (like PCL) to their final location
 		Save,
 		// Keep all types, methods, and fields but add System.Runtime.BypassNGenAttribute to unmarked methods.

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -40,15 +40,15 @@ namespace Mono.Linker
 {
 	public class AssemblyResolver : IAssemblyResolver
 	{
-		readonly List<string> _references = new ();
-		readonly LinkContext _context;
-		readonly List<string> _directories = new ();
-		readonly Dictionary<AssemblyDefinition, string> _assemblyToPath = new ();
-		readonly List<MemoryMappedViewStream> _viewStreams = new ();
-		readonly ReaderParameters _defaultReaderParameters;
+		private readonly List<string> _references = new ();
+		private readonly LinkContext _context;
+		private readonly List<string> _directories = new ();
+		private readonly Dictionary<AssemblyDefinition, string> _assemblyToPath = new ();
+		private readonly List<MemoryMappedViewStream> _viewStreams = new ();
+		private readonly ReaderParameters _defaultReaderParameters;
 
-		HashSet<string>? _unresolvedAssemblies;
-		HashSet<string>? _reportedUnresolvedAssemblies;
+		private HashSet<string>? _unresolvedAssemblies;
+		private HashSet<string>? _reportedUnresolvedAssemblies;
 
 		public AssemblyResolver (LinkContext context)
 		{
@@ -68,7 +68,7 @@ namespace Mono.Linker
 			throw new InternalErrorException ($"Assembly '{assembly}' was not loaded using linker resolver");
 		}
 
-		AssemblyDefinition? ResolveFromReferences (AssemblyNameReference name)
+		private AssemblyDefinition? ResolveFromReferences (AssemblyNameReference name)
 		{
 			foreach (var reference in _references) {
 				foreach (var extension in Extensions) {
@@ -118,7 +118,7 @@ namespace Mono.Linker
 			return asm;
 		}
 
-		void ReportUnresolvedAssembly (AssemblyNameReference reference)
+		private void ReportUnresolvedAssembly (AssemblyNameReference reference)
 		{
 			if (_reportedUnresolvedAssemblies == null)
 				_reportedUnresolvedAssemblies = new HashSet<string> ();
@@ -174,9 +174,9 @@ namespace Mono.Linker
 			throw new NotSupportedException ();
 		}
 
-		static readonly string[] Extensions = new[] { ".dll", ".exe" };
+		private static readonly string[] Extensions = new[] { ".dll", ".exe" };
 
-		AssemblyDefinition? SearchDirectory (AssemblyNameReference name)
+		private AssemblyDefinition? SearchDirectory (AssemblyNameReference name)
 		{
 			foreach (var directory in _directories) {
 				foreach (var extension in Extensions) {

--- a/src/linker/Linker/BCL.cs
+++ b/src/linker/Linker/BCL.cs
@@ -60,7 +60,7 @@ namespace Mono.Linker
 			return true;
 		}
 
-		static readonly string[] corlibNames = new[] {
+		private static readonly string[] corlibNames = new[] {
 			"System.Private.CoreLib",
 			"mscorlib",
 			"System.Runtime",

--- a/src/linker/Linker/Constants.cs
+++ b/src/linker/Linker/Constants.cs
@@ -3,7 +3,7 @@
 
 namespace Mono.Linker
 {
-	static class Constants
+	internal static class Constants
 	{
 		// Prefix used in error/warning reporting to specify the tool it comes from
 		public const string ILLink = "ILLink";

--- a/src/linker/Linker/CustomAttributeArgumentExtensions.cs
+++ b/src/linker/Linker/CustomAttributeArgumentExtensions.cs
@@ -22,7 +22,7 @@ namespace Mono.Linker
 			}
 			return aVal.Equals (bVal);
 		}
-		static object BaseValue (this object value)
+		private static object BaseValue (this object value)
 		{
 			while (value is CustomAttributeArgument caa)
 				value = caa.Value;

--- a/src/linker/Linker/CustomAttributeSource.cs
+++ b/src/linker/Linker/CustomAttributeSource.cs
@@ -12,7 +12,7 @@ namespace Mono.Linker
 	{
 		public AttributeInfo PrimaryAttributeInfo { get; }
 		private readonly Dictionary<AssemblyDefinition, AttributeInfo?> _embeddedXmlInfos;
-		readonly LinkContext _context;
+		private readonly LinkContext _context;
 
 		public CustomAttributeSource (LinkContext context)
 		{

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -154,7 +154,7 @@ namespace Mono.Linker
 		public static readonly DependencyInfo AlreadyMarked = new DependencyInfo (DependencyKind.AlreadyMarked, null);
 		public static readonly DependencyInfo DisablePrivateReflectionRequirement = new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement, null);
 		public bool Equals (DependencyInfo other) => (Kind, Source) == (other.Kind, other.Source);
-		public override bool Equals (Object? obj) => obj is DependencyInfo info && this.Equals (info);
+		public override bool Equals (object? obj) => obj is DependencyInfo info && this.Equals (info);
 		public override int GetHashCode () => (Kind, Source).GetHashCode ();
 		public static bool operator == (DependencyInfo lhs, DependencyInfo rhs) => lhs.Equals (rhs);
 		public static bool operator != (DependencyInfo lhs, DependencyInfo rhs) => !lhs.Equals (rhs);

--- a/src/linker/Linker/DependencyRecorderHelper.cs
+++ b/src/linker/Linker/DependencyRecorderHelper.cs
@@ -11,7 +11,7 @@ namespace Mono.Linker
 	/// </summary>
 	public class DependencyRecorderHelper
 	{
-		static bool IsAssemblyBound (TypeDefinition td)
+		private static bool IsAssemblyBound (TypeDefinition td)
 		{
 			do {
 				if (td.IsNestedPrivate || td.IsNestedAssembly || td.IsNestedFamilyAndAssembly)
@@ -48,7 +48,7 @@ namespace Mono.Linker
 			return "Other:" + o;
 		}
 
-		static bool WillAssemblyBeModified (LinkContext context, AssemblyDefinition assembly)
+		private static bool WillAssemblyBeModified (LinkContext context, AssemblyDefinition assembly)
 		{
 			switch (context.Annotations.GetAction (assembly)) {
 			case AssemblyAction.Link:

--- a/src/linker/Linker/DgmlDependencyRecorder.cs
+++ b/src/linker/Linker/DgmlDependencyRecorder.cs
@@ -140,13 +140,13 @@ namespace Mono.Linker
 
 		private int _nodeIndex = 0;
 
-		void AddNode (string node)
+		private void AddNode (string node)
 		{
 			nodeList.Add (node, _nodeIndex);
 			_nodeIndex++;
 		}
 
-		void AddLink (string source, string target, object? kind)
+		private void AddLink (string source, string target, object? kind)
 		{
 			linkList.Add ((source, target, DependencyRecorderHelper.TokenString (context, kind)));
 		}

--- a/src/linker/Linker/DocumentationSignatureGenerator.PartVisitor.cs
+++ b/src/linker/Linker/DocumentationSignatureGenerator.PartVisitor.cs
@@ -120,7 +120,7 @@ namespace Mono.Linker
 
 					// If the containing type is nested within other types.
 					// e.g. A<T>.B<U>.M<V>(T t, U u, V v) should be M(`0, `1, ``0).
-					// Roslyn needs to add generic arities of parents, but the innermost type redeclares 
+					// Roslyn needs to add generic arities of parents, but the innermost type redeclares
 					// all generic parameters so we don't need to add them.
 					builder.Append ('`');
 				}
@@ -153,7 +153,7 @@ namespace Mono.Linker
 					builder.Append ('.');
 				}
 
-				if (!String.IsNullOrEmpty (typeReference.Namespace))
+				if (!string.IsNullOrEmpty (typeReference.Namespace))
 					builder.Append (typeReference.Namespace).Append ('.');
 
 				// This includes '`n' for mangled generic types

--- a/src/linker/Linker/DocumentationSignatureParser.cs
+++ b/src/linker/Linker/DocumentationSignatureParser.cs
@@ -69,14 +69,14 @@ namespace Mono.Linker
 			return results;
 		}
 
-		static string GetSignaturePart (TypeReference type, ITryResolveMetadata resolver)
+		private static string GetSignaturePart (TypeReference type, ITryResolveMetadata resolver)
 		{
 			var builder = new StringBuilder ();
 			DocumentationSignatureGenerator.PartVisitor.Instance.VisitTypeReference (type, builder, resolver);
 			return builder.ToString ();
 		}
 
-		static bool ParseDocumentationSignature (string id, ModuleDefinition module, List<IMemberDefinition> results, ITryResolveMetadata resolver)
+		private static bool ParseDocumentationSignature (string id, ModuleDefinition module, List<IMemberDefinition> results, ITryResolveMetadata resolver)
 		{
 			if (id == null)
 				return false;
@@ -90,7 +90,7 @@ namespace Mono.Linker
 			return results.Count > 0;
 		}
 
-		static void ParseSignature (string id, ref int index, ModuleDefinition module, List<IMemberDefinition> results, ITryResolveMetadata resolver)
+		private static void ParseSignature (string id, ref int index, ModuleDefinition module, List<IMemberDefinition> results, ITryResolveMetadata resolver)
 		{
 			Debug.Assert (results.Count == 0);
 			var memberTypeChar = PeekNextChar (id, index);
@@ -147,7 +147,7 @@ namespace Mono.Linker
 				(name, arity) = ParseTypeOrNamespaceName (id, ref index, nameBuilder);
 				// if we are at the end of the dotted name and still haven't resolved it to
 				// a type, there are no results.
-				if (String.IsNullOrEmpty (name))
+				if (string.IsNullOrEmpty (name))
 					return;
 
 				// no more dots, so don't loop any more
@@ -263,7 +263,7 @@ namespace Mono.Linker
 		// To avoid looking for types by name in all referenced assemblies, we just represent types
 		// that are part of a signature by their doc comment strings, and we check for matching
 		// strings when looking for matching member signatures.
-		static string? ParseTypeSymbol (string id, ref int index, IGenericParameterProvider? typeParameterContext)
+		private static string? ParseTypeSymbol (string id, ref int index, IGenericParameterProvider? typeParameterContext)
 		{
 			var results = new List<string> ();
 			ParseTypeSymbol (id, ref index, typeParameterContext, results);
@@ -274,7 +274,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		static void ParseTypeSymbol (string id, ref int index, IGenericParameterProvider? typeParameterContext, List<string> results)
+		private static void ParseTypeSymbol (string id, ref int index, IGenericParameterProvider? typeParameterContext, List<string> results)
 		{
 			// Note: Roslyn has a special case that deviates from the language spec, which
 			// allows context expressions embedded in a type reference => <context-definition>:<type-parameter>
@@ -330,7 +330,7 @@ namespace Mono.Linker
 			index = endIndex;
 		}
 
-		static void ParseTypeParameterSymbol (string id, ref int index, IGenericParameterProvider? typeParameterContext, List<string> results)
+		private static void ParseTypeParameterSymbol (string id, ref int index, IGenericParameterProvider? typeParameterContext, List<string> results)
 		{
 			// skip the first `
 			Debug.Assert (PeekNextChar (id, index) == '`');
@@ -369,14 +369,14 @@ namespace Mono.Linker
 			}
 		}
 
-		static void ParseNamedTypeSymbol (string id, ref int index, IGenericParameterProvider? typeParameterContext, List<string> results)
+		private static void ParseNamedTypeSymbol (string id, ref int index, IGenericParameterProvider? typeParameterContext, List<string> results)
 		{
 			Debug.Assert (results.Count == 0);
 			var nameBuilder = new StringBuilder ();
 			// loop for dotted names
 			while (true) {
 				var name = ParseName (id, ref index);
-				if (String.IsNullOrEmpty (name))
+				if (string.IsNullOrEmpty (name))
 					return;
 
 				nameBuilder.Append (name);
@@ -418,7 +418,7 @@ namespace Mono.Linker
 			results.Add (nameBuilder.ToString ());
 		}
 
-		static int ParseArrayBounds (string id, ref int index)
+		private static int ParseArrayBounds (string id, ref int index)
 		{
 			index++; // skip '['
 
@@ -458,7 +458,7 @@ namespace Mono.Linker
 			return bounds;
 		}
 
-		static bool ParseTypeArguments (string id, ref int index, IGenericParameterProvider? typeParameterContext, List<string> typeArguments)
+		private static bool ParseTypeArguments (string id, ref int index, IGenericParameterProvider? typeParameterContext, List<string> typeArguments)
 		{
 			index++; // skip over {
 
@@ -489,7 +489,7 @@ namespace Mono.Linker
 			return true;
 		}
 
-		static void GetMatchingTypes (ModuleDefinition module, TypeDefinition? declaringType, string name, int arity, List<IMemberDefinition> results, ITryResolveMetadata resolver)
+		private static void GetMatchingTypes (ModuleDefinition module, TypeDefinition? declaringType, string name, int arity, List<IMemberDefinition> results, ITryResolveMetadata resolver)
 		{
 			Debug.Assert (module != null);
 
@@ -505,7 +505,7 @@ namespace Mono.Linker
 				return;
 
 			foreach (var nestedType in declaringType.NestedTypes) {
-				Debug.Assert (String.IsNullOrEmpty (nestedType.Namespace));
+				Debug.Assert (string.IsNullOrEmpty (nestedType.Namespace));
 				if (nestedType.Name != name)
 					continue;
 
@@ -521,7 +521,7 @@ namespace Mono.Linker
 			}
 		}
 
-		static void GetMatchingMethods (string id, ref int index, TypeDefinition? type, string memberName, int arity, List<IMemberDefinition> results, ITryResolveMetadata resolver, bool acceptName = false)
+		private static void GetMatchingMethods (string id, ref int index, TypeDefinition? type, string memberName, int arity, List<IMemberDefinition> results, ITryResolveMetadata resolver, bool acceptName = false)
 		{
 			if (type == null)
 				return;
@@ -574,7 +574,7 @@ namespace Mono.Linker
 			index = endIndex;
 		}
 
-		static void GetMatchingProperties (string id, ref int index, TypeDefinition? type, string memberName, List<IMemberDefinition> results, ITryResolveMetadata resolver, bool acceptName = false)
+		private static void GetMatchingProperties (string id, ref int index, TypeDefinition? type, string memberName, List<IMemberDefinition> results, ITryResolveMetadata resolver, bool acceptName = false)
 		{
 			if (type == null)
 				return;
@@ -610,7 +610,7 @@ namespace Mono.Linker
 			index = endIndex;
 		}
 
-		static void GetMatchingFields (TypeDefinition? type, string memberName, List<IMemberDefinition> results)
+		private static void GetMatchingFields (TypeDefinition? type, string memberName, List<IMemberDefinition> results)
 		{
 			if (type == null)
 				return;
@@ -621,7 +621,7 @@ namespace Mono.Linker
 			}
 		}
 
-		static void GetMatchingEvents (TypeDefinition? type, string memberName, List<IMemberDefinition> results)
+		private static void GetMatchingEvents (TypeDefinition? type, string memberName, List<IMemberDefinition> results)
 		{
 			if (type == null)
 				return;
@@ -632,7 +632,7 @@ namespace Mono.Linker
 			}
 		}
 
-		static bool AllParametersMatch (Collection<ParameterDefinition> methodParameters, List<string> expectedParameters, ITryResolveMetadata resolver)
+		private static bool AllParametersMatch (Collection<ParameterDefinition> methodParameters, List<string> expectedParameters, ITryResolveMetadata resolver)
 		{
 			if (methodParameters.Count != expectedParameters.Count)
 				return false;
@@ -645,7 +645,7 @@ namespace Mono.Linker
 			return true;
 		}
 
-		static bool ParseParameterList (string id, ref int index, IGenericParameterProvider typeParameterContext, List<string> parameters)
+		private static bool ParseParameterList (string id, ref int index, IGenericParameterProvider typeParameterContext, List<string> parameters)
 		{
 			System.Diagnostics.Debug.Assert (typeParameterContext != null);
 
@@ -681,14 +681,14 @@ namespace Mono.Linker
 			return true;
 		}
 
-		static char PeekNextChar (string id, int index)
+		private static char PeekNextChar (string id, int index)
 		{
 			return index >= id.Length ? '\0' : id[index];
 		}
 
-		static readonly char[] s_nameDelimiters = { ':', '.', '(', ')', '{', '}', '[', ']', ',', '\'', '@', '*', '`', '~' };
+		private static readonly char[] s_nameDelimiters = { ':', '.', '(', ')', '{', '}', '[', ']', ',', '\'', '@', '*', '`', '~' };
 
-		static string ParseName (string id, ref int index)
+		private static string ParseName (string id, ref int index)
 		{
 			string name;
 
@@ -705,12 +705,12 @@ namespace Mono.Linker
 		}
 
 		// undoes dot encodings within names...
-		static string DecodeName (string name)
+		private static string DecodeName (string name)
 		{
 			return name.Replace ('#', '.');
 		}
 
-		static int ReadNextInteger (string id, ref int index)
+		private static int ReadNextInteger (string id, ref int index)
 		{
 			int n = 0;
 

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -46,8 +46,8 @@ namespace Mono.Linker
 
 	public partial class Driver : IDisposable
 	{
-		const string resolvers = "-a|-x";
-		const string _linker = "IL Linker";
+		private const string resolvers = "-a|-x";
+		private const string _linker = "IL Linker";
 
 		public static int Main (string[] args)
 		{
@@ -69,9 +69,9 @@ namespace Mono.Linker
 			}
 		}
 
-		readonly Queue<string> arguments;
-		bool _needAddBypassNGenStep;
-		LinkContext? context;
+		private readonly Queue<string> arguments;
+		private bool _needAddBypassNGenStep;
+		private LinkContext? context;
 		protected LinkContext Context {
 			get {
 				Debug.Assert (context != null);
@@ -146,7 +146,7 @@ namespace Mono.Linker
 						numBackslash /= 2;
 					}
 					if (numBackslash > 0)
-						argBuilder.Append (new String ('\\', numBackslash));
+						argBuilder.Append (new string ('\\', numBackslash));
 					if (cur < 0 || (!inquote && char.IsWhiteSpace ((char) cur)))
 						break;
 					if (copyChar)
@@ -157,7 +157,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void ErrorMissingArgument (string optionName)
+		private void ErrorMissingArgument (string optionName)
 		{
 			Context.LogError (null, DiagnosticId.MissingArgumentForCommanLineOptionName, optionName);
 		}
@@ -823,7 +823,7 @@ namespace Mono.Linker
 		/// This method is called in the exception filter for unexpected exceptions.
 		/// Prints error messages and returns false to avoid catching in the exception filter.
 		/// </summary>
-		bool LogFatalError (Exception e)
+		private bool LogFatalError (Exception e)
 		{
 			switch (e) {
 			case LinkerFatalErrorException lex:
@@ -846,7 +846,7 @@ namespace Mono.Linker
 
 		private static IEnumerable<int> ProcessWarningCodes (string value)
 		{
-			string Unquote (string arg)
+			static string Unquote (string arg)
 			{
 				if (arg.Length > 1 && arg[0] == '"' && arg[arg.Length - 1] == '"')
 					return arg.Substring (1, arg.Length - 2);
@@ -865,7 +865,7 @@ namespace Mono.Linker
 			}
 		}
 
-		Assembly? GetCustomAssembly (string arg)
+		private Assembly? GetCustomAssembly (string arg)
 		{
 			if (Path.IsPathRooted (arg)) {
 				var assemblyPath = Path.GetFullPath (arg);
@@ -895,7 +895,7 @@ namespace Mono.Linker
 			pipeline.AddStepBefore (typeof (MarkStep), new LinkAttributesStep (File.OpenRead (file), file));
 		}
 
-		static void AddBodySubstituterStep (Pipeline pipeline, string file)
+		private static void AddBodySubstituterStep (Pipeline pipeline, string file)
 		{
 			pipeline.AddStepBefore (typeof (MarkStep), new BodySubstituterStep (File.OpenRead (file), file));
 		}
@@ -923,7 +923,7 @@ namespace Mono.Linker
 			return true;
 		}
 
-		bool TryGetCustomAssembly (ref string arg, [NotNullWhen (true)] out Assembly? assembly)
+		private bool TryGetCustomAssembly (ref string arg, [NotNullWhen (true)] out Assembly? assembly)
 		{
 			assembly = null;
 			int pos = arg.IndexOf (",");
@@ -1028,7 +1028,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		static IMarkHandler? FindMarkHandler (Pipeline pipeline, string name)
+		private static IMarkHandler? FindMarkHandler (Pipeline pipeline, string name)
 		{
 			foreach (IMarkHandler step in pipeline.MarkHandlers) {
 				Type t = step.GetType ();
@@ -1039,7 +1039,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		Type? ResolveStepType (string type, Assembly assembly)
+		private Type? ResolveStepType (string type, Assembly assembly)
 		{
 			// Ignore warning, since we're just enabling analyzer for dogfooding
 #pragma warning disable IL2026
@@ -1054,7 +1054,7 @@ namespace Mono.Linker
 			return step;
 		}
 
-		TStep? ResolveStep<TStep> (string type, Assembly assembly) where TStep : class
+		private TStep? ResolveStep<TStep> (string type, Assembly assembly) where TStep : class
 		{
 			// Ignore warning, since we're just enabling analyzer for dogfooding
 #pragma warning disable IL2026
@@ -1074,7 +1074,7 @@ namespace Mono.Linker
 			return (TStep?) Activator.CreateInstance (step);
 		}
 
-		static string[] GetFiles (string param)
+		private static string[] GetFiles (string param)
 		{
 			if (param.Length < 1 || param[0] != '@')
 				return new string[] { param };
@@ -1083,7 +1083,7 @@ namespace Mono.Linker
 			return ReadLines (file);
 		}
 
-		static string[] ReadLines (string file)
+		private static string[] ReadLines (string file)
 		{
 			var lines = new List<string> ();
 			using (StreamReader reader = new StreamReader (file)) {
@@ -1094,7 +1094,7 @@ namespace Mono.Linker
 			return lines.ToArray ();
 		}
 
-		AssemblyAction? ParseAssemblyAction (string s)
+		private AssemblyAction? ParseAssemblyAction (string s)
 		{
 			switch (s.ToLowerInvariant ()) {
 			case "copy":
@@ -1118,7 +1118,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		AssemblyRootMode? ParseAssemblyRootsMode (string s)
+		private AssemblyRootMode? ParseAssemblyRootsMode (string s)
 		{
 			switch (s.ToLowerInvariant ()) {
 			case "default":
@@ -1137,7 +1137,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		bool GetWarnVersion (string text, out WarnVersion version)
+		private bool GetWarnVersion (string text, out WarnVersion version)
 		{
 			if (int.TryParse (text, out int versionNum)) {
 				version = (WarnVersion) versionNum;
@@ -1181,7 +1181,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		bool TryGetMetadataTrimming (string text, out MetadataTrimming metadataTrimming)
+		private bool TryGetMetadataTrimming (string text, out MetadataTrimming metadataTrimming)
 		{
 			switch (text.ToLowerInvariant ()) {
 			case "all":
@@ -1217,7 +1217,7 @@ namespace Mono.Linker
 			}
 		}
 
-		bool GetBoolParam (string token, Action<bool> action)
+		private bool GetBoolParam (string token, Action<bool> action)
 		{
 			if (arguments.Count == 0) {
 				action (true);
@@ -1240,7 +1240,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		bool GetStringParam (string token, [NotNullWhen (true)] out string? value)
+		private bool GetStringParam (string token, [NotNullWhen (true)] out string? value)
 		{
 			value = null;
 			if (arguments.Count < 1) {
@@ -1258,7 +1258,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		string? GetNextStringValue ()
+		private string? GetNextStringValue ()
 		{
 			if (arguments.Count < 1)
 				return null;
@@ -1284,12 +1284,12 @@ namespace Mono.Linker
 			return new List<BaseStep> ();
 		}
 
-		static bool IsValidAssemblyName (string value)
+		private static bool IsValidAssemblyName (string value)
 		{
 			return !string.IsNullOrEmpty (value);
 		}
 
-		static void Usage ()
+		private static void Usage ()
 		{
 			Console.WriteLine (_linker);
 
@@ -1389,20 +1389,20 @@ namespace Mono.Linker
 			Console.WriteLine ("");
 		}
 
-		static void Version ()
+		private static void Version ()
 		{
 			Console.WriteLine ("{0} Version {1}",
 				_linker,
 				System.Reflection.Assembly.GetExecutingAssembly ().GetName ().Version);
 		}
 
-		static void About ()
+		private static void About ()
 		{
 			Console.WriteLine ("For more information, visit the project Web site");
 			Console.WriteLine ("   https://github.com/dotnet/linker");
 		}
 
-		static Pipeline GetStandardPipeline ()
+		private static Pipeline GetStandardPipeline ()
 		{
 			Pipeline p = new Pipeline ();
 			p.AppendStep (new ProcessReferencesStep ());

--- a/src/linker/Linker/DynamicDependency.cs
+++ b/src/linker/Linker/DynamicDependency.cs
@@ -71,7 +71,7 @@ namespace Mono.Linker
 			// Don't honor the Condition until we have figured out the behavior for DynamicDependencyAttribute:
 			// https://github.com/dotnet/linker/issues/1231
 			// if (!ShouldProcess (context, customAttribute))
-			// 	return null;
+			//  return null;
 
 			var dynamicDependency = GetDynamicDependency (customAttribute);
 			if (dynamicDependency != null)
@@ -81,7 +81,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		static DynamicDependency? GetDynamicDependency (CustomAttribute ca)
+		private static DynamicDependency? GetDynamicDependency (CustomAttribute ca)
 		{
 			var args = ca.ConstructorArguments;
 			if (args.Count < 1 || args.Count > 3)

--- a/src/linker/Linker/EmbeddedXmlInfo.cs
+++ b/src/linker/Linker/EmbeddedXmlInfo.cs
@@ -12,7 +12,7 @@ namespace Mono.Linker
 {
 	public static class EmbeddedXmlInfo
 	{
-		static EmbeddedResource? GetEmbeddedXml (AssemblyDefinition assembly, Func<Resource, bool> predicate)
+		private static EmbeddedResource? GetEmbeddedXml (AssemblyDefinition assembly, Func<Resource, bool> predicate)
 		{
 			return assembly.Modules
 				.SelectMany (mod => mod.Resources)
@@ -94,7 +94,7 @@ namespace Mono.Linker
 			return attributeInfo;
 		}
 
-		static string GetAssemblyName (string descriptor)
+		private static string GetAssemblyName (string descriptor)
 		{
 			int pos = descriptor.LastIndexOf ('.');
 			if (pos == -1)
@@ -103,7 +103,7 @@ namespace Mono.Linker
 			return descriptor.Substring (0, pos);
 		}
 
-		static bool ShouldProcessRootDescriptorResource (AssemblyDefinition assembly, LinkContext context, string resourceName)
+		private static bool ShouldProcessRootDescriptorResource (AssemblyDefinition assembly, LinkContext context, string resourceName)
 		{
 			if (resourceName.Equals ("ILLink.Descriptors.xml", StringComparison.OrdinalIgnoreCase))
 				return true;
@@ -122,17 +122,17 @@ namespace Mono.Linker
 			}
 		}
 
-		static DescriptorMarker GetExternalResolveStep (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
+		private static DescriptorMarker GetExternalResolveStep (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
 			return new DescriptorMarker (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}
 
-		static BodySubstitutionParser GetExternalSubstitutionParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
+		private static BodySubstitutionParser GetExternalSubstitutionParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
 			return new BodySubstitutionParser (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}
 
-		static LinkAttributesParser GetExternalLinkAttributesParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
+		private static LinkAttributesParser GetExternalLinkAttributesParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
 			return new LinkAttributesParser (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}

--- a/src/linker/Linker/FeatureSettings.cs
+++ b/src/linker/Linker/FeatureSettings.cs
@@ -41,7 +41,7 @@ namespace Mono.Linker
 
 		public static string GetAttribute (XPathNavigator nav, string attribute)
 		{
-			return nav.GetAttribute (attribute, String.Empty);
+			return nav.GetAttribute (attribute, string.Empty);
 		}
 	}
 }

--- a/src/linker/Linker/FieldDefinitionExtensions.cs
+++ b/src/linker/Linker/FieldDefinitionExtensions.cs
@@ -5,7 +5,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-	static class FieldDefinitionExtensions
+	internal static class FieldDefinitionExtensions
 	{
 		public static bool IsCompilerGenerated (this FieldDefinition field)
 		{

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -66,20 +66,20 @@ namespace Mono.Linker
 	public class LinkContext : IMetadataResolver, ITryResolveMetadata, IDisposable
 	{
 
-		readonly Pipeline _pipeline;
-		readonly Dictionary<string, AssemblyAction> _actions;
-		readonly Dictionary<string, string> _parameters;
-		int? _targetRuntime;
+		private readonly Pipeline _pipeline;
+		private readonly Dictionary<string, AssemblyAction> _actions;
+		private readonly Dictionary<string, string> _parameters;
+		private int? _targetRuntime;
 
-		readonly AssemblyResolver _resolver;
-		readonly TypeNameResolver _typeNameResolver;
+		private readonly AssemblyResolver _resolver;
+		private readonly TypeNameResolver _typeNameResolver;
 
-		readonly AnnotationStore _annotations;
-		readonly CustomAttributeSource _customAttributes;
-		readonly CompilerGeneratedState _compilerGeneratedState;
-		readonly List<MessageContainer> _cachedWarningMessageContainers;
-		readonly ILogger _logger;
-		readonly Dictionary<AssemblyDefinition, bool> _isTrimmable;
+		private readonly AnnotationStore _annotations;
+		private readonly CustomAttributeSource _customAttributes;
+		private readonly CompilerGeneratedState _compilerGeneratedState;
+		private readonly List<MessageContainer> _cachedWarningMessageContainers;
+		private readonly ILogger _logger;
+		private readonly Dictionary<AssemblyDefinition, bool> _isTrimmable;
 
 		public Pipeline Pipeline {
 			get { return _pipeline; }
@@ -246,7 +246,7 @@ namespace Mono.Linker
 
 		public void SetFeatureValue (string feature, bool value)
 		{
-			Debug.Assert (!String.IsNullOrEmpty (feature));
+			Debug.Assert (!string.IsNullOrEmpty (feature));
 			FeatureSettings[feature] = value;
 		}
 
@@ -352,7 +352,7 @@ namespace Mono.Linker
 			return references;
 		}
 
-		static AssemblyNameReference GetReference (IMetadataScope scope)
+		private static AssemblyNameReference GetReference (IMetadataScope scope)
 		{
 			AssemblyNameReference reference;
 			if (scope is ModuleDefinition moduleDefinition) {
@@ -735,7 +735,7 @@ namespace Mono.Linker
 			return SingleWarn.TryGetValue (assemblyName, out value) && value;
 		}
 
-		static WarnVersion GetWarningVersion ()
+		private static WarnVersion GetWarningVersion ()
 		{
 			// This should return an increasing WarnVersion for new warning waves.
 			return WarnVersion.ILLink5;
@@ -752,9 +752,9 @@ namespace Mono.Linker
 			return _targetRuntime.Value;
 		}
 
-		readonly Dictionary<MethodReference, MethodDefinition?> methodresolveCache = new ();
-		readonly Dictionary<FieldReference, FieldDefinition?> fieldresolveCache = new ();
-		readonly Dictionary<TypeReference, TypeDefinition?> typeresolveCache = new ();
+		private readonly Dictionary<MethodReference, MethodDefinition?> methodresolveCache = new ();
+		private readonly Dictionary<FieldReference, FieldDefinition?> fieldresolveCache = new ();
+		private readonly Dictionary<TypeReference, TypeDefinition?> typeresolveCache = new ();
 
 		public MethodDefinition? Resolve (MethodReference methodReference)
 		{
@@ -891,7 +891,7 @@ namespace Mono.Linker
 				: null;
 		}
 
-		readonly HashSet<MemberReference> unresolved_reported = new ();
+		private readonly HashSet<MemberReference> unresolved_reported = new ();
 
 		protected virtual void ReportUnresolved (FieldReference fieldReference)
 		{
@@ -914,7 +914,7 @@ namespace Mono.Linker
 
 	public class CodeOptimizationsSettings
 	{
-		sealed class Pair
+		private sealed class Pair
 		{
 			public Pair (CodeOptimizations set, CodeOptimizations values)
 			{
@@ -926,7 +926,7 @@ namespace Mono.Linker
 			public CodeOptimizations Values;
 		}
 
-		readonly Dictionary<string, Pair> perAssembly = new ();
+		private readonly Dictionary<string, Pair> perAssembly = new ();
 
 		public CodeOptimizationsSettings (CodeOptimizations globalOptimizations)
 		{

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -11,9 +11,9 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-	readonly struct LinkerAttributesInformation
+	internal readonly struct LinkerAttributesInformation
 	{
-		readonly List<(Type Type, List<Attribute> Attributes)>? _linkerAttributes;
+		private readonly List<(Type Type, List<Attribute> Attributes)>? _linkerAttributes;
 
 		private LinkerAttributesInformation (List<(Type Type, List<Attribute> Attributes)>? cache)
 		{
@@ -107,7 +107,7 @@ namespace Mono.Linker
 			return attributeList.Cast<T> ();
 		}
 
-		static Attribute? ProcessRequiresUnreferencedCodeAttribute (LinkContext context, ICustomAttributeProvider provider, CustomAttribute customAttribute)
+		private static Attribute? ProcessRequiresUnreferencedCodeAttribute (LinkContext context, ICustomAttributeProvider provider, CustomAttribute customAttribute)
 		{
 			if (!(provider is MethodDefinition || provider is TypeDefinition))
 				return null;

--- a/src/linker/Linker/LinkerILProcessor.cs
+++ b/src/linker/Linker/LinkerILProcessor.cs
@@ -8,11 +8,11 @@ using Mono.Cecil.Cil;
 namespace Mono.Linker
 {
 #pragma warning disable RS0030
-	sealed class LinkerILProcessor
+	internal sealed class LinkerILProcessor
 	{
-		readonly ILProcessor _ilProcessor;
+		private readonly ILProcessor _ilProcessor;
 
-		Collections.Generic.Collection<Instruction> Instructions => _ilProcessor.Body.Instructions;
+		private Collections.Generic.Collection<Instruction> Instructions => _ilProcessor.Body.Instructions;
 
 		internal LinkerILProcessor (MethodBody body)
 		{
@@ -75,7 +75,7 @@ namespace Mono.Linker
 
 		public void RemoveAt (int index) => Remove (Instructions[index]);
 
-		void RedirectScopeStart (Instruction oldTarget, Instruction? newTarget)
+		private void RedirectScopeStart (Instruction oldTarget, Instruction? newTarget)
 		{
 			// In Cecil "start" pointers point to the first instruction in a given scope
 			// and the "end" pointers point to the first instruction after the given block
@@ -96,14 +96,14 @@ namespace Mono.Linker
 		}
 
 #pragma warning disable IDE0060 // Remove unused parameter
-		static void RedirectScopeEnd (Instruction? oldTarget, Instruction? newTarget)
+		private static void RedirectScopeEnd (Instruction? oldTarget, Instruction? newTarget)
 #pragma warning restore IDE0060 // Remove unused parameter
 		{
 			// Currently Cecil treats all block boundaries as "starts"
 			// so nothing to do here.
 		}
 
-		void ReplaceInstructionReference (Instruction oldTarget, Instruction? newTarget)
+		private void ReplaceInstructionReference (Instruction oldTarget, Instruction? newTarget)
 		{
 			foreach (var instr in Instructions) {
 				switch (instr.OpCode.FlowControl) {
@@ -129,7 +129,7 @@ namespace Mono.Linker
 #pragma warning disable RS0030
 	}
 
-	static class ILProcessorExtensions
+	internal static class ILProcessorExtensions
 	{
 		public static LinkerILProcessor GetLinkerILProcessor (this MethodBody body)
 		{

--- a/src/linker/Linker/MemberActionStore.cs
+++ b/src/linker/Linker/MemberActionStore.cs
@@ -11,7 +11,7 @@ namespace Mono.Linker
 	{
 		public SubstitutionInfo PrimarySubstitutionInfo { get; }
 		private readonly Dictionary<AssemblyDefinition, SubstitutionInfo?> _embeddedXmlInfos;
-		readonly LinkContext _context;
+		private readonly LinkContext _context;
 
 		public MemberActionStore (LinkContext context)
 		{

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -210,7 +210,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		static bool TryLogSingleWarning (LinkContext context, int code, MessageOrigin origin, string subcategory)
+		private static bool TryLogSingleWarning (LinkContext context, int code, MessageOrigin origin, string subcategory)
 		{
 			if (subcategory != MessageSubCategory.TrimAnalysis)
 				return false;
@@ -289,10 +289,10 @@ namespace Mono.Linker
 			string origin = Origin?.ToString () ?? originApp;
 
 			StringBuilder sb = new StringBuilder ();
-			sb.Append (origin).Append (":");
+			sb.Append (origin).Append (':');
 
 			if (!string.IsNullOrEmpty (SubCategory))
-				sb.Append (" ").Append (SubCategory);
+				sb.Append (' ').Append (SubCategory);
 
 			string cat;
 			switch (Category) {
@@ -309,14 +309,14 @@ namespace Mono.Linker
 			}
 
 			if (!string.IsNullOrEmpty (cat)) {
-				sb.Append (" ")
+				sb.Append (' ')
 					.Append (cat)
 					.Append (" IL")
 					// Warning and error messages always have a code.
 					.Append (Code!.Value.ToString ("D4"))
 					.Append (": ");
 			} else {
-				sb.Append (" ");
+				sb.Append (' ');
 			}
 
 			if (Origin?.Provider != null) {

--- a/src/linker/Linker/MessageOrigin.cs
+++ b/src/linker/Linker/MessageOrigin.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker
 		public int SourceColumn { get; }
 		public int? ILOffset { get; }
 
-		const int HiddenLineNumber = 0xfeefee;
+		private const int HiddenLineNumber = 0xfeefee;
 
 		public MessageOrigin (IMemberDefinition? memberDefinition, int? ilOffset = null)
 			: this (memberDefinition as ICustomAttributeProvider, ilOffset)
@@ -106,11 +106,11 @@ namespace Mono.Linker
 
 			StringBuilder sb = new StringBuilder (fileName);
 			if (sourceLine != 0) {
-				sb.Append ("(").Append (sourceLine);
+				sb.Append ('(').Append (sourceLine);
 				if (sourceColumn != 0)
-					sb.Append (",").Append (sourceColumn);
+					sb.Append (',').Append (sourceColumn);
 
-				sb.Append (")");
+				sb.Append (')');
 			}
 
 			return sb.ToString ();

--- a/src/linker/Linker/MethodBodyScanner.cs
+++ b/src/linker/Linker/MethodBodyScanner.cs
@@ -55,9 +55,9 @@ namespace Mono.Linker
 			return true;
 		}
 	}
-	readonly struct InterfacesOnStackScanner
+	internal readonly struct InterfacesOnStackScanner
 	{
-		readonly LinkContext context;
+		private readonly LinkContext context;
 
 		public InterfacesOnStackScanner (LinkContext context)
 		{
@@ -95,7 +95,7 @@ namespace Mono.Linker
 			return interfaceImplementations;
 		}
 
-		HashSet<TypeDefinition> AllPossibleStackTypes (MethodDefinition method)
+		private HashSet<TypeDefinition> AllPossibleStackTypes (MethodDefinition method)
 		{
 			if (!method.HasBody)
 				throw new ArgumentException ("Method does not have body", nameof (method));
@@ -144,7 +144,7 @@ namespace Mono.Linker
 			return types;
 		}
 
-		void AddMatchingInterfaces (HashSet<(InterfaceImplementation, TypeDefinition)> results, TypeDefinition type, TypeDefinition[] interfaceTypes)
+		private void AddMatchingInterfaces (HashSet<(InterfaceImplementation, TypeDefinition)> results, TypeDefinition type, TypeDefinition[] interfaceTypes)
 		{
 			if (!type.HasInterfaces)
 				return;
@@ -155,7 +155,7 @@ namespace Mono.Linker
 			}
 		}
 
-		bool HasInterface (TypeDefinition type, TypeDefinition interfaceType, [NotNullWhen (true)] out InterfaceImplementation? implementation)
+		private bool HasInterface (TypeDefinition type, TypeDefinition interfaceType, [NotNullWhen (true)] out InterfaceImplementation? implementation)
 		{
 			implementation = null;
 			if (!type.HasInterfaces)
@@ -171,7 +171,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		void AddFromGenericInstance (HashSet<TypeDefinition> set, IGenericInstance instance)
+		private void AddFromGenericInstance (HashSet<TypeDefinition> set, IGenericInstance instance)
 		{
 			if (!instance.HasGenericArguments)
 				return;
@@ -180,7 +180,7 @@ namespace Mono.Linker
 				AddIfResolved (set, genericArgument);
 		}
 
-		void AddFromGenericParameterProvider (HashSet<TypeDefinition> set, IGenericParameterProvider provider)
+		private void AddFromGenericParameterProvider (HashSet<TypeDefinition> set, IGenericParameterProvider provider)
 		{
 			if (!provider.HasGenericParameters)
 				return;
@@ -191,7 +191,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void AddIfResolved (HashSet<TypeDefinition> set, TypeReference item)
+		private void AddIfResolved (HashSet<TypeDefinition> set, TypeReference item)
 		{
 			var resolved = context.TryResolve (item);
 			if (resolved == null)

--- a/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/linker/Linker/MethodReferenceExtensions.cs
@@ -40,7 +40,7 @@ namespace Mono.Linker
 			}
 
 			// Append parameters
-			sb.Append ("(");
+			sb.Append ('(');
 			if (method.HasParameters) {
 				for (int i = 0; i < method.Parameters.Count - 1; i++)
 					sb.Append (method.Parameters[i].ParameterType.GetDisplayNameWithoutNamespace ()).Append (", ");
@@ -48,7 +48,7 @@ namespace Mono.Linker
 				sb.Append (method.Parameters[method.Parameters.Count - 1].ParameterType.GetDisplayNameWithoutNamespace ());
 			}
 
-			sb.Append (")");
+			sb.Append (')');
 
 			// Insert generic parameters
 			if (method.HasGenericParameters) {

--- a/src/linker/Linker/OverrideInformation.cs
+++ b/src/linker/Linker/OverrideInformation.cs
@@ -9,8 +9,8 @@ namespace Mono.Linker
 	[DebuggerDisplay ("{Override}")]
 	public class OverrideInformation
 	{
-		readonly ITryResolveMetadata resolver;
-		readonly OverridePair _pair;
+		private readonly ITryResolveMetadata resolver;
+		private readonly OverridePair _pair;
 		private InterfaceImplementation? _matchingInterfaceImplementation;
 
 		public OverrideInformation (MethodDefinition @base, MethodDefinition @override, ITryResolveMetadata resolver, InterfaceImplementation? matchingInterfaceImplementation = null)

--- a/src/linker/Linker/Pipeline.cs
+++ b/src/linker/Linker/Pipeline.cs
@@ -39,7 +39,7 @@ namespace Mono.Linker
 	public class Pipeline
 	{
 
-		readonly List<IStep> _steps;
+		private readonly List<IStep> _steps;
 		public List<IMarkHandler> MarkHandlers { get; }
 
 		public Pipeline ()

--- a/src/linker/Linker/RemoveAttributeInstancesAttribute.cs
+++ b/src/linker/Linker/RemoveAttributeInstancesAttribute.cs
@@ -9,7 +9,7 @@ using Mono.Collections.Generic;
 namespace Mono.Linker
 {
 	/// <summary>
-	/// This attribute name will be the name hardcoded in linker which will remove all 
+	/// This attribute name will be the name hardcoded in linker which will remove all
 	/// attribute usages but not the attribute definition
 	/// </summary>
 	[AttributeUsage (

--- a/src/linker/Linker/SerializationMarker.cs
+++ b/src/linker/Linker/SerializationMarker.cs
@@ -51,12 +51,12 @@ namespace Mono.Linker
 
 	public class SerializationMarker
 	{
-		readonly LinkContext _context;
+		private readonly LinkContext _context;
 
-		SerializerKind ActiveSerializers { get; set; }
+		private SerializerKind ActiveSerializers { get; set; }
 
-		Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>>? _trackedRoots;
-		Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>> TrackedRoots {
+		private Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>>? _trackedRoots;
+		private Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>> TrackedRoots {
 			get {
 				if (_trackedRoots == null)
 					_trackedRoots = new Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>> ();
@@ -65,8 +65,8 @@ namespace Mono.Linker
 			}
 		}
 
-		HashSet<TypeDefinition>? _recursiveTypes;
-		HashSet<TypeDefinition> RecursiveTypes {
+		private HashSet<TypeDefinition>? _recursiveTypes;
+		private HashSet<TypeDefinition> RecursiveTypes {
 			get {
 				if (_recursiveTypes == null)
 					_recursiveTypes = new HashSet<TypeDefinition> ();
@@ -82,7 +82,7 @@ namespace Mono.Linker
 
 		public bool IsActive (SerializerKind serializerKind) => ActiveSerializers.HasFlag (serializerKind);
 
-		static DependencyKind ToDependencyKind (SerializerKind serializerKind) => serializerKind switch {
+		private static DependencyKind ToDependencyKind (SerializerKind serializerKind) => serializerKind switch {
 			SerializerKind.DataContractSerializer => DependencyKind.DataContractSerialized,
 			SerializerKind.XmlSerializer => DependencyKind.XmlSerialized,
 			_ => throw new ArgumentException (nameof (SerializerKind))
@@ -168,7 +168,7 @@ namespace Mono.Linker
 			MarkRecursiveMembersInternal (type, reason);
 		}
 
-		void MarkRecursiveMembersInternal (TypeReference typeRef, in DependencyInfo reason)
+		private void MarkRecursiveMembersInternal (TypeReference typeRef, in DependencyInfo reason)
 		{
 			if (typeRef == null)
 				return;

--- a/src/linker/Linker/Tracer.cs
+++ b/src/linker/Linker/Tracer.cs
@@ -39,7 +39,7 @@ namespace Mono.Linker
 	{
 		protected readonly LinkContext context;
 
-		List<IDependencyRecorder>? recorders;
+		private List<IDependencyRecorder>? recorders;
 
 		public Tracer (LinkContext context)
 		{
@@ -69,7 +69,7 @@ namespace Mono.Linker
 		}
 
 		[MemberNotNullWhen (true, "recorders")]
-		bool IsRecordingEnabled ()
+		private bool IsRecordingEnabled ()
 		{
 			return recorders != null;
 		}

--- a/src/linker/Linker/TypeHierarchyCache.cs
+++ b/src/linker/Linker/TypeHierarchyCache.cs
@@ -8,7 +8,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-	sealed class TypeHierarchyCache
+	internal sealed class TypeHierarchyCache
 	{
 		[Flags]
 		private enum HierarchyFlags
@@ -17,8 +17,8 @@ namespace Mono.Linker
 			IsSystemReflectionIReflect = 0x02,
 		}
 
-		readonly Dictionary<TypeDefinition, HierarchyFlags> _cache = new Dictionary<TypeDefinition, HierarchyFlags> ();
-		readonly LinkContext context;
+		private readonly Dictionary<TypeDefinition, HierarchyFlags> _cache = new Dictionary<TypeDefinition, HierarchyFlags> ();
+		private readonly LinkContext context;
 
 		public TypeHierarchyCache (LinkContext context)
 		{

--- a/src/linker/Linker/TypeMapInfo.cs
+++ b/src/linker/Linker/TypeMapInfo.cs
@@ -37,8 +37,8 @@ namespace Mono.Linker
 
 	public class TypeMapInfo
 	{
-		readonly HashSet<AssemblyDefinition> assemblies = new HashSet<AssemblyDefinition> ();
-		readonly LinkContext context;
+		private readonly HashSet<AssemblyDefinition> assemblies = new HashSet<AssemblyDefinition> ();
+		private readonly LinkContext context;
 		protected readonly Dictionary<MethodDefinition, List<MethodDefinition>> base_methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 		protected readonly Dictionary<MethodDefinition, List<OverrideInformation>> override_methods = new Dictionary<MethodDefinition, List<OverrideInformation>> ();
 		protected readonly Dictionary<MethodDefinition, List<(TypeDefinition InstanceType, InterfaceImplementation ImplementationProvider)>> default_interface_implementations = new Dictionary<MethodDefinition, List<(TypeDefinition, InterfaceImplementation)>> ();
@@ -48,7 +48,7 @@ namespace Mono.Linker
 			this.context = context;
 		}
 
-		void EnsureProcessed (AssemblyDefinition assembly)
+		private void EnsureProcessed (AssemblyDefinition assembly)
 		{
 			if (!assemblies.Add (assembly))
 				return;
@@ -119,7 +119,7 @@ namespace Mono.Linker
 				MapType (nested);
 		}
 
-		void MapInterfaceMethodsInTypeHierarchy (TypeDefinition type)
+		private void MapInterfaceMethodsInTypeHierarchy (TypeDefinition type)
 		{
 			if (!type.HasInterfaces)
 				return;
@@ -163,7 +163,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void MapVirtualMethods (TypeDefinition type)
+		private void MapVirtualMethods (TypeDefinition type)
 		{
 			if (!type.HasMethods)
 				return;
@@ -182,7 +182,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void MapVirtualMethod (MethodDefinition method)
+		private void MapVirtualMethod (MethodDefinition method)
 		{
 			MethodDefinition? @base = GetBaseMethodInTypeHierarchy (method);
 			if (@base == null)
@@ -191,7 +191,7 @@ namespace Mono.Linker
 			AnnotateMethods (@base, method);
 		}
 
-		void MapOverrides (MethodDefinition method)
+		private void MapOverrides (MethodDefinition method)
 		{
 			foreach (MethodReference override_ref in method.Overrides) {
 				MethodDefinition? @override = context.TryResolve (override_ref);
@@ -202,18 +202,18 @@ namespace Mono.Linker
 			}
 		}
 
-		void AnnotateMethods (MethodDefinition @base, MethodDefinition @override, InterfaceImplementation? matchingInterfaceImplementation = null)
+		private void AnnotateMethods (MethodDefinition @base, MethodDefinition @override, InterfaceImplementation? matchingInterfaceImplementation = null)
 		{
 			AddBaseMethod (@override, @base);
 			AddOverride (@base, @override, matchingInterfaceImplementation);
 		}
 
-		MethodDefinition? GetBaseMethodInTypeHierarchy (MethodDefinition method)
+		private MethodDefinition? GetBaseMethodInTypeHierarchy (MethodDefinition method)
 		{
 			return GetBaseMethodInTypeHierarchy (method.DeclaringType, method);
 		}
 
-		MethodDefinition? GetBaseMethodInTypeHierarchy (TypeDefinition type, MethodReference method)
+		private MethodDefinition? GetBaseMethodInTypeHierarchy (TypeDefinition type, MethodReference method)
 		{
 			TypeReference? @base = GetInflatedBaseType (type);
 			while (@base != null) {
@@ -227,7 +227,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		TypeReference? GetInflatedBaseType (TypeReference type)
+		private TypeReference? GetInflatedBaseType (TypeReference type)
 		{
 			if (type == null)
 				return null;
@@ -260,7 +260,7 @@ namespace Mono.Linker
 		// Note that this returns a list to potentially cover the diamond case (more than one
 		// most specific implementation of the given interface methods). Linker needs to preserve
 		// all the implementations so that the proper exception can be thrown at runtime.
-		IEnumerable<InterfaceImplementation> GetDefaultInterfaceImplementations (TypeDefinition type, MethodDefinition interfaceMethod)
+		private IEnumerable<InterfaceImplementation> GetDefaultInterfaceImplementations (TypeDefinition type, MethodDefinition interfaceMethod)
 		{
 			// Go over all interfaces, trying to find a method that is an explicit MethodImpl of the
 			// interface method in question.
@@ -303,7 +303,7 @@ namespace Mono.Linker
 			}
 		}
 
-		MethodDefinition? TryMatchMethod (TypeReference type, MethodReference method)
+		private MethodDefinition? TryMatchMethod (TypeReference type, MethodReference method)
 		{
 			foreach (var candidate in type.GetMethods (context)) {
 				var md = context.TryResolve (candidate);
@@ -317,7 +317,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		bool MethodMatch (MethodReference candidate, MethodReference method)
+		private bool MethodMatch (MethodReference candidate, MethodReference method)
 		{
 			if (candidate.HasParameters != method.HasParameters)
 				return false;
@@ -356,7 +356,7 @@ namespace Mono.Linker
 			return true;
 		}
 
-		static bool TypeMatch (IModifierType a, IModifierType b)
+		private static bool TypeMatch (IModifierType a, IModifierType b)
 		{
 			if (!TypeMatch (a.ModifierType, b.ModifierType))
 				return false;
@@ -364,7 +364,7 @@ namespace Mono.Linker
 			return TypeMatch (a.ElementType, b.ElementType);
 		}
 
-		static bool TypeMatch (TypeSpecification a, TypeSpecification b)
+		private static bool TypeMatch (TypeSpecification a, TypeSpecification b)
 		{
 			if (a is GenericInstanceType gita)
 				return TypeMatch (gita, (GenericInstanceType) b);
@@ -378,7 +378,7 @@ namespace Mono.Linker
 			return TypeMatch (a.ElementType, b.ElementType);
 		}
 
-		static bool TypeMatch (GenericInstanceType a, GenericInstanceType b)
+		private static bool TypeMatch (GenericInstanceType a, GenericInstanceType b)
 		{
 			if (!TypeMatch (a.ElementType, b.ElementType))
 				return false;
@@ -402,7 +402,7 @@ namespace Mono.Linker
 			return true;
 		}
 
-		static bool TypeMatch (GenericParameter a, GenericParameter b)
+		private static bool TypeMatch (GenericParameter a, GenericParameter b)
 		{
 			if (a.Position != b.Position)
 				return false;
@@ -413,7 +413,7 @@ namespace Mono.Linker
 			return true;
 		}
 
-		static bool TypeMatch (FunctionPointerType a, FunctionPointerType b)
+		private static bool TypeMatch (FunctionPointerType a, FunctionPointerType b)
 		{
 			if (a.HasParameters != b.HasParameters)
 				return false;
@@ -446,7 +446,7 @@ namespace Mono.Linker
 			return true;
 		}
 
-		static bool TypeMatch (TypeReference a, TypeReference b)
+		private static bool TypeMatch (TypeReference a, TypeReference b)
 		{
 			if (a is TypeSpecification || b is TypeSpecification) {
 				if (a.GetType () != b.GetType ())

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -14,7 +14,7 @@ namespace Mono.Linker
 {
 	internal sealed class TypeNameResolver
 	{
-		readonly LinkContext _context;
+		private readonly LinkContext _context;
 
 		public readonly record struct TypeResolutionRecord (AssemblyDefinition ReferringAssembly, TypeDefinition ResolvedType);
 
@@ -115,7 +115,7 @@ namespace Mono.Linker
 			return typeReference != null;
 		}
 
-		TypeReference? ResolveTypeName (AssemblyDefinition assembly, TypeName typeName, List<TypeResolutionRecord> typeResolutionRecords)
+		private TypeReference? ResolveTypeName (AssemblyDefinition assembly, TypeName typeName, List<TypeResolutionRecord> typeResolutionRecords)
 		{
 			if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
 				// In this case we ignore the assembly parameter since the type name has assembly in it

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -86,7 +86,7 @@ namespace Mono.Linker
 			sb.Insert (0, '<');
 		}
 
-		static void PrependGenericArguments (Stack<TypeReference> genericArguments, int argumentsToTake, StringBuilder sb)
+		private static void PrependGenericArguments (Stack<TypeReference> genericArguments, int argumentsToTake, StringBuilder sb)
 		{
 			sb.Insert (0, '>').Insert (0, genericArguments.Pop ().GetDisplayNameWithoutNamespace ().ToString ());
 			while (--argumentsToTake > 0)
@@ -95,7 +95,7 @@ namespace Mono.Linker
 			sb.Insert (0, '<');
 		}
 
-		static void AppendArrayType (ArrayType arrayType, StringBuilder sb)
+		private static void AppendArrayType (ArrayType arrayType, StringBuilder sb)
 		{
 			void parseArrayDimensions (ArrayType at)
 			{

--- a/src/linker/Linker/TypeReferenceWalker.cs
+++ b/src/linker/Linker/TypeReferenceWalker.cs
@@ -9,7 +9,7 @@ using Mono.Collections.Generic;
 
 namespace Mono.Linker
 {
-	abstract class TypeReferenceWalker
+	internal abstract class TypeReferenceWalker
 	{
 		protected readonly AssemblyDefinition assembly;
 
@@ -49,7 +49,7 @@ namespace Mono.Linker
 
 		protected virtual void ProcessExtra () { }
 
-		void WalkScopes (TypeDefinition typeDefinition)
+		private void WalkScopes (TypeDefinition typeDefinition)
 		{
 			WalkCustomAttributesTypesScopes (typeDefinition);
 			WalkSecurityAttributesTypesScopes (typeDefinition);
@@ -119,7 +119,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkTypeScope (Collection<GenericParameter> genericParameters)
+		private void WalkTypeScope (Collection<GenericParameter> genericParameters)
 		{
 			foreach (var gp in genericParameters) {
 				WalkCustomAttributesTypesScopes (gp);
@@ -128,7 +128,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkTypeScope (Collection<GenericParameterConstraint> constraints)
+		private void WalkTypeScope (Collection<GenericParameterConstraint> constraints)
 		{
 			foreach (var gc in constraints) {
 				WalkCustomAttributesTypesScopes (gc);
@@ -136,7 +136,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkTypeScope (Collection<ParameterDefinition> parameters)
+		private void WalkTypeScope (Collection<ParameterDefinition> parameters)
 		{
 			foreach (var p in parameters) {
 				WalkCustomAttributesTypesScopes (p);
@@ -145,13 +145,13 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkTypeScope (Collection<ExportedType> forwarders)
+		private void WalkTypeScope (Collection<ExportedType> forwarders)
 		{
 			foreach (var f in forwarders)
 				ProcessExportedType (f);
 		}
 
-		void WalkTypeScope (MethodBody body)
+		private void WalkTypeScope (MethodBody body)
 		{
 			if (body.HasVariables) {
 				foreach (var v in body.Variables) {
@@ -206,7 +206,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkMethodReference (MethodReference mr)
+		private void WalkMethodReference (MethodReference mr)
 		{
 			WalkScopeOfTypeReference (mr.ReturnType);
 			WalkScopeOfTypeReference (mr.DeclaringType);
@@ -221,13 +221,13 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkFieldReference (FieldReference fr)
+		private void WalkFieldReference (FieldReference fr)
 		{
 			WalkScopeOfTypeReference (fr.FieldType);
 			WalkScopeOfTypeReference (fr.DeclaringType);
 		}
 
-		void WalkMarshalInfoTypeScope (IMarshalInfoProvider provider)
+		private void WalkMarshalInfoTypeScope (IMarshalInfoProvider provider)
 		{
 			if (!provider.HasMarshalInfo)
 				return;
@@ -236,7 +236,7 @@ namespace Mono.Linker
 				WalkScopeOfTypeReference (cmi.ManagedType);
 		}
 
-		void WalkCustomAttributesTypesScopes (ICustomAttributeProvider customAttributeProvider)
+		private void WalkCustomAttributesTypesScopes (ICustomAttributeProvider customAttributeProvider)
 		{
 			if (!customAttributeProvider.HasCustomAttributes)
 				return;
@@ -245,7 +245,7 @@ namespace Mono.Linker
 				WalkForwardedTypesScope (ca);
 		}
 
-		void WalkSecurityAttributesTypesScopes (ISecurityDeclarationProvider securityAttributeProvider)
+		private void WalkSecurityAttributesTypesScopes (ISecurityDeclarationProvider securityAttributeProvider)
 		{
 			if (!securityAttributeProvider.HasSecurityDeclarations)
 				return;
@@ -259,7 +259,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkForwardedTypesScope (CustomAttribute attribute)
+		private void WalkForwardedTypesScope (CustomAttribute attribute)
 		{
 			WalkMethodReference (attribute.Constructor);
 
@@ -279,7 +279,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkForwardedTypesScope (SecurityAttribute attribute)
+		private void WalkForwardedTypesScope (SecurityAttribute attribute)
 		{
 			if (attribute.HasFields) {
 				foreach (var field in attribute.Fields)
@@ -292,7 +292,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkForwardedTypesScope (CustomAttributeArgument attributeArgument)
+		private void WalkForwardedTypesScope (CustomAttributeArgument attributeArgument)
 		{
 			WalkScopeOfTypeReference (attributeArgument.Type);
 
@@ -310,7 +310,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkScopeOfTypeReference (TypeReference type)
+		private void WalkScopeOfTypeReference (TypeReference type)
 		{
 			if (type == null)
 				return;

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -31,9 +31,9 @@ namespace Mono.Linker
 			}
 		}
 
-		readonly LinkContext _context;
-		readonly Dictionary<ICustomAttributeProvider, Dictionary<int, Suppression>> _suppressions;
-		HashSet<AssemblyDefinition> InitializedAssemblies { get; }
+		private readonly LinkContext _context;
+		private readonly Dictionary<ICustomAttributeProvider, Dictionary<int, Suppression>> _suppressions;
+		private HashSet<AssemblyDefinition> InitializedAssemblies { get; }
 
 		public UnconditionalSuppressMessageAttributeState (LinkContext context)
 		{
@@ -42,7 +42,7 @@ namespace Mono.Linker
 			InitializedAssemblies = new HashSet<AssemblyDefinition> ();
 		}
 
-		void AddSuppression (Suppression suppression)
+		private void AddSuppression (Suppression suppression)
 		{
 			var used = false;
 			if (!_suppressions.TryGetValue (suppression.Provider, out var suppressions)) {
@@ -102,7 +102,7 @@ namespace Mono.Linker
 			}
 		}
 
-		bool IsSuppressed (int id, ICustomAttributeProvider warningOrigin, out SuppressMessageInfo info)
+		private bool IsSuppressed (int id, ICustomAttributeProvider warningOrigin, out SuppressMessageInfo info)
 		{
 			info = default;
 
@@ -139,7 +139,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		bool IsSuppressedOnElement (int id, ICustomAttributeProvider? provider, out SuppressMessageInfo info)
+		private bool IsSuppressedOnElement (int id, ICustomAttributeProvider? provider, out SuppressMessageInfo info)
 		{
 			info = default;
 
@@ -154,7 +154,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		bool TryGetSuppressionsForProvider (ICustomAttributeProvider? provider, out Dictionary<int, Suppression>? suppressions)
+		private bool TryGetSuppressionsForProvider (ICustomAttributeProvider? provider, out Dictionary<int, Suppression>? suppressions)
 		{
 			suppressions = null;
 			if (provider == null)
@@ -194,7 +194,7 @@ namespace Mono.Linker
 			return _suppressions.TryGetValue (provider, out suppressions);
 		}
 
-		static bool TryDecodeSuppressMessageAttributeData (CustomAttribute attribute, out SuppressMessageInfo info)
+		private static bool TryDecodeSuppressMessageAttributeData (CustomAttribute attribute, out SuppressMessageInfo info)
 		{
 			info = default;
 
@@ -255,7 +255,7 @@ namespace Mono.Linker
 			}
 		}
 
-		IEnumerable<Suppression> DecodeSuppressions (ICustomAttributeProvider provider)
+		private IEnumerable<Suppression> DecodeSuppressions (ICustomAttributeProvider provider)
 		{
 			Debug.Assert (provider is not ModuleDefinition or AssemblyDefinition);
 
@@ -273,7 +273,7 @@ namespace Mono.Linker
 			}
 		}
 
-		IEnumerable<Suppression> DecodeAssemblyAndModuleSuppressions (ModuleDefinition module)
+		private IEnumerable<Suppression> DecodeAssemblyAndModuleSuppressions (ModuleDefinition module)
 		{
 			AssemblyDefinition assembly = module.Assembly;
 			foreach (var suppression in DecodeGlobalSuppressions (module, assembly))
@@ -285,7 +285,7 @@ namespace Mono.Linker
 			}
 		}
 
-		IEnumerable<Suppression> DecodeGlobalSuppressions (ModuleDefinition module, ICustomAttributeProvider provider)
+		private IEnumerable<Suppression> DecodeGlobalSuppressions (ModuleDefinition module, ICustomAttributeProvider provider)
 		{
 			var attributes = _context.CustomAttributes.GetCustomAttributes (provider).
 					Where (a => TypeRefHasUnconditionalSuppressions (a.AttributeType));
@@ -294,7 +294,7 @@ namespace Mono.Linker
 				if (!TryDecodeSuppressMessageAttributeData (instance, out info))
 					continue;
 
-				var scope = info.Scope?.ToLower ();
+				var scope = info.Scope?.ToLowerInvariant ();
 				if (info.Target == null && (scope == "module" || scope == null)) {
 					yield return new Suppression (info, originAttribute: instance, provider);
 					continue;
@@ -321,7 +321,7 @@ namespace Mono.Linker
 			}
 		}
 
-		static bool TypeRefHasUnconditionalSuppressions (TypeReference typeRef)
+		private static bool TypeRefHasUnconditionalSuppressions (TypeReference typeRef)
 		{
 			return typeRef.Name == "UnconditionalSuppressMessageAttribute" &&
 				typeRef.Namespace == "System.Diagnostics.CodeAnalysis";

--- a/src/linker/Linker/WarningSuppressionWriter.cs
+++ b/src/linker/Linker/WarningSuppressionWriter.cs
@@ -15,7 +15,7 @@ namespace Mono.Linker
 	{
 		private readonly Dictionary<AssemblyNameDefinition, HashSet<(int Code, IMemberDefinition Member)>> _warnings;
 		private readonly FileOutputKind _fileOutputKind;
-		readonly LinkContext _context;
+		private readonly LinkContext _context;
 
 		public WarningSuppressionWriter (LinkContext context, FileOutputKind fileOutputKind = FileOutputKind.CSharp)
 		{
@@ -56,7 +56,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void OutputSuppressionsXmlFormat (AssemblyNameDefinition assemblyName, string directory)
+		private void OutputSuppressionsXmlFormat (AssemblyNameDefinition assemblyName, string directory)
 		{
 			var xmlTree = new XElement ("linker");
 			var xmlAssembly = new XElement ("assembly", new XAttribute ("fullname", assemblyName.FullName));
@@ -81,7 +81,7 @@ namespace Mono.Linker
 			}
 		}
 
-		void OutputSuppressionsCSharpFormat (AssemblyNameDefinition assemblyName, string directory)
+		private void OutputSuppressionsCSharpFormat (AssemblyNameDefinition assemblyName, string directory)
 		{
 			using (var sw = new StreamWriter (Path.Combine (directory, $"{assemblyName.Name}.WarningSuppressions.cs"))) {
 				StringBuilder sb = new StringBuilder ("using System.Diagnostics.CodeAnalysis;").AppendLine ().AppendLine ();
@@ -98,7 +98,7 @@ namespace Mono.Linker
 			}
 		}
 
-		List<(int Code, string MemberDocumentationSignature)> GetListOfWarnings (AssemblyNameDefinition assemblyName)
+		private List<(int Code, string MemberDocumentationSignature)> GetListOfWarnings (AssemblyNameDefinition assemblyName)
 		{
 			List<(int Code, string MemberDocumentationSignature)> listOfWarnings = new List<(int Code, string MemberDocumentationSignature)> ();
 			StringBuilder sb = new StringBuilder ();
@@ -112,7 +112,7 @@ namespace Mono.Linker
 			return listOfWarnings;
 		}
 
-		static string GetWarningSuppressionScopeString (string memberDocumentationSignature)
+		private static string GetWarningSuppressionScopeString (string memberDocumentationSignature)
 		{
 			if (memberDocumentationSignature.StartsWith (DocumentationSignatureGenerator.TypePrefix))
 				return "type";

--- a/src/tlens/TLens.Analyzers/Analyzer.cs
+++ b/src/tlens/TLens.Analyzers/Analyzer.cs
@@ -6,7 +6,7 @@ using Mono.Cecil;
 
 namespace TLens.Analyzers
 {
-	abstract class Analyzer
+	internal abstract class Analyzer
 	{
 		protected virtual bool RequiredMethodBody => true;
 
@@ -19,7 +19,7 @@ namespace TLens.Analyzers
 
 		public abstract void PrintResults (int maxCount);
 
-		void WalkType (TypeDefinition type)
+		private void WalkType (TypeDefinition type)
 		{
 			foreach (var method in type.Methods) {
 				if (RequiredMethodBody && !method.HasBody)
@@ -55,4 +55,3 @@ namespace TLens.Analyzers
 		}
 	}
 }
-

--- a/src/tlens/TLens.Analyzers/DuplicatedCodeAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/DuplicatedCodeAnalyzer.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class DuplicatedCodeAnalyzer : Analyzer
+	internal sealed class DuplicatedCodeAnalyzer : Analyzer
 	{
-		readonly Dictionary<string, List<MethodDefinition>> strings = new Dictionary<string, List<MethodDefinition>> ();
+		private readonly Dictionary<string, List<MethodDefinition>> strings = new Dictionary<string, List<MethodDefinition>> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{

--- a/src/tlens/TLens.Analyzers/InterfaceDispatchAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/InterfaceDispatchAnalyzer.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace TLens.Analyzers
 {
-	sealed class InterfaceDispatchAnalyzer : InterfacesAnalyzer
+	internal sealed class InterfaceDispatchAnalyzer : InterfacesAnalyzer
 	{
 		public override void PrintResults (int maxCount)
 		{

--- a/src/tlens/TLens.Analyzers/InterfaceTypeCheckAnalyzers.cs
+++ b/src/tlens/TLens.Analyzers/InterfaceTypeCheckAnalyzers.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace TLens.Analyzers
 {
-	sealed class InterfaceTypeCheckAnalyzers : InterfacesAnalyzer
+	internal sealed class InterfaceTypeCheckAnalyzers : InterfacesAnalyzer
 	{
 		public override void PrintResults (int maxCount)
 		{

--- a/src/tlens/TLens.Analyzers/InterfacesAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/InterfacesAnalyzer.cs
@@ -7,7 +7,7 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	abstract class InterfacesAnalyzer : Analyzer
+	internal abstract class InterfacesAnalyzer : Analyzer
 	{
 		protected readonly Dictionary<TypeDefinition, List<TypeDefinition>> interfaces = new Dictionary<TypeDefinition, List<TypeDefinition>> ();
 		protected readonly Dictionary<TypeDefinition, HashSet<MethodDefinition>> usage = new Dictionary<TypeDefinition, HashSet<MethodDefinition>> ();

--- a/src/tlens/TLens.Analyzers/InverterCtorsChainAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/InverterCtorsChainAnalyzer.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class InverterCtorsChainAnalyzer : Analyzer
+	internal sealed class InverterCtorsChainAnalyzer : Analyzer
 	{
-		readonly List<(MethodDefinition, MethodDefinition)> ctors = new List<(MethodDefinition, MethodDefinition)> ();
+		private readonly List<(MethodDefinition, MethodDefinition)> ctors = new List<(MethodDefinition, MethodDefinition)> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{

--- a/src/tlens/TLens.Analyzers/LargeStaticArraysAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/LargeStaticArraysAnalyzer.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class LargeStaticArraysAnalyzer : Analyzer
+	internal sealed class LargeStaticArraysAnalyzer : Analyzer
 	{
-		readonly List<(int, MethodDefinition)> methods = new List<(int, MethodDefinition)> ();
+		private readonly List<(int, MethodDefinition)> methods = new List<(int, MethodDefinition)> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{

--- a/src/tlens/TLens.Analyzers/LargeStaticCtorAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/LargeStaticCtorAnalyzer.cs
@@ -8,9 +8,9 @@ using Mono.Cecil;
 
 namespace TLens.Analyzers
 {
-	sealed class LargeStaticCtorAnalyzer : Analyzer
+	internal sealed class LargeStaticCtorAnalyzer : Analyzer
 	{
-		readonly List<MethodDefinition> cctors = new List<MethodDefinition> ();
+		private readonly List<MethodDefinition> cctors = new List<MethodDefinition> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{

--- a/src/tlens/TLens.Analyzers/LargeStringsAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/LargeStringsAnalyzer.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class LargeStringsAnalyzer : Analyzer
+	internal sealed class LargeStringsAnalyzer : Analyzer
 	{
-		readonly List<(int, MethodDefinition)> ldstrs = new List<(int, MethodDefinition)> ();
+		private readonly List<(int, MethodDefinition)> ldstrs = new List<(int, MethodDefinition)> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{

--- a/src/tlens/TLens.Analyzers/LimitedMethodCalls.cs
+++ b/src/tlens/TLens.Analyzers/LimitedMethodCalls.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class LimitedMethodCalls : Analyzer
+	internal sealed class LimitedMethodCalls : Analyzer
 	{
-		readonly Dictionary<MethodDefinition, List<MethodDefinition>> methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
+		private readonly Dictionary<MethodDefinition, List<MethodDefinition>> methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{

--- a/src/tlens/TLens.Analyzers/RedundantFieldInitializationAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/RedundantFieldInitializationAnalyzer.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class RedundantFieldInitializationAnalyzer : Analyzer
+	internal sealed class RedundantFieldInitializationAnalyzer : Analyzer
 	{
-		readonly Dictionary<MethodDefinition, List<FieldDefinition>> ctors = new Dictionary<MethodDefinition, List<FieldDefinition>> ();
+		private readonly Dictionary<MethodDefinition, List<FieldDefinition>> ctors = new Dictionary<MethodDefinition, List<FieldDefinition>> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{
@@ -26,7 +26,7 @@ namespace TLens.Analyzers
 			}
 		}
 
-		void RedundantInitializationToDefaultValues (MethodDefinition ctor)
+		private void RedundantInitializationToDefaultValues (MethodDefinition ctor)
 		{
 			if (ctor.DeclaringType.IsValueType)
 				return;
@@ -93,12 +93,12 @@ namespace TLens.Analyzers
 			}
 		}
 
-		static bool IsDefaultNumeric (Instruction instruction)
+		private static bool IsDefaultNumeric (Instruction instruction)
 		{
 			return instruction.OpCode.Code == Code.Ldc_I4_0;
 		}
 
-		static bool IsLoadIntPtrOrUIntPtrZero (Instruction instruction)
+		private static bool IsLoadIntPtrOrUIntPtrZero (Instruction instruction)
 		{
 			if (instruction.OpCode.Code != Code.Ldsfld)
 				return false;

--- a/src/tlens/TLens.Analyzers/TypeInstatiationAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/TypeInstatiationAnalyzer.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class TypeInstatiationAnalyzer : Analyzer
+	internal sealed class TypeInstatiationAnalyzer : Analyzer
 	{
-		readonly Dictionary<TypeDefinition, List<MethodDefinition>> types = new Dictionary<TypeDefinition, List<MethodDefinition>> ();
+		private readonly Dictionary<TypeDefinition, List<MethodDefinition>> types = new Dictionary<TypeDefinition, List<MethodDefinition>> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{

--- a/src/tlens/TLens.Analyzers/UnnecessaryFieldsAssignmentAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/UnnecessaryFieldsAssignmentAnalyzer.cs
@@ -9,10 +9,10 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class UnnecessaryFieldsAssignmentAnalyzer : Analyzer
+	internal sealed class UnnecessaryFieldsAssignmentAnalyzer : Analyzer
 	{
 		[Flags]
-		enum Access
+		private enum Access
 		{
 			None = 0,
 			Read = 1 << 1,
@@ -20,8 +20,8 @@ namespace TLens.Analyzers
 			ValuePropagation = 1 << 3,
 		}
 
-		readonly Dictionary<FieldDefinition, Access> fields = new Dictionary<FieldDefinition, Access> ();
-		readonly Dictionary<FieldDefinition, List<MethodDefinition>> writes = new Dictionary<FieldDefinition, List<MethodDefinition>> ();
+		private readonly Dictionary<FieldDefinition, Access> fields = new Dictionary<FieldDefinition, Access> ();
+		private readonly Dictionary<FieldDefinition, List<MethodDefinition>> writes = new Dictionary<FieldDefinition, List<MethodDefinition>> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{
@@ -82,7 +82,7 @@ namespace TLens.Analyzers
 		public override void PrintResults (int maxCount)
 		{
 			var static_entries = fields.Where (l => l.Value == Access.Write && l.Key.IsStatic).
-				OrderBy (l => l.Key, new FieldTypeSizeComparer ()).
+				OrderBy (l => l.Key, default (FieldTypeSizeComparer)).
 				ThenBy (l => l.Key.DeclaringType.FullName).
 				Take (maxCount);
 			if (static_entries.Any ()) {
@@ -100,7 +100,7 @@ namespace TLens.Analyzers
 			}
 
 			var instance_entries = fields.Where (l => l.Value == Access.Write && !l.Key.IsStatic).
-				OrderBy (l => l.Key, new FieldTypeSizeComparer ()).
+				OrderBy (l => l.Key, default (FieldTypeSizeComparer)).
 				ThenBy (l => l.Key.DeclaringType.FullName).
 				Take (maxCount);
 			if (instance_entries.Any ()) {
@@ -118,7 +118,7 @@ namespace TLens.Analyzers
 			}
 		}
 
-		struct FieldTypeSizeComparer : IComparer<FieldDefinition>
+		private struct FieldTypeSizeComparer : IComparer<FieldDefinition>
 		{
 			public int Compare (FieldDefinition x, FieldDefinition y)
 			{
@@ -128,7 +128,7 @@ namespace TLens.Analyzers
 				return GetSize (y_type).CompareTo (GetSize (x_type));
 			}
 
-			static int GetSize (TypeReference type)
+			private static int GetSize (TypeReference type)
 			{
 				if (type.IsArray)
 					return 100;

--- a/src/tlens/TLens.Analyzers/UnusedParametersAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/UnusedParametersAnalyzer.cs
@@ -10,9 +10,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class UnusedParametersAnalyzer : Analyzer
+	internal sealed class UnusedParametersAnalyzer : Analyzer
 	{
-		readonly List<(MethodDefinition, int)> methods = new List<(MethodDefinition, int)> ();
+		private readonly List<(MethodDefinition, int)> methods = new List<(MethodDefinition, int)> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{

--- a/src/tlens/TLens.Analyzers/UserOperatorCalledForNullCheckAnalyzer.cs
+++ b/src/tlens/TLens.Analyzers/UserOperatorCalledForNullCheckAnalyzer.cs
@@ -9,9 +9,9 @@ using Mono.Cecil.Cil;
 
 namespace TLens.Analyzers
 {
-	sealed class UserOperatorCalledForNullCheckAnalyzer : Analyzer
+	internal sealed class UserOperatorCalledForNullCheckAnalyzer : Analyzer
 	{
-		sealed class Counters
+		private sealed class Counters
 		{
 			public int Total;
 			public int Redundant;
@@ -19,7 +19,7 @@ namespace TLens.Analyzers
 			public double Ratio => (double) Redundant / Total;
 		}
 
-		readonly Dictionary<MethodDefinition, Counters> operators = new Dictionary<MethodDefinition, Counters> ();
+		private readonly Dictionary<MethodDefinition, Counters> operators = new Dictionary<MethodDefinition, Counters> ();
 
 		protected override void ProcessMethod (MethodDefinition method)
 		{
@@ -62,7 +62,7 @@ namespace TLens.Analyzers
 			PrintHeader ("User operators used for null checks");
 
 			foreach (var e in entries) {
-				Console.WriteLine ($"User operator '{e.Key.ToDisplay ()}' was called {e.Value.Redundant} [{e.Value.Ratio.ToString ("0%")}] times with null values");
+				Console.WriteLine ($"User operator '{e.Key.ToDisplay ()}' was called {e.Value.Redundant} [{e.Value.Ratio:0%}] times with null values");
 			}
 		}
 	}

--- a/src/tlens/TLens/AssemlyReferenceResolver.cs
+++ b/src/tlens/TLens/AssemlyReferenceResolver.cs
@@ -8,10 +8,10 @@ using Mono.Cecil;
 
 namespace TLens
 {
-	sealed class AssemlyReferenceResolver : IAssemblyResolver
+	internal sealed class AssemlyReferenceResolver : IAssemblyResolver
 	{
-		readonly string[] additionalFolders;
-		readonly Dictionary<string, AssemblyDefinition> resolved = new ();
+		private readonly string[] additionalFolders;
+		private readonly Dictionary<string, AssemblyDefinition> resolved = new ();
 
 		public AssemlyReferenceResolver (string[] additionalFolders)
 		{

--- a/src/tlens/TLens/Driver.cs
+++ b/src/tlens/TLens/Driver.cs
@@ -11,9 +11,9 @@ using TLens.Analyzers;
 
 namespace TLens
 {
-	sealed class Driver
+	internal sealed class Driver
 	{
-		static int Main (string[] args)
+		private static int Main (string[] args)
 		{
 			bool showUsage = false;
 			bool error = false;
@@ -99,7 +99,7 @@ namespace TLens
 			return 0;
 		}
 
-		static void ShowUsage (OptionSet options)
+		private static void ShowUsage (OptionSet options)
 		{
 			Console.WriteLine ("Trimming Lens");
 			Console.WriteLine ("  tlens [options] input-files");
@@ -115,7 +115,7 @@ namespace TLens
 			}
 		}
 
-		static List<AssemblyDefinition> LoadFiles (List<string> files, AssemlyReferenceResolver resolver)
+		private static List<AssemblyDefinition> LoadFiles (List<string> files, AssemlyReferenceResolver resolver)
 		{
 			var assemblies = new List<AssemblyDefinition> ();
 			foreach (var file in files) {

--- a/src/tlens/TLens/LensesCollection.cs
+++ b/src/tlens/TLens/LensesCollection.cs
@@ -8,7 +8,7 @@ using TLens.Analyzers;
 
 namespace TLens
 {
-	static class LensesCollection
+	internal static class LensesCollection
 	{
 		public sealed class LensAnalyzerDetails
 		{
@@ -37,7 +37,7 @@ namespace TLens
 		// Most used/unused attributes
 		// Constants passed as arguments
 		//
-		static readonly LensAnalyzerDetails[] all = new[] {
+		private static readonly LensAnalyzerDetails[] all = new[] {
 			new LensAnalyzerDetails ("duplicated-code",
 				"Methods which are possible duplicates", typeof (DuplicatedCodeAnalyzer)),
 			new LensAnalyzerDetails ("fields-init",

--- a/src/tlens/TLens/MethodDefinitionExtensions.cs
+++ b/src/tlens/TLens/MethodDefinitionExtensions.cs
@@ -6,7 +6,7 @@ using Mono.Cecil;
 
 namespace TLens
 {
-	static class MethodDefinitionExtensions
+	internal static class MethodDefinitionExtensions
 	{
 		public static string ToDisplay (this MethodDefinition method, bool showSize = false)
 		{
@@ -17,7 +17,7 @@ namespace TLens
 			if (showSize) {
 				str.Append (" [size: ");
 				str.Append (method.GetEstimatedSize ());
-				str.Append ("]");
+				str.Append (']');
 			}
 
 			return str.ToString ();

--- a/src/tlens/TLens/Runner.cs
+++ b/src/tlens/TLens/Runner.cs
@@ -8,9 +8,9 @@ using TLens.Analyzers;
 
 namespace TLens
 {
-	sealed class Runner
+	internal sealed class Runner
 	{
-		readonly List<Analyzer> analyzers = new List<Analyzer> ();
+		private readonly List<Analyzer> analyzers = new List<Analyzer> ();
 
 		public void AddAnalyzer (Analyzer analyzer)
 		{

--- a/src/tlens/TLens/SizeStatistics.cs
+++ b/src/tlens/TLens/SizeStatistics.cs
@@ -6,7 +6,7 @@ using Mono.Cecil;
 
 namespace TLens
 {
-	static class SizeStatistics
+	internal static class SizeStatistics
 	{
 		public static int GetEstimatedSize (this TypeDefinition type)
 		{


### PR DESCRIPTION
Add current runtime analyzer settings to linker .editorconfig and eng/Analyzers.props
Fix code style warnings

*Notes:* 
- This basically breaks the baroque coding guidelines from mono (https://www.mono-project.com/community/contributing/coding-guidelines/#baroque-coding) although the repo is no longer in the mono domain several of the guidelines are still applied
- This PR can cause merge conflicts for those working in the linker repo after merging

Fixes https://github.com/dotnet/linker/issues/3018

Adding as a draft to discuss if this is the right thing we want for linker repo