### PR TITLE
[release/7.0] Don't hardcode Microsoft.CodeAnalysis version for source-build

### DIFF
--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -17,7 +17,8 @@
     <None Include="Microsoft.NET.ILLink.Analyzers.props" CopyToOutputDirectory="PreserveNewest" />
     <!-- The repo CodeAnalyis version is ahead of what is shipped with Visual Studio, so that version breaks the analyzers when used in .Net Framework builds -->
     <!-- Once Visual Studio ships with a version >= $MicrosoftCodeAnalysisVersion, this should be changed to use the property -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0-2.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0-2.final" PrivateAssets="all" Condition="'$(DotNetBuildFromSource)' != 'true'"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" Condition="'$(DotNetBuildFromSource)' == 'true'"/>
     <PackageReference Condition="'$(DotNetBuildFromSource)' != 'true'" Include="StaticCs" Version="$(StaticCsVersion)">
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>contentfiles</ExcludeAssets> <!-- We include our own copy of the ClosedAttribute to work in source build -->


### PR DESCRIPTION
When building from source, we need to use the latest version of Microsoft.CodeAnalysis. Since source-build only supports Linux and doesn't need to worry about Visual Studio, this doesn't cause the issue described in the comment.

I also think it would be good to check if Visual Studio has already updated the Microsoft.CodeAnalysis.Csharp version or find out when it will.