### PR TITLE
Enable CodeQL with TSA

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\mono",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
+    "repositoryName": "linker",
+    "codebaseName": "linker"
+}

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -2,7 +2,7 @@
     "instanceUrl": "https://devdiv.visualstudio.com/",
     "template": "TFSDEVDIV",
     "projectName": "DEVDIV",
-    "areaPath": "DevDiv\\mono",
+    "areaPath": "DevDiv\\NET Runtime\\Managed Linker",
     "iterationPath": "DevDiv",
     "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
     "repositoryName": "linker",

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -28,6 +28,10 @@ variables:
     value: ${{ format('{0} /p:OfficialBuildId=$(Build.BuildNumber) /p:Test=false /p:IntegrationTest=false', variables['_BuildArgs']) }}
   # Provide HelixApiAccessToken for telemetry
   - group: DotNet-HelixApi-Access
+  - name: Codeql.Enabled
+    value: True
+  - name: Codeql.TSAEnabled
+    value: True
 
 stages:
 - stage: build


### PR DESCRIPTION
CodeQL is a static analysis tool that is able to scan source code to help detect security vulnerabilities. In dotnet/linker, there already exists auto-injection of CodeQL's init and finalize tasks within the official default pipeline.

This PR does the following:
Enables CodeQL
Enable TSA with CodeQL