### PR TITLE
Fix lint command

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
     <MicrosoftDotNetApiCompatVersion>7.0.0-beta.22426.8</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21271.1</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
-    <MicrosoftCodeAnalysisVersion>4.4.0-2.22379.3</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>4.4.0-1.final</MicrosoftCodeAnalysisVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftCodeAnalysisVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.*</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -145,9 +145,7 @@ stages:
       steps:
       - checkout: self
         submodules: true
-      # Disabled to prevent dotnet-format bugs (see https://github.com/dotnet/linker/pull/2884).
-      # This should be turned back on when we are on a preview7 SDK.
-      # - script: ./lint.sh --verify-no-changes --verbosity diagnostic
+      - script: ./lint.sh --verify-no-changes --verbosity diagnostic
 
 # Post-Build Arcade logic
 - ${{ if eq(variables.officialBuild, 'true') }}:

--- a/src/ILLink.CodeFix/RequiresAssemblyFilesCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresAssemblyFilesCodeFixProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -33,7 +32,7 @@ namespace ILLink.CodeFix
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 
-		protected override SyntaxNode[] GetAttributeArguments (ISymbol? attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic) => 
-			RequiresHelpers.GetAttributeArgumentsForRequires (targetSymbol, syntaxGenerator, HasPublicAccessibility(attributableSymbol));
+		protected override SyntaxNode[] GetAttributeArguments (ISymbol? attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic) =>
+			RequiresHelpers.GetAttributeArgumentsForRequires (targetSymbol, syntaxGenerator, HasPublicAccessibility (attributableSymbol));
 	}
 }

--- a/src/ILLink.CodeFix/RequiresDynamicCodeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresDynamicCodeCodeFixProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;

--- a/src/ILLink.CodeFix/RequiresHelpers.cs
+++ b/src/ILLink.CodeFix/RequiresHelpers.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis;
 using ILLink.RoslynAnalyzer;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editing;
 
 namespace ILLink.CodeFixProvider
 {

--- a/src/ILLink.CodeFix/RequiresUnreferencedCodeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresUnreferencedCodeCodeFixProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;

--- a/src/ILLink.RoslynAnalyzer/CompilationExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/CompilationExtensions.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Immutable;
-using System;
 
 namespace ILLink.RoslynAnalyzer
 {
@@ -73,7 +73,7 @@ namespace ILLink.RoslynAnalyzer
 
 			return type;
 		}
-		
+
 		// copied from https://github.com/dotnet/roslyn/blob/main/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
 		private static SymbolVisibility GetResultantVisibility (this ISymbol symbol)
 		{

--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -423,9 +423,7 @@ namespace ILLink.Tasks
 				members = featureSwitchMembers[featureSwitch.Value][className];
 			}
 
-			if (members.fields == null) {
-				members.fields = new HashSet<string> ();
-			}
+			members.fields ??= new HashSet<string> ();
 			members.fields.Add (fieldName);
 		}
 
@@ -446,9 +444,7 @@ namespace ILLink.Tasks
 				members = featureSwitchMembers[featureSwitch.Value][fullClassName];
 			}
 
-			if (members.methods == null) {
-				members.methods = new HashSet<string> ();
-			}
+			members.methods ??= new HashSet<string> ();
 			members.methods.Add (methodName);
 		}
 

--- a/src/analyzer/LinkerAnalyzerCore/DependencyGraph.cs
+++ b/src/analyzer/LinkerAnalyzerCore/DependencyGraph.cs
@@ -70,8 +70,7 @@ namespace LinkerAnalyzer.Core
 								VertexData begin = Vertex (b, true);
 								VertexData end = Vertex (e, true);
 
