### PR TITLE
Use LinkContext caching when resolving ExportedTypes

### DIFF
--- a/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
+++ b/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
@@ -23,7 +23,7 @@ namespace ILLink.Shared.TrimAnalysis
 		/// </summary>
 		Type_get_TypeHandle,
 		/// <summary>
-		/// <see cref="System.Object.GetType()"/>
+		/// <see cref="object.GetType()"/>
 		/// </summary>
 		Object_GetType,
 		/// <summary>
@@ -39,8 +39,10 @@ namespace ILLink.Shared.TrimAnalysis
 		/// </summary>
 		TypeInfo_AsType,
 		/// <summary>
-		/// <see cref="System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle)"/> or 
-		/// <see cref="System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)"/>
+		/// <list type="table">
+		/// <item><see cref="System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle)"/></item>
+		/// <item><see cref="System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)"/></item>
+		/// </list>
 		/// </summary>
 		MethodBase_GetMethodFromHandle,
 		/// <summary>
@@ -51,50 +53,267 @@ namespace ILLink.Shared.TrimAnalysis
 		// Anything above this marker will require the method to be run through
 		// the reflection body scanner.
 		RequiresReflectionBodyScanner_Sentinel = 1000,
+		/// <summary>
+		/// <see cref="System.Type.MakeGenericType(System.Type[])"/>
+		/// </summary>
 		Type_MakeGenericType,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.Type.GetType(string)"/></item>
+		/// <item><see cref= "System.Type.GetType(string, bool)" /></item>
+		/// <item><see cref="System.Type.GetType(string, bool, bool)"/></item>
+		/// <item><see cref="System.Type.GetType(string, System.Func{System.Reflection.AssemblyName, System.Reflection.Assembly?}?, System.Func{System.Reflection.Assembly?, string, bool, System.Type?}?)"/></item>
+		/// <item><see cref="System.Type.GetType(string, System.Func{System.Reflection.AssemblyName, System.Reflection.Assembly?}?, System.Func{System.Reflection.Assembly?, string, bool, System.Type?}?, bool)"/></item>
+		/// <item><see cref="System.Type.GetType(string, System.Func{System.Reflection.AssemblyName, System.Reflection.Assembly?}?, System.Func{System.Reflection.Assembly?, string, bool, System.Type?}?, bool, bool)"/></item>
+		/// </list>
+		/// </summary>
 		Type_GetType,
+		/// <summary>
+		/// <item><see cref="System.Type.GetConstructor(System.Type[])"/></item>
+		/// <item><see cref="System.Type.GetConstructor(System.Reflection.BindingFlags, System.Type[])"/></item>
+		/// <item><see cref="System.Type.GetConstructor(System.Reflection.BindingFlags, System.Reflection.Binder?, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// <item><see cref="System.Type.GetConstructor(System.Reflection.BindingFlags, System.Reflection.Binder?, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// </list>
+		/// </summary>
 		Type_GetConstructor,
+		/// <summary>
+		/// <see cref="System.Type.GetConstructors(System.Reflection.BindingFlags)"/>
+		/// </summary>
 		Type_GetConstructors__BindingFlags,
+		/// <summary>
+		/// <item><see cref="System.Type.GetMethod(string)"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, System.Reflection.BindingFlags)"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, System.Type[])"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, System.Reflection.BindingFlags, System.Type[])"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, System.Reflection.BindingFlags, System.Reflection.Binder, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, System.Reflection.BindingFlags, System.Reflection.Binder, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, int, System.Type[])"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, int, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, int, System.Reflection.BindingFlags, System.Reflection.Binder?, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// <item><see cref="System.Type.GetMethod(string, int, System.Reflection.BindingFlags, System.Reflection.Binder?, System.Reflection.CallingConventions, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// </list>
+		/// </summary>
 		Type_GetMethod,
+		/// <summary>
+		/// <see cref="System.Type.GetMethod(System.Reflection.BindingFlags)"/>
+		/// </summary>
 		Type_GetMethods__BindingFlags,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.Type.GetField(string)"/></item>
+		/// <item><see cref="System.Type.GetField(string, System.Reflection.BindingFlags)"/></item>
+		/// </list>
+		/// </summary>
 		Type_GetField,
+		/// <summary>
+		/// <see cref="System.Type.GetFields(System.Reflection.BindingFlags)"/>
+		/// </summary>
 		Type_GetFields__BindingFlags,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.Type.GetProperty(string)"/></item>
