### PR TITLE
Tests for TypeInfo intrinsics

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
@@ -26,6 +26,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task TypeInfoIntrinsics ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task UnsafeDataFlow ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Inheritance.VirtualMethodsTests.g.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Inheritance.VirtualMethodsTests.g.cs
@@ -28,7 +28,7 @@ namespace ILLink.RoslynAnalyzer.Tests.Inheritance
 		}
 
 		[Fact]
-		public Task OverrideInUnmarkedClassIsRemoved ()
+		public Task OverrideOfAbstractInUnmarkedClassIsRemoved ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/TypeInfoCalls.il
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/TypeInfoCalls.il
@@ -1,0 +1,112 @@
+// Metadata version: v4.0.30319
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 7:0:0:0
+}
+.assembly 'library'
+{
+  .hash algorithm 0x00008004
+  .ver 1:0:0:0
+}
+.module library.dll
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public abstract auto ansi sealed beforefieldinit Library.TypeInfoCalls
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig static void  TestGetConstructors(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  callvirt   instance class [System.Runtime]System.Reflection.ConstructorInfo[] [System.Runtime]System.Reflection.TypeInfo::GetConstructors()
+    IL_0007:  pop
+    IL_0008:  ret
+  }
+
+  .method public hidebysig static void  TestGetMethods(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  callvirt   instance class [System.Runtime]System.Reflection.MethodInfo[] [System.Runtime]System.Reflection.TypeInfo::GetMethods()
+    IL_0007:  pop
+    IL_0008:  ret
+  }
+
+  .method public hidebysig static void  TestGetFields(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  callvirt   instance class [System.Runtime]System.Reflection.FieldInfo[] [System.Runtime]System.Reflection.TypeInfo::GetFields()
+    IL_0007:  pop
+    IL_0008:  ret
+  }
+
+  .method public hidebysig static void  TestGetProperties(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  callvirt   instance class [System.Runtime]System.Reflection.PropertyInfo[] [System.Runtime]System.Reflection.TypeInfo::GetProperties()
+    IL_0007:  pop
+    IL_0008:  ret
+  }
+
+  .method public hidebysig static void  TestGetEvents(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  callvirt   instance class [System.Runtime]System.Reflection.EventInfo[] [System.Runtime]System.Reflection.TypeInfo::GetEvents()
+    IL_0007:  pop
+    IL_0008:  ret
+  }
+
+  .method public hidebysig static void  TestGetNestedTypes(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  callvirt   instance class [System.Runtime]System.Type[] [System.Runtime]System.Reflection.TypeInfo::GetNestedTypes()
+    IL_0007:  pop
+    IL_0008:  ret
+  }
+
+  .method public hidebysig static void  TestGetField(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldstr      "unknown"
+    IL_0007:  callvirt   instance class [System.Runtime]System.Reflection.FieldInfo [System.Runtime]System.Reflection.TypeInfo::GetField(string)
+    IL_000c:  pop
+    IL_000d:  ret
+  }
+
+  .method public hidebysig static void  TestGetProperty(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldstr      "unknown"
+    IL_0007:  callvirt   instance class [System.Runtime]System.Reflection.PropertyInfo [System.Runtime]System.Reflection.TypeInfo::GetProperty(string)
+    IL_000c:  pop
+    IL_000d:  ret
+  }
+
+  .method public hidebysig static void  TestGetEvent(class [System.Runtime]System.Reflection.TypeInfo 'type') cil managed
+  {
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldstr      "unknown"
+    IL_0007:  callvirt   instance class [System.Runtime]System.Reflection.EventInfo [System.Runtime]System.Reflection.TypeInfo::GetEvent(string)
+    IL_000c:  pop
+    IL_000d:  ret
+  }
+
+} // end of class Library.TypeInfoCalls

--- a/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/TypeInfoCalls.il
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/TypeInfoCalls.il
@@ -2,7 +2,6 @@
 .assembly extern System.Runtime
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 7:0:0:0
 }
 .assembly 'library'
 {

--- a/test/Mono.Linker.Tests.Cases/DataFlow/TypeInfoIntrinsics.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/TypeInfoIntrinsics.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+	//   - so the main validation is done by the ExpectedWarning attributes.
+	[SkipKeptItemsValidation]
+	[Define ("IL_ASSEMBLY_AVAILABLE")]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/TypeInfoCalls.il" })]
+
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetConstructors(TypeInfo)")]
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetMethods(TypeInfo)")]
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetFields(TypeInfo)")]
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetProperties(TypeInfo)")]
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetEvents(TypeInfo)")]
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetNestedTypes(TypeInfo)")]
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetField(TypeInfo)")]
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetProperty(TypeInfo)")]
+	[LogContains ("IL2070: Library.TypeInfoCalls.TestGetEvent(TypeInfo)")]
+	public class TypeInfoIntrinsics
+	{
+		public static void Main ()
+		{
+#if IL_ASSEMBLY_AVAILABLE
+			Library.TypeInfoCalls.TestGetConstructors(typeof(string).GetTypeInfo());
+			Library.TypeInfoCalls.TestGetMethods(typeof(string).GetTypeInfo());
+			Library.TypeInfoCalls.TestGetFields(typeof(string).GetTypeInfo());
+			Library.TypeInfoCalls.TestGetProperties(typeof(string).GetTypeInfo());
+			Library.TypeInfoCalls.TestGetEvents(typeof(string).GetTypeInfo());
+			Library.TypeInfoCalls.TestGetNestedTypes(typeof(string).GetTypeInfo());
+			Library.TypeInfoCalls.TestGetField(typeof(string).GetTypeInfo());
+			Library.TypeInfoCalls.TestGetProperty(typeof(string).GetTypeInfo());
+			Library.TypeInfoCalls.TestGetEvent(typeof(string).GetTypeInfo());
+#endif
+		}
+	}
+}


### PR DESCRIPTION
This is a port of the tests from https://github.com/dotnet/linker/pull/3109 (the fix is not needed since the code now works differently and doesn't have the problem)