### PR TITLE
Update ILLink.RoslynAnalyzer.csproj Microsoft.CodeAnalysis.CSharp version

### DIFF
--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -18,7 +18,7 @@
     <!-- The repo CodeAnalyis version is ahead of what is shipped with Visual Studio, so that version breaks the analyzers when used in .Net Framework builds -->
     <!-- Once Visual Studio ships with a version >= $(MicrosoftCodeAnalysisVersion), this should be changed to use the property -->
     <!-- Source-build must always build with the $(MicrosoftCodeAnalysisVersion) to prevent introducing prebuilts. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0-2.final" PrivateAssets="all" />
+    <PackageReference Condition="'$(DotNetBuildFromSource)' != 'true'" Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0-2.final" PrivateAssets="all" />
     <PackageReference Condition="'$(DotNetBuildFromSource)' == 'true'" Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
     <PackageReference Condition="'$(DotNetBuildFromSource)' != 'true'" Include="StaticCs" Version="$(StaticCsVersion)">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -16,8 +16,10 @@
   <ItemGroup>
     <None Include="Microsoft.NET.ILLink.Analyzers.props" CopyToOutputDirectory="PreserveNewest" />
     <!-- The repo CodeAnalyis version is ahead of what is shipped with Visual Studio, so that version breaks the analyzers when used in .Net Framework builds -->
-    <!-- Once Visual Studio ships with a version >= $MicrosoftCodeAnalysisVersion, this should be changed to use the property -->
+    <!-- Once Visual Studio ships with a version >= $(MicrosoftCodeAnalysisVersion), this should be changed to use the property -->
+    <!-- Source-build must always build with the $(MicrosoftCodeAnalysisVersion) to prevent introducing prebuilts. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0-2.final" PrivateAssets="all" />
+    <PackageReference Condition="'$(DotNetBuildFromSource)' == 'true'" Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
     <PackageReference Condition="'$(DotNetBuildFromSource)' != 'true'" Include="StaticCs" Version="$(StaticCsVersion)">
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>contentfiles</ExcludeAssets> <!-- We include our own copy of the ClosedAttribute to work in source build -->


### PR DESCRIPTION
The hardcoded Microsoft.CodeAnalysis.CSharp version reference in ILLink.RoslynAnalyzer.csproj causes a prebuilt for source-build.  We should be referencing the versions.props property to keep the reference to the latest version for source-build.