-								if (end.parentIndexes == null)
-									end.parentIndexes = new List<int> ();
+								end.parentIndexes ??= new List<int> ();
 								if (!end.parentIndexes.Contains (begin.index)) {
 									end.parentIndexes.Add (begin.index);
 									//Console.WriteLine (" end parent index: {0}", end.parentIndexes);

--- a/src/linker/Linker.Dataflow/AttributeDataFlow.cs
+++ b/src/linker/Linker.Dataflow/AttributeDataFlow.cs
@@ -28,7 +28,7 @@ namespace Mono.Linker.Dataflow
 		public void ProcessAttributeDataflow (MethodDefinition method, IList<CustomAttributeArgument> arguments)
 		{
 			for (int i = 0; i < method.Parameters.Count; i++) {
-				var parameterValue = _context.Annotations.FlowAnnotations.GetMethodParameterValue (method, (SourceParameterIndex)i);
+				var parameterValue = _context.Annotations.FlowAnnotations.GetMethodParameterValue (method, (SourceParameterIndex) i);
 				if (parameterValue.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None) {
 					MultiValue value = GetValueForCustomAttributeArgument (arguments[i]);
 					var diagnosticContext = new DiagnosticContext (_origin, diagnosticsEnabled: true, _context);

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -276,9 +276,7 @@ namespace ILLink.Shared.TrimAnalysis
 							continue;
 						}
 
-						if (paramAnnotations == null) {
-							paramAnnotations = new DynamicallyAccessedMemberTypes[method.Parameters.Count + offset];
-						}
+						paramAnnotations ??= new DynamicallyAccessedMemberTypes[method.Parameters.Count + offset];
 						paramAnnotations[i + offset] = pa;
 					}
 
@@ -293,8 +291,7 @@ namespace ILLink.Shared.TrimAnalysis
 							var genericParameter = method.GenericParameters[genericParameterIndex];
 							var annotation = GetMemberTypesForDynamicallyAccessedMembersAttribute (method, providerIfNotMember: genericParameter);
 							if (annotation != DynamicallyAccessedMemberTypes.None) {
-								if (genericParameterAnnotations == null)
-									genericParameterAnnotations = new DynamicallyAccessedMemberTypes[method.GenericParameters.Count];
+								genericParameterAnnotations ??= new DynamicallyAccessedMemberTypes[method.GenericParameters.Count];
 								genericParameterAnnotations[genericParameterIndex] = annotation;
 							}
 						}
@@ -406,8 +403,7 @@ namespace ILLink.Shared.TrimAnalysis
 					var provider = attrs?[genericParameterIndex] ?? type.GenericParameters[genericParameterIndex];
 					var annotation = GetMemberTypesForDynamicallyAccessedMembersAttribute (type, providerIfNotMember: provider);
 					if (annotation != DynamicallyAccessedMemberTypes.None) {
-						if (typeGenericParameterAnnotations == null)
-							typeGenericParameterAnnotations = new DynamicallyAccessedMemberTypes[type.GenericParameters.Count];
+						typeGenericParameterAnnotations ??= new DynamicallyAccessedMemberTypes[type.GenericParameters.Count];
 						typeGenericParameterAnnotations[genericParameterIndex] = annotation;
 					}
 				}

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -12,11 +12,11 @@ using ILLink.Shared.TypeSystemProxy;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;
+using static Mono.Linker.ParameterHelpers;
 using LocalVariableStore = System.Collections.Generic.Dictionary<
 	Mono.Cecil.Cil.VariableDefinition,
 	Mono.Linker.Dataflow.ValueBasicBlockPair>;
 using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
-using static Mono.Linker.ParameterHelpers;
 
 namespace Mono.Linker.Dataflow
 {
@@ -301,9 +301,7 @@ namespace Mono.Linker.Dataflow
 					}
 				}
 
