### PR TITLE
Increase build versions again

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETSdkILPackageVersion)</MicrosoftNETCoreILAsmVersion>
     <!-- SRM version should match the SDK version at https://github.com/dotnet/sdk/blob/master/eng/Versions.props -->
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
-    <MicrosoftBuildFrameworkVersion>17.0.0</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildFrameworkVersion>17.2.2</MicrosoftBuildFrameworkVersion>
     <MicrosoftDotNetApiCompatVersion>6.0.0-beta.22517.1</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21271.1</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
@@ -24,7 +24,7 @@
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.*</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftNETTestSdkVersion>16.11.0</MicrosoftNETTestSdkVersion>
-    <NuGetProtocolVersion>5.8.0</NuGetProtocolVersion>
+    <NuGetProtocolVersion>6.3.0</NuGetProtocolVersion>
     <!-- This controls the version of the cecil package, or the version of cecil in the project graph
          when we build the cecil submodule. The reference assembly package will depend on this version of cecil.
          Keep this in sync with ProjectInfo.cs in the submodule. -->


### PR DESCRIPTION
Looks like the new builds weren't quite new enough. I tracked down the MSBuild reference and it looks like it's a transitive dependency on netstandard2.0 that's the problem. 17.2.2 should remove that dependency and still be supported for all net6.0 platforms.