+		/// <item><see cref="System.Type.GetProperty(string, System.Reflection.BindingFlags)"/></item>
+		/// <item><see cref="System.Type.GetProperty(string, System.Type?)"/></item>
+		/// <item><see cref="System.Type.GetProperty(string, System.Type[])"/></item>
+		/// <item><see cref="System.Type.GetProperty(string, System.Type?, System.Type[])"/></item>
+		/// <item><see cref="System.Type.GetProperty(string, System.Type?, System.Type[], System.Reflection.ParameterModifier[])"/></item>
+		/// <item><see cref="System.Type.GetProperty(string, System.Reflection.BindingFlags, System.Reflection.Binder?, System.Type?, System.Type[], System.Reflection.ParameterModifier[]?)"/></item>
+		/// </list>
+		/// </summary>
 		Type_GetProperty,
+		/// <summary>
+		/// <see cref="System.Type.GetProperties(System.Reflection.BindingFlags)"/>
+		/// </summary>
 		Type_GetProperties__BindingFlags,
+		/// <summary>
+		/// <list type="table">
+		///	<item><see cref="System.Type.GetEvent(string)"/></item>
+		///	<item><see cref="System.Type.GetEvent(string, System.Reflection.BindingFlags)"/></item>
+		/// </list>
+		/// </summary>
 		Type_GetEvent,
+		/// <summary>
+		/// <see cref="System.Type.GetEvents(System.Reflection.BindingFlags)"/>
+		/// </summary>
 		Type_GetEvents__BindingFlags,
+		/// <summary>
+		/// <list type="table">
+		///	<item><see cref="System.Type.GetNestedType(string)"/></item>
+		///	<item><see cref="System.Type.GetNestedType(string, System.Reflection.BindingFlags)"/></item>
+		///	</list>
+		/// </summary>
 		Type_GetNestedType,
+		/// <summary>
+		/// <see cref="System.Type.GetNestedTypes(System.Reflection.BindingFlags)"/>
+		/// </summary>
 		Type_GetNestedTypes__BindingFlags,
+		/// <summary>
+		/// <list type="table">
+		///	<item><see cref="System.Type.GetMember(string)"/></item>
+		///	<item><see cref="System.Type.GetMember(string, System.Reflection.BindingFlags)"/></item>
+		///	<item><see cref="System.Type.GetMember(string, System.Reflection.MemberTypes, System.Reflection.BindingFlags)"/></item>
+		///	</list>
+		/// </summary>
 		Type_GetMember,
+		/// <summary>
+		/// <see cref="System.Type.GetMembers(System.Reflection.BindingFlags)"/>
+		/// </summary>
 		Type_GetMembers__BindingFlags,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.Type.GetInterface(string)"/></item>
+		/// <item><see cref="System.Type.GetInterface(string, bool)"/></item>
+		/// </list>
+		/// </summary>
 		Type_GetInterface,
+		/// <summary>
+		/// <see cref="System.Type.AssemblyQualifiedName"/>
+		/// </summary>
 		Type_get_AssemblyQualifiedName,
+		/// <summary>
+		/// <see cref="System.Type.UnderlyingSystemType"/>
+		/// </summary>
 		Type_get_UnderlyingSystemType,
+		/// <summary>
+		/// <see cref="System.Type.BaseType"/>
+		/// </summary>
 		Type_get_BaseType,
+		/// <summary>
+		///	<see cref="System.Linq.Expressions.Expression.Call(System.Type, string, System.Type[]?, System.Linq.Expressions.Expression[]?))"/>
+		/// </summary>
 		Expression_Call,
+		/// <summary>
+		/// <see cref="System.Linq.Expressions.Expression.Field(System.Linq.Expressions.Expression?, System.Type, string)"/>
+		/// </summary>
 		Expression_Field,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.Linq.Expressions.Expression.Property(System.Linq.Expressions.Expression?, System.Reflection.MethodInfo)"/></item>
+		/// <item><see cref="System.Linq.Expressions.Expression.Property(System.Linq.Expressions.Expression?, System.Type, string)"/></item>
+		/// </list>
+		/// </summary>
 		Expression_Property,
+		/// <summary>
+		/// <see cref="System.Linq.Expressions.Expression.New(System.Type)"/>
+		/// </summary>
 		Expression_New,
+		/// <summary>
+		/// <see cref="System.Enum.GetValues(System.Type)"/>
+		/// </summary>
 		Enum_GetValues,
+		/// <summary>
+		/// <see cref="System.Runtime.InteropServices.Marshal.SizeOf(System.Type)"/>
+		/// </summary>
 		Marshal_SizeOf,
+		/// <summary>
+		/// <see cref="System.Runtime.InteropServices.Marshal.OffsetOf(System.Type, string)"/>
+		/// </summary>
 		Marshal_OffsetOf,
+		/// <summary>
+		/// <see cref="System.Runtime.InteropServices.Marshal.PtrToStructure(nint, System.Type)"/>
+		/// </summary>
 		Marshal_PtrToStructure,
+		/// <summary>
+		/// <see cref="System.Runtime.InteropServices.Marshal.DestroyStructure(nint, System.Type)"/>
+		/// </summary>
 		Marshal_DestroyStructure,