-				if (currentStack == null) {
-					currentStack = new Stack<StackSlot> (methodBody.MaxStackSize);
-				}
+				currentStack ??= new Stack<StackSlot> (methodBody.MaxStackSize);
 
 				switch (operation.OpCode.Code) {
 				case Code.Add:
@@ -1097,7 +1095,7 @@ namespace Mono.Linker.Dataflow
 
 				if (calledMethod.ParameterReferenceKind ((int) ilArgumentIndex) is not (ReferenceKind.Ref or ReferenceKind.Out))
 					continue;
-				SingleValue newByRefValue = methodIsResolved && (int)parameterIndex < calledMethodDefinition!.Parameters.Count
+				SingleValue newByRefValue = methodIsResolved && (int) parameterIndex < calledMethodDefinition!.Parameters.Count
 					? _context.Annotations.FlowAnnotations.GetMethodParameterValue (calledMethodDefinition!, parameterIndex)
 					: UnknownValue.Instance;
 				StoreInReference (methodArguments[(int) ilArgumentIndex], newByRefValue, callingMethodBody.Method, operation, locals, curBasicBlock, ref ipState);

--- a/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
+++ b/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
@@ -24,8 +24,7 @@ namespace Mono.Linker.Steps
 
 		Dictionary<TypeDefinition, List<MethodDefinition>> PendingOperatorsForType {
 			get {
-				if (_pendingOperatorsForType == null)
-					_pendingOperatorsForType = new Dictionary<TypeDefinition, List<MethodDefinition>> ();
+				_pendingOperatorsForType ??= new Dictionary<TypeDefinition, List<MethodDefinition>> ();
 				return _pendingOperatorsForType;
 			}
 		}
@@ -119,8 +118,7 @@ namespace Mono.Linker.Steps
 		TypeDefinition? _nullableOfT;
 		TypeDefinition? NullableOfT {
 			get {
-				if (_nullableOfT == null)
-					_nullableOfT = BCL.FindPredefinedType (WellKnownType.System_Nullable_T, Context);
+				_nullableOfT ??= BCL.FindPredefinedType (WellKnownType.System_Nullable_T, Context);
 				return _nullableOfT;
 			}
 		}

--- a/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -319,8 +319,7 @@ namespace Mono.Linker.Steps
 				if (!IsConstantValue (instr))
 					return null;
 
-				if (result == null)
-					result = new Instruction[method.Parameters.Count];
+				result ??= new Instruction[method.Parameters.Count];
 
 				result[pos] = instr;
 			}
