### PR TITLE
Update docker to the latest tagging schema

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -95,7 +95,7 @@ stages:
           ${{ if eq(variables.officialBuild, 'true' )}}:
             name: NetCore1ESPool-Internal
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
         workspace:
           clean: all
         steps:


### PR DESCRIPTION
As a part of https://github.com/dotnet/arcade/issues/10123, we are moving all docker containers to the new tagging schema