### PR TITLE
Remove redundant checks in IntrinsicId switch statements

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
@@ -66,7 +66,9 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 		{
 			DiagnosticContext diagnosticContext = new (Operation.Syntax.GetLocation ());
 			HandleCallAction handleCallAction = new (diagnosticContext, OwningSymbol, Operation);
-			if (!handleCallAction.Invoke (new MethodProxy (CalledMethod), Instance, Arguments, out _, out _)) {
+			MethodProxy method = new (CalledMethod);
+			IntrinsicId intrinsicId = Intrinsics.GetIntrinsicIdForMethod (method);
+			if (!handleCallAction.Invoke (method, Instance, Arguments, intrinsicId, out _)) {
 				// If this returns false it means the intrinsic needs special handling:
 				// case IntrinsicId.TypeDelegator_Ctor:
 				//    No diagnostics to report - this is an "identity" operation for data flow, can't produce diagnostics on its own

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -252,8 +252,10 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 			var diagnosticContext = DiagnosticContext.CreateDisabled ();
 			var handleCallAction = new HandleCallAction (diagnosticContext, Method, operation);
+			MethodProxy method = new (calledMethod);
+			var intrinsicId = Intrinsics.GetIntrinsicIdForMethod (method);
 
-			if (!handleCallAction.Invoke (new MethodProxy (calledMethod), instance, arguments, out MultiValue methodReturnValue, out var intrinsicId)) {
+			if (!handleCallAction.Invoke (method, instance, arguments, intrinsicId, out MultiValue methodReturnValue)) {
 				switch (intrinsicId) {
 				case IntrinsicId.Array_Empty:
 					methodReturnValue = ArrayValue.Create (0);

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -27,7 +27,7 @@ namespace ILLink.Shared.TrimAnalysis
 		readonly FlowAnnotations _annotations;
 		readonly RequireDynamicallyAccessedMembersAction _requireDynamicallyAccessedMembersAction;
 
-		public bool Invoke (MethodProxy calledMethod, MultiValue instanceValue, IReadOnlyList<MultiValue> argumentValues, out MultiValue methodReturnValue, out IntrinsicId intrinsicId, IntrinsicId? knownIntrinsicId = null)
+		public bool Invoke (MethodProxy calledMethod, MultiValue instanceValue, IReadOnlyList<MultiValue> argumentValues, IntrinsicId intrinsicId, out MultiValue methodReturnValue)
 		{
 			MultiValue? returnValue = null;
 
@@ -35,7 +35,6 @@ namespace ILLink.Shared.TrimAnalysis
 			var annotatedMethodReturnValue = _annotations.GetMethodReturnValue (calledMethod);
 			Debug.Assert (requiresDataFlowAnalysis || annotatedMethodReturnValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.None);
 
-			intrinsicId = knownIntrinsicId ?? Intrinsics.GetIntrinsicIdForMethod (calledMethod);
 			switch (intrinsicId) {
 			case IntrinsicId.IntrospectionExtensions_GetTypeInfo:
 				Debug.Assert (instanceValue.IsEmpty ());
@@ -251,25 +250,25 @@ namespace ILLink.Shared.TrimAnalysis
 			// GetNestedTypes (BindingFlags)
 			// GetMembers (BindingFlags)
 			//
-			case IntrinsicId.Type_GetConstructors:
-			case IntrinsicId.Type_GetMethods:
-			case IntrinsicId.Type_GetFields:
-			case IntrinsicId.Type_GetProperties:
-			case IntrinsicId.Type_GetEvents:
-			case IntrinsicId.Type_GetNestedTypes:
-			case IntrinsicId.Type_GetMembers: {
+			case IntrinsicId.Type_GetConstructors__BindingFlags:
+			case IntrinsicId.Type_GetMethods__BindingFlags:
+			case IntrinsicId.Type_GetFields__BindingFlags:
+			case IntrinsicId.Type_GetProperties__BindingFlags:
+			case IntrinsicId.Type_GetEvents__BindingFlags:
+			case IntrinsicId.Type_GetNestedTypes__BindingFlags:
+			case IntrinsicId.Type_GetMembers__BindingFlags: {
 					BindingFlags? bindingFlags;
 					bindingFlags = GetBindingFlagsFromValue (argumentValues[0]);
 					DynamicallyAccessedMemberTypes memberTypes;
 					if (BindingFlagsAreUnsupported (bindingFlags)) {
 						memberTypes = intrinsicId switch {
-							IntrinsicId.Type_GetConstructors => DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors,
-							IntrinsicId.Type_GetMethods => DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods,
-							IntrinsicId.Type_GetEvents => DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents,
-							IntrinsicId.Type_GetFields => DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields,
-							IntrinsicId.Type_GetProperties => DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties,
-							IntrinsicId.Type_GetNestedTypes => DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes,
-							IntrinsicId.Type_GetMembers => DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors |
+							IntrinsicId.Type_GetConstructors__BindingFlags => DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors,
+							IntrinsicId.Type_GetMethods__BindingFlags => DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods,
+							IntrinsicId.Type_GetEvents__BindingFlags => DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents,
+							IntrinsicId.Type_GetFields__BindingFlags => DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields,
+							IntrinsicId.Type_GetProperties__BindingFlags => DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties,
+							IntrinsicId.Type_GetNestedTypes__BindingFlags => DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes,
+							IntrinsicId.Type_GetMembers__BindingFlags => DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors |
 								DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents |
 								DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields |
 								DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods |
@@ -279,13 +278,13 @@ namespace ILLink.Shared.TrimAnalysis
 						};
 					} else {
 						memberTypes = intrinsicId switch {
-							IntrinsicId.Type_GetConstructors => GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags),
-							IntrinsicId.Type_GetMethods => GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (bindingFlags),
-							IntrinsicId.Type_GetEvents => GetDynamicallyAccessedMemberTypesFromBindingFlagsForEvents (bindingFlags),
-							IntrinsicId.Type_GetFields => GetDynamicallyAccessedMemberTypesFromBindingFlagsForFields (bindingFlags),
-							IntrinsicId.Type_GetProperties => GetDynamicallyAccessedMemberTypesFromBindingFlagsForProperties (bindingFlags),
-							IntrinsicId.Type_GetNestedTypes => GetDynamicallyAccessedMemberTypesFromBindingFlagsForNestedTypes (bindingFlags),
-							IntrinsicId.Type_GetMembers => GetDynamicallyAccessedMemberTypesFromBindingFlagsForMembers (bindingFlags),
+							IntrinsicId.Type_GetConstructors__BindingFlags => GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags),
+							IntrinsicId.Type_GetMethods__BindingFlags => GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (bindingFlags),
+							IntrinsicId.Type_GetEvents__BindingFlags => GetDynamicallyAccessedMemberTypesFromBindingFlagsForEvents (bindingFlags),
+							IntrinsicId.Type_GetFields__BindingFlags => GetDynamicallyAccessedMemberTypesFromBindingFlagsForFields (bindingFlags),
+							IntrinsicId.Type_GetProperties__BindingFlags => GetDynamicallyAccessedMemberTypesFromBindingFlagsForProperties (bindingFlags),
+							IntrinsicId.Type_GetNestedTypes__BindingFlags => GetDynamicallyAccessedMemberTypesFromBindingFlagsForNestedTypes (bindingFlags),
+							IntrinsicId.Type_GetMembers__BindingFlags => GetDynamicallyAccessedMemberTypesFromBindingFlagsForMembers (bindingFlags),
 							_ => throw new ArgumentException ($"Reflection call '{calledMethod.GetDisplayName ()}' inside '{GetContainingSymbolDisplayName ()}' is of unexpected member type."),
 						};
 					}
@@ -1015,7 +1014,7 @@ namespace ILLink.Shared.TrimAnalysis
 			// static CreateInstance (System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture)
 			// static CreateInstance (System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture, object?[]? activationAttributes) { throw null; }
 			//
-			case IntrinsicId.Activator_CreateInstance_Type: {
+			case IntrinsicId.Activator_CreateInstance__Type: {
 					int? ctorParameterCount = null;
 					BindingFlags bindingFlags = BindingFlags.Instance;
 					if (calledMethod.GetParametersCount () > 1) {
@@ -1085,7 +1084,7 @@ namespace ILLink.Shared.TrimAnalysis
 			// static CreateInstance (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture, object?[]? activationAttributes)
 			// static CreateInstance (string assemblyName, string typeName, object?[]? activationAttributes)
 			//
-			case IntrinsicId.Activator_CreateInstance_AssemblyName_TypeName:
+			case IntrinsicId.Activator_CreateInstance__AssemblyName_TypeName:
 				ProcessCreateInstanceByName (calledMethod, argumentValues);
 				break;
 

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -610,7 +610,7 @@ namespace ILLink.Shared.TrimAnalysis
 			//
 			// static Property (Expression, MethodInfo)
 			//
-			case IntrinsicId.Expression_Property: {
+			case IntrinsicId.Expression_Property when calledMethod.HasParameterOfType (1, "System.Reflection.MethodInfo"): {
 					if (argumentValues[1].IsEmpty ()) {
 						returnValue = MultiValueLattice.Top;
 						break;

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -251,17 +251,18 @@ namespace ILLink.Shared.TrimAnalysis
 			// GetNestedTypes (BindingFlags)
 			// GetMembers (BindingFlags)
 			//
-			case var callType when (callType == IntrinsicId.Type_GetConstructors || callType == IntrinsicId.Type_GetMethods || callType == IntrinsicId.Type_GetFields ||
-				callType == IntrinsicId.Type_GetProperties || callType == IntrinsicId.Type_GetEvents || callType == IntrinsicId.Type_GetNestedTypes || callType == IntrinsicId.Type_GetMembers)
-				&& calledMethod.IsDeclaredOnType ("System.Type")
-				&& calledMethod.HasParameterOfType (0, "System.Reflection.BindingFlags")
-				&& !calledMethod.IsStatic (): {
-
+			case IntrinsicId.Type_GetConstructors:
+			case IntrinsicId.Type_GetMethods:
+			case IntrinsicId.Type_GetFields:
+			case IntrinsicId.Type_GetProperties:
+			case IntrinsicId.Type_GetEvents:
+			case IntrinsicId.Type_GetNestedTypes:
+			case IntrinsicId.Type_GetMembers: {
 					BindingFlags? bindingFlags;
 					bindingFlags = GetBindingFlagsFromValue (argumentValues[0]);
 					DynamicallyAccessedMemberTypes memberTypes;
 					if (BindingFlagsAreUnsupported (bindingFlags)) {
-						memberTypes = callType switch {
+						memberTypes = intrinsicId switch {
 							IntrinsicId.Type_GetConstructors => DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors,
 							IntrinsicId.Type_GetMethods => DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods,
 							IntrinsicId.Type_GetEvents => DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents,
@@ -277,7 +278,7 @@ namespace ILLink.Shared.TrimAnalysis
 							_ => throw new ArgumentException ($"Reflection call '{calledMethod.GetDisplayName ()}' inside '{GetContainingSymbolDisplayName ()}' is of unexpected member type."),
 						};
 					} else {
-						memberTypes = callType switch {
+						memberTypes = intrinsicId switch {
 							IntrinsicId.Type_GetConstructors => GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags),
 							IntrinsicId.Type_GetMethods => GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (bindingFlags),
 							IntrinsicId.Type_GetEvents => GetDynamicallyAccessedMemberTypesFromBindingFlagsForEvents (bindingFlags),
@@ -307,11 +308,9 @@ namespace ILLink.Shared.TrimAnalysis
 			// GetProperty (string, Type, Type[], ParameterModifier[])
 			// GetProperty (string, BindingFlags, Binder, Type, Type[], ParameterModifier[])
 			//
-			case var fieldPropertyOrEvent when (fieldPropertyOrEvent == IntrinsicId.Type_GetField || fieldPropertyOrEvent == IntrinsicId.Type_GetProperty || fieldPropertyOrEvent == IntrinsicId.Type_GetEvent)
-				&& calledMethod.IsDeclaredOnType ("System.Type")
-				&& calledMethod.HasParameterOfType (0, "System.String")
-				&& !calledMethod.IsStatic (): {
-
+			case IntrinsicId.Type_GetField:
+			case IntrinsicId.Type_GetProperty:
+			case IntrinsicId.Type_GetEvent: {
 					if (instanceValue.IsEmpty () || argumentValues[0].IsEmpty ()) {
 						returnValue = MultiValueLattice.Top;
 						break;
@@ -324,7 +323,7 @@ namespace ILLink.Shared.TrimAnalysis
 						// Assume a default value for BindingFlags for methods that don't use BindingFlags as a parameter
 						bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 
-					DynamicallyAccessedMemberTypes memberTypes = fieldPropertyOrEvent switch {
+					DynamicallyAccessedMemberTypes memberTypes = intrinsicId switch {
 						IntrinsicId.Type_GetEvent => GetDynamicallyAccessedMemberTypesFromBindingFlagsForEvents (bindingFlags),
 						IntrinsicId.Type_GetField => GetDynamicallyAccessedMemberTypesFromBindingFlagsForFields (bindingFlags),
 						IntrinsicId.Type_GetProperty => GetDynamicallyAccessedMemberTypesFromBindingFlagsForProperties (bindingFlags),
@@ -336,7 +335,7 @@ namespace ILLink.Shared.TrimAnalysis
 						if (value is SystemTypeValue systemTypeValue) {
 							foreach (var stringParam in argumentValues[0]) {
 								if (stringParam is KnownStringValue stringValue && !BindingFlagsAreUnsupported (bindingFlags)) {
-									switch (fieldPropertyOrEvent) {
+									switch (intrinsicId) {
 									case IntrinsicId.Type_GetEvent:
 										MarkEventsOnTypeHierarchy (systemTypeValue.RepresentedType, stringValue.Contents, bindingFlags);
 										break;
@@ -527,10 +526,10 @@ namespace ILLink.Shared.TrimAnalysis
 			// static GetRuntimeMethod (this Type type, string name, Type[] parameters)
 			// static GetRuntimeProperty (this Type type, string name)
 			//
-			case var getRuntimeMember when getRuntimeMember == IntrinsicId.RuntimeReflectionExtensions_GetRuntimeEvent
-				|| getRuntimeMember == IntrinsicId.RuntimeReflectionExtensions_GetRuntimeField
-				|| getRuntimeMember == IntrinsicId.RuntimeReflectionExtensions_GetRuntimeMethod
-				|| getRuntimeMember == IntrinsicId.RuntimeReflectionExtensions_GetRuntimeProperty: {
+			case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeEvent:
+			case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeField:
+			case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeMethod:
+			case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeProperty: {
 
 					if (argumentValues[0].IsEmpty () || argumentValues[1].IsEmpty ()) {
 						returnValue = MultiValueLattice.Top;
@@ -538,7 +537,7 @@ namespace ILLink.Shared.TrimAnalysis
 					}
 
 					BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
-					DynamicallyAccessedMemberTypes requiredMemberTypes = getRuntimeMember switch {
+					DynamicallyAccessedMemberTypes requiredMemberTypes = intrinsicId switch {
 						IntrinsicId.RuntimeReflectionExtensions_GetRuntimeEvent => DynamicallyAccessedMemberTypes.PublicEvents,
 						IntrinsicId.RuntimeReflectionExtensions_GetRuntimeField => DynamicallyAccessedMemberTypes.PublicFields,
 						IntrinsicId.RuntimeReflectionExtensions_GetRuntimeMethod => DynamicallyAccessedMemberTypes.PublicMethods,
@@ -552,7 +551,7 @@ namespace ILLink.Shared.TrimAnalysis
 						if (value is SystemTypeValue systemTypeValue) {
 							foreach (var stringParam in argumentValues[1]) {
 								if (stringParam is KnownStringValue stringValue) {
-									switch (getRuntimeMember) {
+									switch (intrinsicId) {
 									case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeEvent:
 										MarkEventsOnTypeHierarchy (systemTypeValue.RepresentedType, stringValue.Contents, bindingFlags);
 										break;
@@ -611,7 +610,7 @@ namespace ILLink.Shared.TrimAnalysis
 			//
 			// static Property (Expression, MethodInfo)
 			//
-			case IntrinsicId.Expression_Property when calledMethod.HasParameterOfType (1, "System.Reflection.MethodInfo"): {
+			case IntrinsicId.Expression_Property: {
 					if (argumentValues[1].IsEmpty ()) {
 						returnValue = MultiValueLattice.Top;
 						break;
@@ -642,8 +641,9 @@ namespace ILLink.Shared.TrimAnalysis
 			// static Field (Expression, Type, String)
 			// static Property (Expression, Type, String)
 			//
-			case var fieldOrPropertyInstrinsic when fieldOrPropertyInstrinsic == IntrinsicId.Expression_Field || fieldOrPropertyInstrinsic == IntrinsicId.Expression_Property: {
-					DynamicallyAccessedMemberTypes memberTypes = fieldOrPropertyInstrinsic == IntrinsicId.Expression_Property
+			case IntrinsicId.Expression_Field:
+			case IntrinsicId.Expression_Property: {
+					DynamicallyAccessedMemberTypes memberTypes = intrinsicId == IntrinsicId.Expression_Property
 						? DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties
 						: DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields;
 
@@ -658,7 +658,7 @@ namespace ILLink.Shared.TrimAnalysis
 							foreach (var stringParam in argumentValues[2]) {
 								if (stringParam is KnownStringValue stringValue) {
 									BindingFlags bindingFlags = argumentValues[0].AsSingleValue () is NullValue ? BindingFlags.Static : BindingFlags.Default;
-									if (fieldOrPropertyInstrinsic == IntrinsicId.Expression_Property) {
+									if (intrinsicId == IntrinsicId.Expression_Property) {
 										MarkPropertiesOnTypeHierarchy (systemTypeValue.RepresentedType, stringValue.Contents, bindingFlags);
 									} else {
 										MarkFieldsOnTypeHierarchy (systemTypeValue.RepresentedType, stringValue.Contents, bindingFlags);
@@ -1119,10 +1119,10 @@ namespace ILLink.Shared.TrimAnalysis
 			// CreateInstanceFromAndUnwrap (string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)
 			// CreateInstanceFromAndUnwrap (string assemblyFile, string typeName, object? []? activationAttributes)
 			//
-			case var appDomainCreateInstance when appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstance
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceAndUnwrap
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFrom
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
+			case IntrinsicId.AppDomain_CreateInstance:
+			case IntrinsicId.AppDomain_CreateInstanceAndUnwrap:
+			case IntrinsicId.AppDomain_CreateInstanceFrom:
+			case IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
 				ProcessCreateInstanceByName (calledMethod, argumentValues);
 				break;
 

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -27,7 +27,7 @@ namespace ILLink.Shared.TrimAnalysis
 		readonly FlowAnnotations _annotations;
 		readonly RequireDynamicallyAccessedMembersAction _requireDynamicallyAccessedMembersAction;
 
-		public bool Invoke (MethodProxy calledMethod, MultiValue instanceValue, IReadOnlyList<MultiValue> argumentValues, out MultiValue methodReturnValue, out IntrinsicId intrinsicId)
+		public bool Invoke (MethodProxy calledMethod, MultiValue instanceValue, IReadOnlyList<MultiValue> argumentValues, out MultiValue methodReturnValue, out IntrinsicId intrinsicId, IntrinsicId? knownIntrinsicId = null)
 		{
 			MultiValue? returnValue = null;
 
@@ -35,7 +35,7 @@ namespace ILLink.Shared.TrimAnalysis
 			var annotatedMethodReturnValue = _annotations.GetMethodReturnValue (calledMethod);
 			Debug.Assert (requiresDataFlowAnalysis || annotatedMethodReturnValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.None);
 
-			intrinsicId = Intrinsics.GetIntrinsicIdForMethod (calledMethod);
+			intrinsicId = knownIntrinsicId ?? Intrinsics.GetIntrinsicIdForMethod (calledMethod);
 			switch (intrinsicId) {
 			case IntrinsicId.IntrospectionExtensions_GetTypeInfo:
 				Debug.Assert (instanceValue.IsEmpty ());

--- a/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
+++ b/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
@@ -10,14 +10,42 @@ namespace ILLink.Shared.TrimAnalysis
 	enum IntrinsicId
 	{
 		None = 0,
+		/// <summary>
+		/// <see cref="System.Reflection.IntrospectionExtensions.GetTypeInfo(System.Type)"/>
+		/// </summary>
 		IntrospectionExtensions_GetTypeInfo,
+		/// <summary>
+		/// <see cref="System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"/>
+		/// </summary>
 		Type_GetTypeFromHandle,
+		/// <summary>
+		/// <see cref="System.Type.TypeHandle"/>
+		/// </summary>
 		Type_get_TypeHandle,
+		/// <summary>
+		/// <see cref="System.Object.GetType()"/>
+		/// </summary>
 		Object_GetType,
+		/// <summary>
+		/// <see cref="System.Reflection.TypeDelegator()"/>
+		/// </summary>
 		TypeDelegator_Ctor,
+		/// <summary>
+		/// <see cref="System.Array.Empty{T}"/>
+		/// </summary>
 		Array_Empty,
+		/// <summary>
+		/// <see cref="System.Reflection.TypeInfo.AsType()"/>
+		/// </summary>
 		TypeInfo_AsType,
+		/// <summary>
+		/// <see cref="System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle)"/> or 
+		/// <see cref="System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)"/>
+		/// </summary>
 		MethodBase_GetMethodFromHandle,
+		/// <summary>
+		/// <see cref="System.Reflection.MethodBase.MethodHandle"/>
+		/// </summary>
 		MethodBase_get_MethodHandle,
 
 		// Anything above this marker will require the method to be run through
@@ -26,19 +54,19 @@ namespace ILLink.Shared.TrimAnalysis
 		Type_MakeGenericType,
 		Type_GetType,
 		Type_GetConstructor,
-		Type_GetConstructors,
+		Type_GetConstructors__BindingFlags,
 		Type_GetMethod,
-		Type_GetMethods,
+		Type_GetMethods__BindingFlags,
 		Type_GetField,
-		Type_GetFields,
+		Type_GetFields__BindingFlags,
 		Type_GetProperty,
-		Type_GetProperties,
+		Type_GetProperties__BindingFlags,
 		Type_GetEvent,
-		Type_GetEvents,
+		Type_GetEvents__BindingFlags,
 		Type_GetNestedType,
-		Type_GetNestedTypes,
+		Type_GetNestedTypes__BindingFlags,
 		Type_GetMember,
-		Type_GetMembers,
+		Type_GetMembers__BindingFlags,
 		Type_GetInterface,
 		Type_get_AssemblyQualifiedName,
 		Type_get_UnderlyingSystemType,
@@ -53,8 +81,8 @@ namespace ILLink.Shared.TrimAnalysis
 		Marshal_PtrToStructure,
 		Marshal_DestroyStructure,
 		Marshal_GetDelegateForFunctionPointer,
-		Activator_CreateInstance_Type,
-		Activator_CreateInstance_AssemblyName_TypeName,
+		Activator_CreateInstance__Type,
+		Activator_CreateInstance__AssemblyName_TypeName,
 		Activator_CreateInstanceFrom,
 		AppDomain_CreateInstance,
 		AppDomain_CreateInstanceAndUnwrap,

--- a/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
+++ b/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
@@ -146,7 +146,7 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.HasParameterOfType (0, "System.Reflection.BindingFlags")
 					&& calledMethod.HasParametersCount (1)
 					&& !calledMethod.IsStatic ()
-					=> IntrinsicId.Type_GetConstructors,
+					=> IntrinsicId.Type_GetConstructors__BindingFlags,
 
 				// System.Type.GetMethod (string)
 				// System.Type.GetMethod (string, BindingFlags)
@@ -169,7 +169,7 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.HasParameterOfType (0, "System.Reflection.BindingFlags")
 					&& calledMethod.HasParametersCount (1)
 					&& !calledMethod.IsStatic ()
-					=> IntrinsicId.Type_GetMethods,
+					=> IntrinsicId.Type_GetMethods__BindingFlags,
 
 				// System.Type.GetField (string)
 				// System.Type.GetField (string, BindingFlags)
@@ -183,7 +183,7 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.HasParameterOfType (0, "System.Reflection.BindingFlags")
 					&& calledMethod.HasParametersCount (1)
 					&& !calledMethod.IsStatic ()
-					=> IntrinsicId.Type_GetFields,
+					=> IntrinsicId.Type_GetFields__BindingFlags,
 
 				// System.Type.GetEvent (string)
 				// System.Type.GetEvent (string, BindingFlags)
@@ -197,7 +197,7 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.HasParameterOfType (0, "System.Reflection.BindingFlags")
 					&& calledMethod.HasParametersCount (1)
 					&& !calledMethod.IsStatic ()
-					=> IntrinsicId.Type_GetEvents,
+					=> IntrinsicId.Type_GetEvents__BindingFlags,
 
 				// System.Type.GetNestedType (string)
 				// System.Type.GetNestedType (string, BindingFlags)
@@ -211,7 +211,7 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.HasParameterOfType (0, "System.Reflection.BindingFlags")
 					&& calledMethod.HasParametersCount (1)
 					&& !calledMethod.IsStatic ()
-					=> IntrinsicId.Type_GetNestedTypes,
+					=> IntrinsicId.Type_GetNestedTypes__BindingFlags,
 
 				// System.Type.GetMember (String)
 				// System.Type.GetMember (String, BindingFlags)
@@ -229,7 +229,7 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.HasParameterOfType (0, "System.Reflection.BindingFlags")
 					&& calledMethod.HasParametersCount (1)
 					&& !calledMethod.IsStatic ()
-					=> IntrinsicId.Type_GetMembers,
+					=> IntrinsicId.Type_GetMembers__BindingFlags,
 
 				// System.Type.GetInterface (string)
 				// System.Type.GetInterface (string, bool)
@@ -275,7 +275,7 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.HasParameterOfType (0, "System.Reflection.BindingFlags")
 					&& calledMethod.HasParametersCount (1)
 					&& !calledMethod.IsStatic ()
-					=> IntrinsicId.Type_GetProperties,
+					=> IntrinsicId.Type_GetProperties__BindingFlags,
 
 				// static System.Object.GetType ()
 				"GetType" when calledMethod.IsDeclaredOnType ("System.Object")
@@ -297,7 +297,7 @@ namespace ILLink.Shared.TrimAnalysis
 				"CreateInstance" when calledMethod.IsDeclaredOnType ("System.Activator")
 					&& !calledMethod.HasGenericParameters ()
 					&& calledMethod.HasParameterOfType (0, "System.Type")
-					=> IntrinsicId.Activator_CreateInstance_Type,
+					=> IntrinsicId.Activator_CreateInstance__Type,
 
 				// static System.Activator.CreateInstance (string assemblyName, string typeName)
 				// static System.Activator.CreateInstance (string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object?[]? args, System.Globalization.CultureInfo? culture, object?[]? activationAttributes)
@@ -306,7 +306,7 @@ namespace ILLink.Shared.TrimAnalysis
 					&& !calledMethod.HasGenericParameters ()
 					&& calledMethod.HasParameterOfType (0, "System.String")
 					&& calledMethod.HasParameterOfType (1, "System.String")
-					=> IntrinsicId.Activator_CreateInstance_AssemblyName_TypeName,
+					=> IntrinsicId.Activator_CreateInstance__AssemblyName_TypeName,
 
 				// static System.Activator.CreateInstanceFrom (string assemblyFile, string typeName)
 				// static System.Activator.CreateInstanceFrom (string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object? []? args, System.Globalization.CultureInfo? culture, object? []? activationAttributes)

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -196,7 +196,8 @@ namespace Mono.Linker.Dataflow
 			MultiValue? maybeMethodReturnValue = null;
 
 			var handleCallAction = new HandleCallAction (context, reflectionMarker, diagnosticContext, callingMethodDefinition);
-			switch (Intrinsics.GetIntrinsicIdForMethod (calledMethodDefinition)) {
+			var intrinsicId = Intrinsics.GetIntrinsicIdForMethod (calledMethodDefinition);
+			switch (intrinsicId) {
 			case IntrinsicId.IntrospectionExtensions_GetTypeInfo:
 			case IntrinsicId.TypeInfo_AsType:
 			case IntrinsicId.Type_get_UnderlyingSystemType:
@@ -242,7 +243,7 @@ namespace Mono.Linker.Dataflow
 			case IntrinsicId.AppDomain_CreateInstanceFrom:
 			case IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
 			case IntrinsicId.Assembly_CreateInstance: {
-					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, out methodReturnValue, out _);
+					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, out methodReturnValue, out _, intrinsicId);
 				}
 
 			case IntrinsicId.None: {
@@ -251,7 +252,7 @@ namespace Mono.Linker.Dataflow
 					if (context.Annotations.DoesMethodRequireUnreferencedCode (calledMethodDefinition, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCode))
 						MarkStep.ReportRequiresUnreferencedCode (calledMethodDefinition.GetDisplayName (), requiresUnreferencedCode, diagnosticContext);
 
-					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, out methodReturnValue, out _);
+					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, out methodReturnValue, out _, intrinsicId);
 				}
 
 			case IntrinsicId.TypeDelegator_Ctor: {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -206,13 +206,13 @@ namespace Mono.Linker.Dataflow
 			case IntrinsicId.Type_GetInterface:
 			case IntrinsicId.Type_get_AssemblyQualifiedName:
 			case IntrinsicId.RuntimeHelpers_RunClassConstructor:
-			case IntrinsicId.Type_GetConstructors:
-			case IntrinsicId.Type_GetMethods:
-			case IntrinsicId.Type_GetFields:
-			case IntrinsicId.Type_GetProperties:
-			case IntrinsicId.Type_GetEvents:
-			case IntrinsicId.Type_GetNestedTypes:
-			case IntrinsicId.Type_GetMembers:
+			case IntrinsicId.Type_GetConstructors__BindingFlags:
+			case IntrinsicId.Type_GetMethods__BindingFlags:
+			case IntrinsicId.Type_GetFields__BindingFlags:
+			case IntrinsicId.Type_GetProperties__BindingFlags:
+			case IntrinsicId.Type_GetEvents__BindingFlags:
+			case IntrinsicId.Type_GetNestedTypes__BindingFlags:
+			case IntrinsicId.Type_GetMembers__BindingFlags:
 			case IntrinsicId.Type_GetField:
 			case IntrinsicId.Type_GetProperty:
 			case IntrinsicId.Type_GetEvent:
@@ -235,15 +235,15 @@ namespace Mono.Linker.Dataflow
 			case IntrinsicId.Expression_Call:
 			case IntrinsicId.Expression_New:
 			case IntrinsicId.Type_GetType:
-			case IntrinsicId.Activator_CreateInstance_Type:
-			case IntrinsicId.Activator_CreateInstance_AssemblyName_TypeName:
+			case IntrinsicId.Activator_CreateInstance__Type:
+			case IntrinsicId.Activator_CreateInstance__AssemblyName_TypeName:
 			case IntrinsicId.Activator_CreateInstanceFrom:
 			case IntrinsicId.AppDomain_CreateInstance:
 			case IntrinsicId.AppDomain_CreateInstanceAndUnwrap:
 			case IntrinsicId.AppDomain_CreateInstanceFrom:
 			case IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
 			case IntrinsicId.Assembly_CreateInstance: {
-					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, out methodReturnValue, out _, intrinsicId);
+					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, intrinsicId, out methodReturnValue);
 				}
 
 			case IntrinsicId.None: {
@@ -252,7 +252,7 @@ namespace Mono.Linker.Dataflow
 					if (context.Annotations.DoesMethodRequireUnreferencedCode (calledMethodDefinition, out RequiresUnreferencedCodeAttribute? requiresUnreferencedCode))
 						MarkStep.ReportRequiresUnreferencedCode (calledMethodDefinition.GetDisplayName (), requiresUnreferencedCode, diagnosticContext);
 
-					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, out methodReturnValue, out _, intrinsicId);
+					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, intrinsicId, out methodReturnValue);
 				}
 
 			case IntrinsicId.TypeDelegator_Ctor: {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -205,25 +205,26 @@ namespace Mono.Linker.Dataflow
 			case IntrinsicId.Type_GetInterface:
 			case IntrinsicId.Type_get_AssemblyQualifiedName:
 			case IntrinsicId.RuntimeHelpers_RunClassConstructor:
-			case var callType when (callType == IntrinsicId.Type_GetConstructors || callType == IntrinsicId.Type_GetMethods || callType == IntrinsicId.Type_GetFields ||
-				callType == IntrinsicId.Type_GetProperties || callType == IntrinsicId.Type_GetEvents || callType == IntrinsicId.Type_GetNestedTypes || callType == IntrinsicId.Type_GetMembers)
-				&& calledMethod.DeclaringType.IsTypeOf (WellKnownType.System_Type)
-				&& calledMethod.Parameters[0].ParameterType.FullName == "System.Reflection.BindingFlags"
-				&& calledMethod.HasThis:
-			case var fieldPropertyOrEvent when (fieldPropertyOrEvent == IntrinsicId.Type_GetField || fieldPropertyOrEvent == IntrinsicId.Type_GetProperty || fieldPropertyOrEvent == IntrinsicId.Type_GetEvent)
-				&& calledMethod.DeclaringType.IsTypeOf (WellKnownType.System_Type)
-				&& calledMethod.Parameters[0].ParameterType.IsTypeOf (WellKnownType.System_String)
-				&& calledMethod.HasThis:
-			case var getRuntimeMember when getRuntimeMember == IntrinsicId.RuntimeReflectionExtensions_GetRuntimeEvent
-				|| getRuntimeMember == IntrinsicId.RuntimeReflectionExtensions_GetRuntimeField
-				|| getRuntimeMember == IntrinsicId.RuntimeReflectionExtensions_GetRuntimeMethod
-				|| getRuntimeMember == IntrinsicId.RuntimeReflectionExtensions_GetRuntimeProperty:
+			case IntrinsicId.Type_GetConstructors:
+			case IntrinsicId.Type_GetMethods:
+			case IntrinsicId.Type_GetFields:
+			case IntrinsicId.Type_GetProperties:
+			case IntrinsicId.Type_GetEvents:
+			case IntrinsicId.Type_GetNestedTypes:
+			case IntrinsicId.Type_GetMembers:
+			case IntrinsicId.Type_GetField:
+			case IntrinsicId.Type_GetProperty:
+			case IntrinsicId.Type_GetEvent:
+			case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeEvent:
+			case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeField:
+			case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeMethod:
+			case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeProperty:
 			case IntrinsicId.Type_GetMember:
 			case IntrinsicId.Type_GetMethod:
 			case IntrinsicId.Type_GetNestedType:
 			case IntrinsicId.Nullable_GetUnderlyingType:
-			case IntrinsicId.Expression_Property when calledMethod.HasParameterOfType (1, "System.Reflection.MethodInfo"):
-			case var fieldOrPropertyIntrinsic when fieldOrPropertyIntrinsic == IntrinsicId.Expression_Field || fieldOrPropertyIntrinsic == IntrinsicId.Expression_Property:
+			case IntrinsicId.Expression_Property:
+			case IntrinsicId.Expression_Field:
 			case IntrinsicId.Type_get_BaseType:
 			case IntrinsicId.Type_GetConstructor:
 			case IntrinsicId.MethodBase_GetMethodFromHandle:
@@ -236,10 +237,10 @@ namespace Mono.Linker.Dataflow
 			case IntrinsicId.Activator_CreateInstance_Type:
 			case IntrinsicId.Activator_CreateInstance_AssemblyName_TypeName:
 			case IntrinsicId.Activator_CreateInstanceFrom:
-			case var appDomainCreateInstance when appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstance
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceAndUnwrap
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFrom
-					|| appDomainCreateInstance == IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
+			case IntrinsicId.AppDomain_CreateInstance:
+			case IntrinsicId.AppDomain_CreateInstanceAndUnwrap:
+			case IntrinsicId.AppDomain_CreateInstanceFrom:
+			case IntrinsicId.AppDomain_CreateInstanceFromAndUnwrap:
 			case IntrinsicId.Assembly_CreateInstance: {
 					return handleCallAction.Invoke (calledMethodDefinition, instanceValue, argumentValues, out methodReturnValue, out _);
 				}


### PR DESCRIPTION
In ReflectionMethodBodyScanner and HandleCallAction, we do many of the same checks that already occur in `GetIntrinsicIdFromMethod`, and in a few places we have 'when' conditions that could just be regular cases. This removes the extra checks so the switch can be simpler and more optimized.

In the linker, we also get the IntrinsicId twice, so this adds an optional parameter for a known IntrinsicId. 