@@ -578,8 +577,7 @@ namespace Mono.Linker.Steps
 
 			void RewriteConditionToNop (int index)
 			{
-				if (conditionInstrsToRemove == null)
-					conditionInstrsToRemove = new List<int> ();
+				conditionInstrsToRemove ??= new List<int> ();
 
 				conditionInstrsToRemove.Add (index);
 				RewriteToNop (index);
@@ -755,8 +753,7 @@ namespace Mono.Linker.Steps
 						Instruction[]? args = GetArgumentsOnStack (md, FoldedInstructions ?? instructions, i);
 						targetResult = args?.Length > 0 && md.IsStatic ? EvaluateIntrinsicCall (md, args) : null;
 
-						if (targetResult == null)
-							targetResult = optimizer.TryGetMethodCallResult (new CalleePayload (md, args))?.Instruction;
+						targetResult ??= optimizer.TryGetMethodCallResult (new CalleePayload (md, args))?.Instruction;
 
 						if (targetResult == null)
 							break;
@@ -1007,8 +1004,7 @@ namespace Mono.Linker.Steps
 							continue;
 
 						case FlowControl.Cond_Branch:
-							if (condBranches == null)
-								condBranches = new Stack<int> ();
+							condBranches ??= new Stack<int> ();
 
 							switch (instr.Operand) {
 							case Instruction starget:
@@ -1052,15 +1048,13 @@ namespace Mono.Linker.Steps
 							int end = instrs.IndexOf (handler.TryEnd) - 1;
 
 							if (!HasAnyBitSet (reachable, start, end)) {
-								if (unreachableHandlers == null)
-									unreachableHandlers = new List<ExceptionHandler> ();
+								unreachableHandlers ??= new List<ExceptionHandler> ();
 
 								unreachableHandlers.Add (handler);
 								continue;
 							}
 
-							if (condBranches == null)
-								condBranches = new Stack<int> ();
+							condBranches ??= new Stack<int> ();
 
 							condBranches.Push (GetInstructionIndex (handler.HandlerStart));
 							if (handler.FilterStart != null)
@@ -1240,8 +1234,7 @@ namespace Mono.Linker.Steps
 
 					VariableDefinition? variable = GetVariableReference (instr);
 					if (variable != null) {
-						if (removedVariablesReferences == null)
-							removedVariablesReferences = new List<VariableDefinition> ();
+						removedVariablesReferences ??= new List<VariableDefinition> ();
 						if (!removedVariablesReferences.Contains (variable))
 							removedVariablesReferences.Add (variable);
 					}
@@ -1273,8 +1266,7 @@ namespace Mono.Linker.Steps
 							if (index > 0 && IsSideEffectFreeLoad (instrs[index - 1])) {
 								var nop = Instruction.Create (OpCodes.Nop);
 
-								if (sentinelNops == null)
-									sentinelNops = new List<Instruction> ();
+								sentinelNops ??= new List<Instruction> ();
 								sentinelNops.Add (nop);
 
 								ILProcessor.Replace (index - 1, Instruction.Create (OpCodes.Pop));
@@ -1902,16 +1894,14 @@ namespace Mono.Linker.Steps
 
 			void PushOnStack (Instruction instruction)
 			{
-				if (stack_instr == null)
-					stack_instr = new Stack<Instruction> ();
+				stack_instr ??= new Stack<Instruction> ();
 
 				stack_instr.Push (instruction);
 			}
 
 			void StoreToLocals (int index)
 			{
-				if (locals == null)
-					locals = new Dictionary<int, Instruction> ();
+				locals ??= new Dictionary<int, Instruction> ();
 
 				if (stack_instr == null)
 					Debug.Fail ("Invalid IL?");

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -100,12 +100,10 @@ namespace Mono.Linker
 			// Any full path explicit reference takes precedence over other look up logic
 			asm = ResolveFromReferences (name);
 
-			if (asm == null)
-				asm = SearchDirectory (name);
+			asm ??= SearchDirectory (name);
 
 			if (asm == null) {
-				if (_unresolvedAssemblies == null)
-					_unresolvedAssemblies = new HashSet<string> ();
+				_unresolvedAssemblies ??= new HashSet<string> ();
 
 				if (!probing)
 					ReportUnresolvedAssembly (name);
@@ -120,8 +118,7 @@ namespace Mono.Linker
 
 		void ReportUnresolvedAssembly (AssemblyNameReference reference)
 		{
-			if (_reportedUnresolvedAssemblies == null)
-				_reportedUnresolvedAssemblies = new HashSet<string> ();
+			_reportedUnresolvedAssemblies ??= new HashSet<string> ();
 
 			if (!_reportedUnresolvedAssemblies.Add (reference.Name))
 				return;

--- a/src/linker/Linker/DgmlDependencyRecorder.cs
+++ b/src/linker/Linker/DgmlDependencyRecorder.cs
@@ -31,8 +31,7 @@ namespace Mono.Linker
 				IndentChars = " "
 			};
 
-			if (fileName == null)
-				fileName = DefaultDependenciesFileName;
+			fileName ??= DefaultDependenciesFileName;
 
 			if (string.IsNullOrEmpty (Path.GetDirectoryName (fileName)) && !string.IsNullOrEmpty (context.OutputDirectory)) {
 				fileName = Path.Combine (context.OutputDirectory, fileName);

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -69,8 +69,7 @@ namespace Mono.Linker
 				if (attributeValue == null)
 					continue;
 
-				if (cache == null)
-					cache = new List<(Type Type, List<Attribute> Attributes)> ();
+				cache ??= new List<(Type Type, List<Attribute> Attributes)> ();
 
 				Type attributeValueType = attributeValue.GetType ();
 

--- a/src/linker/Linker/ParameterHelpers.cs
+++ b/src/linker/Linker/ParameterHelpers.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using ILLink.Shared;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using ILLink.Shared;
 
 namespace Mono.Linker
 {

--- a/src/linker/Linker/SerializationMarker.cs
+++ b/src/linker/Linker/SerializationMarker.cs
@@ -58,8 +58,7 @@ namespace Mono.Linker
 		Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>>? _trackedRoots;
 		Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>> TrackedRoots {
 			get {
-				if (_trackedRoots == null)
-					_trackedRoots = new Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>> ();
+				_trackedRoots ??= new Dictionary<SerializerKind, HashSet<ICustomAttributeProvider>> ();
 
 				return _trackedRoots;
 			}
@@ -68,8 +67,7 @@ namespace Mono.Linker
 		HashSet<TypeDefinition>? _recursiveTypes;
 		HashSet<TypeDefinition> RecursiveTypes {
 			get {
-				if (_recursiveTypes == null)
-					_recursiveTypes = new HashSet<TypeDefinition> ();
+				_recursiveTypes ??= new HashSet<TypeDefinition> ();
 
 				return _recursiveTypes;
 			}

--- a/src/linker/Linker/Tracer.cs
+++ b/src/linker/Linker/Tracer.cs
@@ -61,9 +61,7 @@ namespace Mono.Linker
 
 		public void AddRecorder (IDependencyRecorder recorder)
 		{
-			if (recorders == null) {
-				recorders = new List<IDependencyRecorder> ();
-			}
+			recorders ??= new List<IDependencyRecorder> ();
 
 			recorders.Add (recorder);
 		}

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -54,8 +54,7 @@ namespace Mono.Linker
 				IndentChars = "\t"
 			};
 
-			if (fileName == null)
-				fileName = DefaultDependenciesFileName;
+			fileName ??= DefaultDependenciesFileName;
 
 			if (string.IsNullOrEmpty (Path.GetDirectoryName (fileName)) && !string.IsNullOrEmpty (context.OutputDirectory)) {
 				fileName = Path.Combine (context.OutputDirectory, fileName);

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
@@ -420,7 +420,7 @@ build_property.{MSBuildPropertyOptionNames.EnableSingleFileAnalyzer} = true")));
 			return VerifyRequiresAssemblyFilesCodeFix (
 				source: test,
 				fixedSource: fixtest,
-				baselineExpected:new[] {
+				baselineExpected: new[] {
 					// /0/Test0.cs(6,14): warning IL3002: Using member 'C.M1()' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app. message.
 					VerifyCS.Diagnostic(DiagnosticId.RequiresAssemblyFiles).WithSpan(6, 14, 6, 18).WithArguments("C.M1()", " message.", ""),
 					// /0/Test0.cs(10,24): warning IL3002: Using member 'C.M1()' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app. message.

--- a/test/ILLink.RoslynAnalyzer.Tests/UnconditionalSuppressMessageCodeFixTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/UnconditionalSuppressMessageCodeFixTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using ILLink.Shared;
-using Microsoft;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;

--- a/test/Mono.Linker.Tests.Cases/Attributes/GenericAttributes.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/GenericAttributes.cs
@@ -6,64 +6,71 @@ namespace Mono.Linker.Tests.Cases.Attributes
 {
 	class GenericAttributes
 	{
-        static void Main ()
-        {
-            new WithGenericAttribute_OfString ();
-            new WithGenericAttribute_OfInt ();
-            new WithConstrainedGenericAttribute ();
-        }
+		static void Main ()
+		{
+			new WithGenericAttribute_OfString ();
+			new WithGenericAttribute_OfInt ();
+			new WithConstrainedGenericAttribute ();
+		}
 
-        [Kept]
-        [KeptAttributeAttribute (typeof (GenericAttribute<string>))]
-        [KeptMember (".ctor()")]
-        [GenericAttribute<string>("t", F = "f", P = "p")]
-        class WithGenericAttribute_OfString {
-        }
+		[Kept]
+		[KeptAttributeAttribute (typeof (GenericAttribute<string>))]
+		[KeptMember (".ctor()")]
+		[GenericAttribute<string> ("t", F = "f", P = "p")]
+		class WithGenericAttribute_OfString
+		{
+		}
 
-        [Kept]
-        [KeptAttributeAttribute (typeof (GenericAttribute<int>))]
-        [KeptMember (".ctor()")]
-        [GenericAttribute<int>(1, F = 2, P = 3)]
-        class WithGenericAttribute_OfInt {
-        }
+		[Kept]
+		[KeptAttributeAttribute (typeof (GenericAttribute<int>))]
+		[KeptMember (".ctor()")]
+		[GenericAttribute<int> (1, F = 2, P = 3)]
+		class WithGenericAttribute_OfInt
+		{
+		}
 
-        [Kept]
-        [KeptAttributeAttribute (typeof (ConstrainedGenericAttribute<DerivedFromConstraintType>))]
-        [KeptMember (".ctor()")]
-        [ConstrainedGenericAttribute<DerivedFromConstraintType>()]
-        class WithConstrainedGenericAttribute {
-        }
+		[Kept]
+		[KeptAttributeAttribute (typeof (ConstrainedGenericAttribute<DerivedFromConstraintType>))]
+		[KeptMember (".ctor()")]
+		[ConstrainedGenericAttribute<DerivedFromConstraintType> ()]
+		class WithConstrainedGenericAttribute
+		{
+		}
 
-        [KeptBaseType (typeof (Attribute))]
-        class GenericAttribute<T> : Attribute {
-            [Kept]
-            public GenericAttribute(T t) {}
+		[KeptBaseType (typeof (Attribute))]
+		class GenericAttribute<T> : Attribute
+		{
+			[Kept]
+			public GenericAttribute (T t) { }
 
-            [Kept]
-            public T F;
+			[Kept]
+			public T F;
 
-            [Kept]
-            [KeptBackingField]
-            public T P {
-                get;
-                [Kept]
-                set;
-            }
-        }
+			[Kept]
+			[KeptBackingField]
+			public T P {
+				get;
+				[Kept]
+				set;
+			}
+		}
 
-        [Kept]
-        class ConstraintType {
-        }
+		[Kept]
+		class ConstraintType
+		{
+		}
 
-        [KeptBaseType (typeof (ConstraintType))]
-        class DerivedFromConstraintType : ConstraintType {
-        }
+		[KeptBaseType (typeof (ConstraintType))]
+		class DerivedFromConstraintType : ConstraintType
+		{
+		}
 
-        [KeptBaseType (typeof (Attribute))]
-        class ConstrainedGenericAttribute<T> : Attribute
-            where T : ConstraintType {
-            [Kept]
-            public ConstrainedGenericAttribute() {}
-        }
-    }
+		[KeptBaseType (typeof (Attribute))]
+		class ConstrainedGenericAttribute<T> : Attribute
+			where T : ConstraintType
+		{
+			[Kept]
+			public ConstrainedGenericAttribute () { }
+		}
+	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -241,7 +241,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		static void TestVarargsMethod ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type, __arglist)
 		{
- 		}
+		}
 
 		class WriteCapturedParameter
 		{

--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -249,8 +249,7 @@ namespace Mono.Linker.Tests.TestCases
 
 		static IEnumerable<TestCase> AllCases ()
 		{
-			if (_cachedAllCases == null)
-				_cachedAllCases = CreateCollector ()
+			_cachedAllCases ??= CreateCollector ()
 					.Collect ()
 					.OrderBy (c => c.DisplayName)
 					.ToArray ();


### PR DESCRIPTION
Use new version of MicrosoftCodeAnalysisVersion in linker (Copy from runtime) to fix the dotnet format (lint.cmd|sh) command
Run the dotnet format command on the repo