+		/// <summary>
+		/// <see cref="System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer(nint, System.Type)"/>
+		/// </summary>
 		Marshal_GetDelegateForFunctionPointer,
+		/// <list type="table">
+		/// <item><see cref="System.Activator.CreateInstance(System.Type)"/></item>
+		/// <item><see cref="System.Activator.CreateInstance(System.Type, bool)"/></item>
+		/// <item><see cref="System.Activator.CreateInstance(System.Type, object[])"/></item>
+		/// <item><see cref="System.Activator.CreateInstance(System.Type, object[], object[])"/></item>
+		/// <item><see cref="System.Activator.CreateInstance(System.Type, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo)"/></item>
+		/// <item><see cref="System.Activator.CreateInstance(System.Type, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo, object[])"/></item>
+		/// </list>
 		Activator_CreateInstance__Type,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.Activator.CreateInstance(string, string)"/></item>
+		/// <item><see cref="System.Activator.CreateInstance(string, string, bool, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo, object[])"/></item>
+		/// <item><see cref="System.Activator.CreateInstance(string, string, object[])"/></item>
+		/// </list>
+		/// </summary>
 		Activator_CreateInstance__AssemblyName_TypeName,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.Activator.CreateInstanceFrom(string, string)"/></item>
+		/// <item><see cref="System.Activator.CreateInstanceFrom(string, string, bool, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo, object[])"/></item>
+		/// <item><see cref="System.Activator.CreateInstanceFrom(string, string, object[])"/></item>
+		/// </list>
+		/// </summary>
 		Activator_CreateInstanceFrom,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.AppDomain.CreateInstance(string, string)"/></item>
+		/// <item><see cref="System.AppDomain.CreateInstance(string, string, bool, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo, object[])"/></item>
+		/// <item><see cref="System.AppDomain.CreateInstance(string, string, object[])"/></item>
+		/// </list>
+		/// </summary>
 		AppDomain_CreateInstance,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.AppDomain.CreateInstanceAndUnwrap(string, string)"/></item>
+		/// <item><see cref="System.AppDomain.CreateInstanceAndUnwrap(string, string, bool, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo, object[])"/></item>
+		/// <item><see cref="System.AppDomain.CreateInstanceAndUnwrap(string, string, object[])"/></item>
+		/// </list>
+		/// </summary>
 		AppDomain_CreateInstanceAndUnwrap,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.AppDomain.CreateInstanceFrom(string, string)"/></item>
+		/// <item><see cref="System.AppDomain.CreateInstanceFrom(string, string, bool, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo, object[])"/></item>
+		/// <item><see cref="System.AppDomain.CreateInstanceFrom(string, string, object[])"/></item>
+		/// </list>
+		/// </summary>
 		AppDomain_CreateInstanceFrom,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.AppDomain.CreateInstanceFromAndUnwrap(string, string)"/></item>
+		/// <item><see cref="System.AppDomain.CreateInstanceFromAndUnwrap(string, string, bool, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo, object[])"/></item>
+		/// <item><see cref="System.AppDomain.CreateInstanceFromAndUnwrap(string, string, object[])"/></item>
+		/// </list>
+		/// </summary>
 		AppDomain_CreateInstanceFromAndUnwrap,
+		/// <summary>
+		/// <list type="table">
+		/// <item><see cref="System.Reflection.Assembly.CreateInstance(string)"/></item>
+		/// <item><see cref="System.Reflection.Assembly.CreateInstance(string, bool)"/></item>
+		/// <item><see cref="System.Reflection.Assembly.CreateInstance(string, bool, System.Reflection.BindingFlags, System.Reflection.Binder, object[], System.Globalization.CultureInfo, object[])"/></item>
+		/// </list>
+		/// </summary>
 		Assembly_CreateInstance,
+		/// <summary>
+		/// <see cref="System.Reflection.RuntimeReflectionExtensions.GetRuntimeEvent(System.Type, string)"/>
+		/// </summary>
 		RuntimeReflectionExtensions_GetRuntimeEvent,
+		/// <summary>
+		/// <see cref="System.Reflection.RuntimeReflectionExtensions.GetRuntimeField(System.Type, string)"/>
+		/// </summary>
 		RuntimeReflectionExtensions_GetRuntimeField,
+		/// <summary>
+		/// <see cref="System.Reflection.RuntimeReflectionExtensions.GetRuntimeMethod(System.Type, string, System.Type[])"/>
+		/// </summary>
 		RuntimeReflectionExtensions_GetRuntimeMethod,
+		/// <summary>
+		/// <see cref="System.Reflection.RuntimeReflectionExtensions.GetRuntimeProperty(System.Type, string)"/>
+		/// </summary>
 		RuntimeReflectionExtensions_GetRuntimeProperty,
