### PR TITLE
Don't mark override of abstract base if the override's declaring type is not marked

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -723,6 +723,8 @@ namespace Mono.Linker.Steps
 		// TODO: Move interface method marking logic here https://github.com/dotnet/linker/issues/3090
 		bool ShouldMarkOverrideForBase (OverrideInformation overrideInformation)
 		{
+			if (!Annotations.IsMarked (overrideInformation.Override.DeclaringType))
+				return false;
 			if (overrideInformation.IsOverrideOfInterfaceMember) {
 				_interfaceOverrides.Add ((overrideInformation, ScopeStack.CurrentScope));
 				return false;

--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Inheritance.VirtualMethodsTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Inheritance.VirtualMethodsTests.g.cs
@@ -28,6 +28,12 @@ namespace ILLink.RoslynAnalyzer.Tests.Inheritance
 		}
 
 		[Fact]
+		public Task OverrideInUnmarkedClassIsRemoved ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task UnusedTypeWithOverrideOfVirtualMethodIsRemoved ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/OverrideOfAbstractInUnmarkedClassIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/OverrideOfAbstractInUnmarkedClassIsRemoved.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods
+{
+	public class OverrideInUnmarkedClassIsRemoved
+	{
+		[Kept]
+		public static void Main ()
+		{
+			MarkedBase x = new MarkedDerived ();
+			x.Method ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		abstract class MarkedBase
+		{
+			[Kept]
+			public abstract int Method ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (MarkedBase))]
+		class MarkedDerived : MarkedBase
+		{
+			[Kept]
+			public override int Method () => 1;
+		}
+
+		class UnmarkedDerived : MarkedBase
+		{
+			public override int Method () => 1;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/OverrideOfAbstractInUnmarkedClassIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/OverrideOfAbstractInUnmarkedClassIsRemoved.cs
@@ -11,7 +11,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods
 {
-	public class OverrideInUnmarkedClassIsRemoved
+	public class OverrideOfAbstractInUnmarkedClassIsRemoved
 	{
 		[Kept]
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/OverrideOfAbstractInUnmarkedClassIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/OverrideOfAbstractInUnmarkedClassIsRemoved.cs
@@ -18,6 +18,12 @@ namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods
 		{
 			MarkedBase x = new MarkedDerived ();
 			x.Method ();
+
+			UsedSecondLevelTypeWithAbstractBase y = new ();
+			y.Method ();
+
+			UsedSecondLevelType z = new ();
+			z.Method ();
 		}
 
 		[Kept]
@@ -38,6 +44,52 @@ namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods
 		}
 
 		class UnmarkedDerived : MarkedBase
+		{
+			public override int Method () => 1;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (MarkedBase))]
+		class UnusedIntermediateType : MarkedBase
+		{
+			[Kept]
+			public override int Method () => 1;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (UnusedIntermediateType))]
+		class UsedSecondLevelType : UnusedIntermediateType
+		{
+			[Kept]
+			public override int Method () => 1;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (MarkedBase))]
+		abstract class UnusedIntermediateTypeWithAbstractOverride : MarkedBase
+		{
+			[Kept]
+			public abstract override int Method ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (UnusedIntermediateTypeWithAbstractOverride))]
+		class UsedSecondLevelTypeWithAbstractBase : UnusedIntermediateTypeWithAbstractOverride
+		{
+			[Kept]
+			public override int Method () => 1;
+		}
+
+		class UnusedSecondLevelTypeWithAbstractBase : UnusedIntermediateTypeWithAbstractOverride
+		{
+			public override int Method () => 1;
+		}
+
+		class UnusedSecondLevelType : UnusedIntermediateType
 		{
 			public override int Method () => 1;
 		}


### PR DESCRIPTION
Adds a check to ensure the declaring type is marked in `ShouldMarkOverrideForBase`.

Adds a test to check for this behavior.

Should fix the issues in linker flow to sdk at https://github.com/dotnet/sdk/pull/28796.

Before the change, in OverrideInUnmarkedClassIsRemoved we would mark `UnmarkedDerived.Method` and `UnmarkedDerived` because `MarkedBase.Method` was marked and `abstract`.