### PR TITLE
Better warning message for DynamicDependency problem

### DIFF
--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -613,7 +613,7 @@
     <value>The member signature or DynamicallyAccessedMemberTypes in a DynamicDependencyAttribute constructor did not resolve to any members on the type.</value>
   </data>
   <data name="NoMembersResolvedForMemberSignatureOrTypeMessage" xml:space="preserve">
-    <value>No members were resolved for '{0}'.</value>
+    <value>No members were resolved for '{0}' on type '{1}'.</value>
   </data>
   <data name="XmlMissingNameAttributeInResourceTitle" xml:space="preserve">
     <value>The resource element in a substitution file did not have a 'name' attribute.</value>

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -947,14 +947,14 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.MemberSignature is string memberSignature) {
 				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature, Context, acceptName: true);
 				if (!members.Any ()) {
-					Context.LogWarning (ScopeStack.CurrentScope.Origin, DiagnosticId.NoMembersResolvedForMemberSignatureOrType, memberSignature);
+					Context.LogWarning (ScopeStack.CurrentScope.Origin, DiagnosticId.NoMembersResolvedForMemberSignatureOrType, memberSignature, type.GetDisplayName ());
 					return;
 				}
 			} else {
 				var memberTypes = dynamicDependency.MemberTypes;
 				members = type.GetDynamicallyAccessedMembers (Context, memberTypes);
 				if (!members.Any ()) {
-					Context.LogWarning (ScopeStack.CurrentScope.Origin, DiagnosticId.NoMembersResolvedForMemberSignatureOrType, memberTypes.ToString ());
+					Context.LogWarning (ScopeStack.CurrentScope.Origin, DiagnosticId.NoMembersResolvedForMemberSignatureOrType, memberTypes.ToString (), type.GetDisplayName ());
 					return;
 				}
 			}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberSignatureWildcard.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberSignatureWildcard.cs
@@ -6,7 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/DynamicDependencyMethodInAssemblyLibrary.cs" })]
-	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMemberSignatureWildcard.Dependency(): No members were resolved for '*'.")]
+	[ExpectedNoWarnings]
 	public class DynamicDependencyMemberSignatureWildcard
 	{
 		public static void Main ()
@@ -15,6 +15,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		}
 
 		[Kept]
+		[ExpectedWarning ("IL2037", "'*'", "'Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInAssemblyLibrary'")]
 		[DynamicDependency ("*", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInAssemblyLibrary", "library")]
 		static void Dependency ()
 		{

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
@@ -58,19 +58,19 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 
 			[Kept]
 
-			[ExpectedWarning ("IL2037", "MissingMethod")]
+			[ExpectedWarning ("IL2037", "MissingMethod", "'Mono.Linker.Tests.Cases.DynamicDependencies.C'")]
 			[DynamicDependency ("MissingMethod", typeof (C))]
 
-			[ExpectedWarning ("IL2037", "Dependency2``1(``0,System.Int32,System.Object)")]
+			[ExpectedWarning ("IL2037", "Dependency2``1(``0,System.Int32,System.Object)", "'Mono.Linker.Tests.Cases.DynamicDependencies.C'")]
 			[DynamicDependency ("Dependency2``1(``0,System.Int32,System.Object)", typeof (C))]
 
-			[ExpectedWarning ("IL2037", "''")]
+			[ExpectedWarning ("IL2037", "''", "'Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.B'")]
 			[DynamicDependency ("")]
 
-			[ExpectedWarning ("IL2037", "#ctor()")]
+			[ExpectedWarning ("IL2037", "#ctor()", "'Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.NestedStruct'")]
 			[DynamicDependency ("#ctor()", typeof (NestedStruct))]
 
-			[ExpectedWarning ("IL2037", "#cctor()")]
+			[ExpectedWarning ("IL2037", "#cctor()", "'Mono.Linker.Tests.Cases.DynamicDependencies.C'")]
 			[DynamicDependency ("#cctor()", typeof (C))]
 
 			[ExpectedWarning ("IL2036", "NonExistentType")]


### PR DESCRIPTION
Include both the member name being looked up, as well as the type the lookup is done on.

Fixes: https://github.com/dotnet/linker/issues/1601