+		/// <summary>
+		/// <see cref="System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(System.RuntimeTypeHandle)"/>
+		/// </summary>
 		RuntimeHelpers_RunClassConstructor,
+		/// <summary>
+		/// <see cref="System.Reflection.MethodInfo.MakeGenericMethod(System.Type[])"/>
+		/// </summary>
 		MethodInfo_MakeGenericMethod,
+		/// <summary>
+		/// <see cref="System.Nullable.GetUnderlyingType(System.Type)"/>
+		/// </summary>
 		Nullable_GetUnderlyingType
 	}
 }

--- a/src/linker/BannedSymbols.txt
+++ b/src/linker/BannedSymbols.txt
@@ -1,4 +1,6 @@
 T:Mono.Cecil.Cil.ILProcessor;Use LinkerILProcessor instead
 M:Mono.Cecil.TypeReference.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers instead
+M:Mono.Cecil.MethodReference.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers instead
+M:Mono.Cecil.ExportedType.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers instead
 P:Mono.Collections.Generic.Collection`1{Mono.Cecil.ParameterDefinition}.Item(System.Int32); use x
 P:Mono.Cecil.ParameterDefinitionCollection.Item(System.Int32); use x

--- a/src/linker/Linker.Steps/CodeRewriterStep.cs
+++ b/src/linker/Linker.Steps/CodeRewriterStep.cs
@@ -166,7 +166,7 @@ namespace Mono.Linker.Steps
 				if (baseType is null)
 					return body;
 
-				MethodReference base_ctor = baseType.GetDefaultInstanceConstructor ();
+				MethodReference base_ctor = baseType.GetDefaultInstanceConstructor (Context);
 				if (base_ctor == null)
 					throw new NotSupportedException ($"Cannot replace constructor for '{method.DeclaringType}' when no base default constructor exists");
 

--- a/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
+++ b/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
@@ -25,7 +25,7 @@ namespace Mono.Linker.Steps
 			if (!context.Annotations.TryGetPreservedMembers (exportedType, out TypePreserveMembers members))
 				return;
 
-			TypeDefinition type = exportedType.Resolve ();
+			TypeDefinition? type = context.TryResolve (exportedType);
 			if (type == null) {
 				if (!context.IgnoreUnresolved)
 					context.LogError (null, DiagnosticId.ExportedTypeCannotBeResolved, exportedType.Name);

--- a/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -191,7 +191,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected virtual TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly, XPathNavigator nav) => exported.Resolve ();
+		protected virtual TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly, XPathNavigator nav) => _context.TryResolve (exported);
 
 		void MatchType (TypeDefinition type, Regex regex, XPathNavigator nav)
 		{

--- a/src/linker/Linker.Steps/SealerStep.cs
+++ b/src/linker/Linker.Steps/SealerStep.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Mono.Cecil;
 using Mono.Collections.Generic;
 
@@ -106,7 +107,7 @@ namespace Mono.Linker.Steps
 				if (!type.IsSealed)
 					continue;
 
-				var bases = Annotations.GetBaseMethods (method);
+				var bases = Annotations.GetBaseMethods (method)?.Select (static x => x.Base).ToList ();
 				// Devirtualize if a method is not override to existing marked methods
 				if (!IsAnyMarked (bases))
 					method.IsVirtual = method.IsFinal = method.IsNewSlot = false;

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -69,7 +69,7 @@ namespace Mono.Linker.Steps
 				case AssemblyAction.CopyUsed:
 				case AssemblyAction.Link:
 				case AssemblyAction.Save:
-					bool changed = AssemblyReferencesCorrector.SweepAssemblyReferences (assembly);
+					bool changed = AssemblyReferencesCorrector.SweepAssemblyReferences (assembly, Context);
 					if (changed && action == AssemblyAction.CopyUsed)
 						Annotations.SetAction (assembly, AssemblyAction.Save);
 					break;
@@ -174,7 +174,7 @@ namespace Mono.Linker.Steps
 				AssemblyAction assemblyAction = AssemblyAction.Copy;
 				if (SweepTypeForwarders (assembly)) {
 					// Need to sweep references, in case sweeping type forwarders removed any
-					AssemblyReferencesCorrector.SweepAssemblyReferences (assembly);
+					AssemblyReferencesCorrector.SweepAssemblyReferences (assembly, Context);
 					assemblyAction = AssemblyAction.Save;
 				}
 
@@ -194,7 +194,7 @@ namespace Mono.Linker.Steps
 			case AssemblyAction.Save:
 				if (SweepTypeForwarders (assembly)) {
 					// Need to sweep references, in case sweeping type forwarders removed any
-					AssemblyReferencesCorrector.SweepAssemblyReferences (assembly);
+					AssemblyReferencesCorrector.SweepAssemblyReferences (assembly, Context);
 				}
 				break;
 			}
@@ -242,7 +242,7 @@ namespace Mono.Linker.Steps
 			}
 
 			if (SweepTypeForwarders (assembly) || updateScopes)
-				AssemblyReferencesCorrector.SweepAssemblyReferences (assembly);
+				AssemblyReferencesCorrector.SweepAssemblyReferences (assembly, Context);
 		}
 
 		bool IsMarkedAssembly (AssemblyDefinition assembly)
@@ -460,7 +460,7 @@ namespace Mono.Linker.Steps
 				//	ov is in a `link` scope and is unmarked
 				//		ShouldRemove returns true if the method is unmarked, but we also We need to make sure the override is in a link scope.
 				//		Only things in a link scope are marked, so ShouldRemove is only valid for items in a `link` scope.
-				if (method.Overrides[i].Resolve () is not MethodDefinition ov || ov.DeclaringType is null || (IsLinkScope (ov.DeclaringType.Scope) && ShouldRemove (ov)))
+				if (Context.TryResolve (method.Overrides[i]) is not MethodDefinition ov || ov.DeclaringType is null || (IsLinkScope (ov.DeclaringType.Scope) && ShouldRemove (ov)))
 					method.Overrides.RemoveAt (i);
 				else
 					i++;
@@ -570,13 +570,16 @@ namespace Mono.Linker.Steps
 
 			bool changedAnyScopes;
 
-			AssemblyReferencesCorrector (AssemblyDefinition assembly) : base (assembly)
+			readonly LinkContext _context;
+
+			AssemblyReferencesCorrector (AssemblyDefinition assembly, LinkContext context) : base (assembly)
 			{
 				this.importer = new DefaultMetadataImporter (assembly.MainModule);
+				this._context = context;
 				changedAnyScopes = false;
 			}
 
-			public static bool SweepAssemblyReferences (AssemblyDefinition assembly)
+			public static bool SweepAssemblyReferences (AssemblyDefinition assembly, LinkContext context)
 			{
 				//
 				// We used to run over list returned by GetTypeReferences but
@@ -586,7 +589,7 @@ namespace Mono.Linker.Steps
 				//
 				assembly.MainModule.AssemblyReferences.Clear ();
 
-				var arc = new AssemblyReferencesCorrector (assembly);
+				var arc = new AssemblyReferencesCorrector (assembly, context);
 				arc.Process ();
 
 				return arc.changedAnyScopes;
@@ -627,7 +630,7 @@ namespace Mono.Linker.Steps
 
 			protected override void ProcessExportedType (ExportedType exportedType)
 			{
-				TypeDefinition td = exportedType.Resolve ();
+				TypeDefinition? td = _context.TryResolve (exportedType);
 				if (td == null) {
 					// Forwarded type cannot be resolved but it was marked
 					// linker is running in --skip-unresolved true mode

--- a/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
+++ b/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
@@ -13,11 +13,11 @@ namespace Mono.Linker.Steps
 		{
 			var annotations = Context.Annotations;
 			foreach (var method in annotations.VirtualMethodsWithAnnotationsToValidate) {
-				var baseMethods = annotations.GetBaseMethods (method);
-				if (baseMethods != null) {
-					foreach (var baseMethod in baseMethods) {
-						annotations.FlowAnnotations.ValidateMethodAnnotationsAreSame (method, baseMethod);
-						ValidateMethodRequiresUnreferencedCodeAreSame (method, baseMethod);
+				var baseOverrideInformations = annotations.GetBaseMethods (method);
+				if (baseOverrideInformations != null) {
+					foreach (var baseOv in baseOverrideInformations) {
+						annotations.FlowAnnotations.ValidateMethodAnnotationsAreSame (method, baseOv.Base);
+						ValidateMethodRequiresUnreferencedCodeAreSame (method, baseOv.Base);
 					}
 				}
 

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -446,9 +446,14 @@ namespace Mono.Linker
 			return TypeMapInfo.GetDefaultInterfaceImplementations (method);
 		}
 
-		public List<MethodDefinition>? GetBaseMethods (MethodDefinition method)
+		public List<OverrideInformation>? GetBaseMethods (MethodDefinition method)
 		{
 			return TypeMapInfo.GetBaseMethods (method);
+		}
+
+		public List<(TypeDefinition Implementor, InterfaceImplementation InterfaceImplementation)>? GetInterfaceImplementors (TypeDefinition type)
+		{
+			return TypeMapInfo.GetInterfaceImplementors (type);
 		}
 
 		public List<MethodDefinition>? GetPreservedMethods (TypeDefinition type)

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -755,6 +755,9 @@ namespace Mono.Linker
 		readonly Dictionary<TypeReference, TypeDefinition?> typeresolveCache = new ();
 		readonly Dictionary<ExportedType, TypeDefinition?> exportedTypeResolveCache = new ();
 
+		/// <summary>
+		/// Tries to resolve the MethodReference to a MethodDefinition and logs a warning if it can't
+		/// </summary>
 		public MethodDefinition? Resolve (MethodReference methodReference)
 		{
 			if (methodReference is MethodDefinition methodDefinition)
@@ -766,7 +769,9 @@ namespace Mono.Linker
 			if (methodresolveCache.TryGetValue (methodReference, out MethodDefinition? md))
 				return md;
 
+#pragma warning disable RS0030 // Cecil's resolve is banned -- this provides the wrapper
 			md = methodReference.Resolve ();
+#pragma warning restore RS0030
 			if (md == null && !IgnoreUnresolved)
 				ReportUnresolved (methodReference);
 
@@ -774,6 +779,9 @@ namespace Mono.Linker
 			return md;
 		}
 
+		/// <summary>
+		/// Tries to resolve the MethodReference to a MethodDefinition and returns null if it can't
+		/// </summary>
 		public MethodDefinition? TryResolve (MethodReference methodReference)
 		{
 			if (methodReference is MethodDefinition methodDefinition)
@@ -785,11 +793,16 @@ namespace Mono.Linker
 			if (methodresolveCache.TryGetValue (methodReference, out MethodDefinition? md))
 				return md;
 
+#pragma warning disable RS0030 // Cecil's resolve is banned -- this method provides the wrapper
 			md = methodReference.Resolve ();
+#pragma warning restore RS0030
 			methodresolveCache.Add (methodReference, md);
 			return md;
 		}
 
+		/// <summary>
+		/// Tries to resolve the FieldReference to a FieldDefinition and logs a warning if it can't
+		/// </summary>
 		public FieldDefinition? Resolve (FieldReference fieldReference)
 		{
 			if (fieldReference is FieldDefinition fieldDefinition)
@@ -809,6 +822,9 @@ namespace Mono.Linker
 			return fd;
 		}
 
+		/// <summary>
+		/// Tries to resolve the FieldReference to a FieldDefinition and returns null if it can't
+		/// </summary>
 		public FieldDefinition? TryResolve (FieldReference fieldReference)
 		{
 			if (fieldReference is FieldDefinition fieldDefinition)
@@ -825,6 +841,9 @@ namespace Mono.Linker
 			return fd;
 		}
 
+		/// <summary>
+		/// Tries to resolve the TypeReference to a TypeDefinition and logs a warning if it can't
+		/// </summary>
 		public TypeDefinition? Resolve (TypeReference typeReference)
 		{
 			if (typeReference is TypeDefinition typeDefinition)
@@ -852,6 +871,9 @@ namespace Mono.Linker
 			return td;
 		}
 
+		/// <summary>
+		/// Tries to resolve the TypeReference to a TypeDefinition and returns null if it can't
+		/// </summary>
 		public TypeDefinition? TryResolve (TypeReference typeReference)
 		{
 			if (typeReference is TypeDefinition typeDefinition)
@@ -882,6 +904,9 @@ namespace Mono.Linker
 			return td;
 		}
 
+		/// <summary>
+		/// Tries to resolve the ExportedType to a TypeDefinition and logs a warning if it can't
+		/// </summary>
 		public TypeDefinition? Resolve (ExportedType et)
 		{
 			if (TryResolve (et) is not TypeDefinition td) {
@@ -891,12 +916,17 @@ namespace Mono.Linker
 			return td;
 		}
 
+		/// <summary>
+		/// Tries to resolve the ExportedType to a TypeDefinition and returns null if it can't
+		/// </summary>
 		public TypeDefinition? TryResolve (ExportedType et)
 		{
 			if (exportedTypeResolveCache.TryGetValue (et, out var td)) {
 				return td;
 			}
+#pragma warning disable RS0030 // Cecil's Resolve is banned -- this method provides the wrapper
 			td = et.Resolve ();
+#pragma warning restore RS0030
 			exportedTypeResolveCache.Add (et, td);
 			return td;
 		}
@@ -929,9 +959,9 @@ namespace Mono.Linker
 				LogError (string.Format (SharedStrings.FailedToResolveTypeElementMessage, typeReference.GetDisplayName ()), (int) DiagnosticId.FailedToResolveMetadataElement);
 		}
 
-		protected virtual void ReportUnresolved (ExportedType typeReference)
+		protected virtual void ReportUnresolved (ExportedType et)
 		{
-			LogError (string.Format (SharedStrings.FailedToResolveTypeElementMessage, typeReference.Name), (int) DiagnosticId.FailedToResolveMetadataElement);
+			LogError (string.Format (SharedStrings.FailedToResolveTypeElementMessage, et.Name), (int) DiagnosticId.FailedToResolveMetadataElement);
 		}
 	}
 

--- a/src/linker/Linker/MarkingHelpers.cs
+++ b/src/linker/Linker/MarkingHelpers.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker
 			if (typeToMatch == null || assembly == null)
 				return;
 
-			if (assembly.MainModule.GetMatchingExportedType (typeToMatch, out var exportedType))
+			if (assembly.MainModule.GetMatchingExportedType (typeToMatch, _context, out var exportedType))
 				MarkExportedType (exportedType, assembly.MainModule, reason, origin);
 		}
 
@@ -40,7 +40,7 @@ namespace Mono.Linker
 				var assembly = _context.Resolve (typeReference.Scope);
 				if (assembly != null &&
 					_context.TryResolve (typeReference) is TypeDefinition typeDefinition &&
-					assembly.MainModule.GetMatchingExportedType (typeDefinition, out var exportedType))
+					assembly.MainModule.GetMatchingExportedType (typeDefinition, _context, out var exportedType))
 					MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, typeReference), origin);
 			}
 		}

--- a/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/linker/Linker/MethodReferenceExtensions.cs
@@ -10,6 +10,7 @@ namespace Mono.Linker
 {
 	public static class MethodReferenceExtensions
 	{
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("ApiDesign", "RS0030:Do not used banned APIs", Justification = "MethodReference.Resolve is banned for performance reasons. GetDisplayName should be a really cold path and shouldn't require a context to call.")]
 		public static string GetDisplayName (this MethodReference method)
 		{
 			var sb = new System.Text.StringBuilder ();

--- a/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -15,17 +15,18 @@ namespace Mono.Linker
 				(module.Attributes & ModuleAttributes.ILLibrary) != 0;
 		}
 
-		public static bool GetMatchingExportedType (this ModuleDefinition module, TypeDefinition typeDefinition, [NotNullWhen (true)] out ExportedType? exportedType)
+		public static bool GetMatchingExportedType (this ModuleDefinition module, TypeDefinition typeDefinition, LinkContext context, [NotNullWhen (true)] out ExportedType? exportedType)
 		{
 			exportedType = null;
 			if (!module.HasExportedTypes)
 				return false;
 
-			foreach (var et in module.ExportedTypes)
-				if (et.Resolve () == typeDefinition) {
+			foreach (var et in module.ExportedTypes) {
+				if (context.TryResolve (et) == typeDefinition) {
 					exportedType = et;
 					return true;
 				}
+			}
 
 			return false;
 		}

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -305,13 +305,13 @@ namespace Mono.Linker
 			return fullTypeName.Replace ('+', '/');
 		}
 
-		public static bool HasDefaultConstructor (this TypeDefinition type)
+		public static bool HasDefaultConstructor (this TypeDefinition type, LinkContext context)
 		{
 			foreach (var m in type.Methods) {
 				if (m.HasParameters)
 					continue;
 
-				var definition = m.Resolve ();
+				var definition = context.Resolve (m);
 				if (definition?.IsDefaultConstructor () == true)
 					return true;
 			}
@@ -319,14 +319,14 @@ namespace Mono.Linker
 			return false;
 		}
 
-		public static MethodReference GetDefaultInstanceConstructor (this TypeDefinition type)
+		public static MethodReference GetDefaultInstanceConstructor (this TypeDefinition type, LinkContext context)
 		{
 			foreach (var m in type.Methods) {
 				if (m.HasParameters)
 					continue;
 
-				var definition = m.Resolve ();
-				if (!definition.IsDefaultConstructor ())
+				var definition = context.Resolve (m);
+				if (definition?.IsDefaultConstructor () != true)
 					continue;
 
 				return m;

--- a/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
@@ -54,7 +54,6 @@ namespace Mono.Linker.Tests.Cases.Attributes
 #if NETCOREAPP
 	[Kept]
 	[KeptMember (".ctor()")]
-	// Interface is not from a 'link' scope, so it is kept
 	[KeptInterface (typeof (IDynamicInterfaceCastable))]
 	class Foo : IDynamicInterfaceCastable
 	{
@@ -76,7 +75,6 @@ namespace Mono.Linker.Tests.Cases.Attributes
 
 	[Kept]
 	[KeptMember (".ctor()")]
-	// Interface is not from a 'link' scope, so it is kept
 	[KeptInterface (typeof (IDynamicInterfaceCastable))]
 	class DynamicCastableImplementedInOtherAssembly : IDynamicInterfaceCastable
 	{

--- a/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
@@ -54,6 +54,8 @@ namespace Mono.Linker.Tests.Cases.Attributes
 #if NETCOREAPP
 	[Kept]
 	[KeptMember (".ctor()")]
+	// Interface is not from a 'link' scope, so it is kept
+	[KeptInterface (typeof (IDynamicInterfaceCastable))]
 	class Foo : IDynamicInterfaceCastable
 	{
 		[Kept]
@@ -74,6 +76,8 @@ namespace Mono.Linker.Tests.Cases.Attributes
 
 	[Kept]
 	[KeptMember (".ctor()")]
+	// Interface is not from a 'link' scope, so it is kept
+	[KeptInterface (typeof (IDynamicInterfaceCastable))]
 	class DynamicCastableImplementedInOtherAssembly : IDynamicInterfaceCastable
 	{
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/InterfaceVariants.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/InterfaceVariants.cs
@@ -21,14 +21,19 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces
 			t = typeof (UninstantiatedPublicClassWithPrivateInterface);
 			t = typeof (ImplementsUsedStaticInterface.InterfaceMethodUnused);
 
-			ImplementsUnusedStaticInterface.Test (); ;
+			ImplementsUnusedStaticInterface.Test ();
 			GenericMethodThatCallsInternalStaticInterfaceMethod
 				<ImplementsUsedStaticInterface.InterfaceMethodUsedThroughInterface> ();
 			// Use all public interfaces - they're marked as public only to denote them as "used"
 			typeof (IPublicInterface).RequiresPublicMethods ();
 			typeof (IPublicStaticInterface).RequiresPublicMethods ();
-			var ___ = new InstantiatedClassWithInterfaces ();
+			_ = new InstantiatedClassWithInterfaces ();
+			MarkIFormattable (null);
 		}
+
+		[Kept]
+		static void MarkIFormattable (IFormattable x)
+		{ }
 
 		[Kept]
 		internal static void GenericMethodThatCallsInternalStaticInterfaceMethod<T> () where T : IStaticInterfaceUsed
@@ -115,7 +120,6 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces
 
 		// Interfaces are kept despite being uninstantiated because it is relevant to variant casting
 		[Kept]
-		[KeptInterface (typeof (IEnumerator))]
 		[KeptInterface (typeof (IPublicInterface))]
 		[KeptInterface (typeof (IPublicStaticInterface))]
 		[KeptInterface (typeof (ICopyLibraryInterface))]
@@ -152,18 +156,12 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces
 			static void IInternalStaticInterface.ExplicitImplementationInternalStaticInterfaceMethod () { }
 
 
-			[Kept]
-			[ExpectBodyModified]
 			bool IEnumerator.MoveNext () { throw new PlatformNotSupportedException (); }
 
-			[Kept]
 			object IEnumerator.Current {
-				[Kept]
-				[ExpectBodyModified]
 				get { throw new PlatformNotSupportedException (); }
 			}
 
-			[Kept]
 			void IEnumerator.Reset () { }
 
 			[Kept]
@@ -199,7 +197,6 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces
 		}
 
 		[Kept]
-		[KeptInterface (typeof (IEnumerator))]
 		[KeptInterface (typeof (IPublicInterface))]
 		[KeptInterface (typeof (IPublicStaticInterface))]
 		[KeptInterface (typeof (ICopyLibraryInterface))]
@@ -236,13 +233,10 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces
 
 			static void IInternalStaticInterface.ExplicitImplementationInternalStaticInterfaceMethod () { }
 
-			[Kept]
 			bool IEnumerator.MoveNext () { throw new PlatformNotSupportedException (); }
 
-			[Kept]
-			object IEnumerator.Current { [Kept] get { throw new PlatformNotSupportedException (); } }
+			object IEnumerator.Current { get { throw new PlatformNotSupportedException (); } }
 
-			[Kept]
 			void IEnumerator.Reset () { }
 
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/InterfaceVariants.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/InterfaceVariants.cs
@@ -113,6 +113,7 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces
 			}
 		}
 
+		// Interfaces are kept despite being uninstantiated because it is relevant to variant casting
 		[Kept]
 		[KeptInterface (typeof (IEnumerator))]
 		[KeptInterface (typeof (IPublicInterface))]

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/UnusedInterfacesInPreservedScope.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/UnusedInterfacesInPreservedScope.cs
@@ -37,10 +37,15 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
 			public int InstanceMethod () => 0;
 		}
 
+		// Keep MyType without marking it relevant to variant casting
+		[Kept]
+		static void KeepMyType (MyType x)
+		{ }
+
 		[Kept]
 		static void Test ()
 		{
-			var x = typeof (MyType); // The only use of MyType
+			KeepMyType (null);
 		}
 	}
 }


### PR DESCRIPTION
Builds off of https://github.com/dotnet/linker/pull/3073.

Bans MethodReference.Resolve and ExportedType.Resolve and recommend LinkContext.Resolve instead.

Adds a cache on LinkContext for resolving ExportedTypes and replaces calls to Cecil's Resolve.

Replaces some calls to MethodReference.Resolve.

Together with https://github.com/dotnet/linker/pull/3073, performance improves to better than before the virtual method regression in August.

Trimmer CPU sec on ASP.Net benchmarks build:
27325 before the regression related to https://github.com/dotnet/linker/issues/3067
87310 in main
23520 after this change