### PR TITLE
Cleanup tests for cases which use different warnings codes that the test mentions

### DIFF
--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
@@ -16,13 +16,17 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 	[ExpectedWarning ("IL2030", "MalformedAssemblyName, thisiswrong", FileName = "LinkAttributeErrorCases.xml", SourceLine = 7, SourceColumn = 8)]
 	[ExpectedWarning ("IL2031", "NonExistentAttribute", FileName = "LinkAttributeErrorCases.xml", SourceLine = 10, SourceColumn = 8)]
 	[ExpectedWarning ("IL2022", "AttributeWithNoParametersAttribute", FileName = "LinkAttributeErrorCases.xml", SourceLine = 13, SourceColumn = 8)]
+	[ExpectedWarning ("IL2022", "AttributeWithEnumParameterAttribute", FileName = "LinkAttributeErrorCases.xml", SourceLine = 18, SourceColumn = 8)]
+	[ExpectedWarning ("IL2022", "AttributeWithIntParameterAttribute", FileName = "LinkAttributeErrorCases.xml", SourceLine = 23, SourceColumn = 8)]
 	[ExpectedWarning ("IL2023", "GetTypeMethod", FileName = "LinkAttributeErrorCases.xml", SourceLine = 47, SourceColumn = 10)]
 	[ExpectedWarning ("IL2024", "methodParameter", "MethodWithParameter", FileName = "LinkAttributeErrorCases.xml", SourceLine = 57, SourceColumn = 10)]
 	[ExpectedWarning ("IL2029", FileName = "LinkAttributeErrorCases.xml", SourceLine = 64, SourceColumn = 6)]
+	[ExpectedWarning ("IL2029", FileName = "LinkAttributeErrorCases.xml", SourceLine = 65, SourceColumn = 6)]
 	[ExpectedWarning ("IL2051", FileName = "LinkAttributeErrorCases.xml", SourceLine = 29, SourceColumn = 10)]
 	[ExpectedWarning ("IL2052", "NonExistentPropertyName", FileName = "LinkAttributeErrorCases.xml", SourceLine = 34, SourceColumn = 10)]
 	[ExpectedWarning ("IL2100", FileName = "ILLink.LinkAttributes.xml", SourceLine = 3, SourceColumn = 4)]
 	[ExpectedWarning ("IL2101", "library", "test", FileName = "ILLink.LinkAttributes.xml", SourceLine = 5, SourceColumn = 4)]
+	[ExpectedNoWarnings]
 	class LinkAttributeErrorCases
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.xml
@@ -14,12 +14,12 @@
         <argument>ExtraArgumentValue</argument>
       </attribute>
 
-      <!-- IL2054 -->
+      <!-- IL2022 -->
       <attribute fullname="Mono.Linker.Tests.Cases.LinkAttributes.LinkAttributeErrorCases/AttributeWithEnumParameterAttribute">
         <argument>NonExistentEnumValue</argument>
       </attribute>
 
-      <!-- IL2054 -->
+      <!-- IL2022 -->
       <attribute fullname="Mono.Linker.Tests.Cases.LinkAttributes.LinkAttributeErrorCases/AttributeWithIntParameterAttribute">
         <argument>NotANumber</argument>
       </attribute>

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
@@ -54,12 +54,13 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 	// [RemovedAttributeInAssembly ("LinkerAttributeRemovalEmbeddedAndLazyLoad.dll", typeof (EmbeddedAttributeToBeRemoved), typeof (TypeWithEmbeddedAttributeToBeRemoved))]
 	[KeptAttributeInAssembly ("LinkerAttributeRemovalEmbeddedAndLazyLoad", typeof (EmbeddedAttributeToBeRemoved), typeof (TypeWithEmbeddedAttributeToBeRemoved))]
 
-	[LogContains ("IL2045: Mono.Linker.Tests.Cases.LinkAttributes.LinkerAttributeRemoval.TestType(): Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute'")]
 	[LogContains ("IL2045: Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TypeOnCopyAssemblyWithAttributeUsage.TypeOnCopyAssemblyWithAttributeUsage(): Attribute 'Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TestAttributeReferencedAsTypeFromCopyAssemblyAttribute'")]
-
 	[LogDoesNotContain ("IL2045")] // No other 2045 messages should be logged
 
+	[ExpectedWarning ("IL2049", "'InvalidInternal'", FileName = "LinkerAttributeRemoval.xml")]
 	[ExpectedWarning ("IL2048", "RemoveAttributeInstances", FileName = "LinkerAttributeRemoval.xml")]
+
+	[ExpectedNoWarnings]
 
 	[KeptMember (".ctor()")]
 	class LinkerAttributeRemoval
@@ -68,7 +69,7 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 		{
 			var instance = new LinkerAttributeRemoval ();
 			instance._fieldWithCustomAttribute = null;
-			string value = instance.methodWithCustomAttribute ("parameter");
+			string value = instance.methodWithCustomAttribute (null);
 			TestType ();
 
 			_ = new TypeOnCopyAssemblyWithAttributeUsage ();
@@ -94,9 +95,10 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		private string methodWithCustomAttribute ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] string parameterWithCustomAttribute)
 		{
-			return "this is a return value";
+			return null;
 		}
 
+		[ExpectedWarning ("IL2045", "Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute'")]
 		[Kept]
 		public static void TestType ()
 		{


### PR DESCRIPTION
We were lacking validation for some of the warnings, and so change in behavior of the product wasn't reflected in the tests. This cleans up tests for IL2053 and IL2054 (which are not produced anymore).