### PR TITLE
Use ContainingType instead of ContainingSymbol in GetReferenceKind

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/ParameterProxy.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/ParameterProxy.cs
@@ -17,7 +17,7 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		public partial ReferenceKind GetReferenceKind () =>
 			IsImplicitThis
-			? ((ITypeSymbol) Method.Method.ContainingSymbol).IsValueType
+			? Method.Method.ContainingType.IsValueType
 				? ReferenceKind.Ref
 				: ReferenceKind.None
 			: Method.Method.Parameters[MetadataIndex].RefKind switch {


### PR DESCRIPTION
Expecting IMethodSymbol.ContainingSymbol to be an ITypeSymbol is causing a type cast exception for local methods that require dataflow analysis (https://github.com/dotnet/linker/issues/3106), and it makes more sense to use ContainingType. I haven't been able to repro the issue (I've had problems building asp.net), but it seems pretty clear this is the fix.