### PR TITLE
Add test case for #3112 with pseudo-circular reference when base provides iface method

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/BaseProvidesInterfaceMethodCircularReference.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/BaseProvidesInterfaceMethodCircularReference.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.Interfaces.BaseProvidesInterfaceEdgeCase.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.BaseProvidesInterfaceEdgeCase
+{
+	/// <summary>
+	/// Reproduces the issue found in https://github.com/dotnet/linker/issues/3112.
+	/// <see cref="Derived1"/> derives from <see cref="Base"/> and uses <see cref="Base"/>'s method to implement <see cref="IFoo"/>, 
+	/// creating a psuedo-circular assembly reference (but not quite since <see cref="Base"/> doesn't implement IFoo itself).
+	/// In the linker, IsMethodNeededByInstantiatedTypeDueToPreservedScope would iterate through <see cref="Base"/>'s method's base methods,
+	/// and in the process would trigger the assembly of <see cref="IFoo"/> to be processed. Since that assembly also has <see cref="Derived2"/> that 
+	/// inherits from <see cref="Base"/> and implements <see cref="IBar"/> using <see cref="Base"/>'s methods, the linker adds 
+	/// <see cref="IBar"/>'s method as a base to <see cref="Base"/>'s method, which modifies the collection as it's being iterated, causing an exception.
+	/// </summary>
+	[SetupCompileBefore ("base.dll", new[] { "Dependencies/Base.cs" })] // Base Implements IFoo.Method (psuedo-reference to ifoo.dll)
+	[SetupCompileBefore ("ifoo.dll", new[] { "Dependencies/IFoo.cs" }, references: new[] { "base.dll" })] // Derived2 references base.dll (circular reference)
+	[SetupCompileBefore ("derived1.dll", new[] { "Dependencies/Derived1.cs" }, references: new[] { "ifoo.dll", "base.dll" })]
+	public class BaseProvidesInterfaceMethodCircularReference
+	{
+		[Kept]
+		public static void Main ()
+		{
+			_ = new Derived1 ();
+			Foo ();
+		}
+
+		[Kept]
+		public static void Foo ()
+		{
+			((IFoo) null).Method ();
+			object x = null;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/Base.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/Base.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.BaseProvidesInterfaceEdgeCase.Dependencies
+{
+	public class Base
+	{
+		public virtual void Method()
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/Base.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/Base.cs
@@ -7,9 +7,9 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.BaseProvidesInterfaceEd
 {
 	public class Base
 	{
-		public virtual void Method()
+		public virtual void Method ()
 		{
-			throw new NotImplementedException();
+			throw new NotImplementedException ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/Derived1.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/Derived1.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.BaseProvidesInterfaceEdgeCase.Dependencies
+{
+	public class Derived1 : Base, IFoo
+	{
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/IFoo.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/IFoo.cs
@@ -5,11 +5,11 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.BaseProvidesInterfaceEd
 {
 	public interface IFoo
 	{
-		void Method();
+		void Method ();
 	}
 	public interface IBar
 	{
-		void Method();
+		void Method ();
 	}
 	public class Derived2 : Base, IBar
 	{

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/IFoo.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/BaseProvidesInterfaceEdgeCase/Dependencies/IFoo.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.BaseProvidesInterfaceEdgeCase.Dependencies
+{
+	public interface IFoo
+	{
+		void Method();
+	}
+	public interface IBar
+	{
+		void Method();
+	}
+	public class Derived2 : Base, IBar
+	{
+	}
+}


### PR DESCRIPTION
Adds a minimal repro for #3112.

The scenario looks like this:

Types;
Base type B has method M.
Derived type D1 derives from B, and implements interface I1 with methods from B.
Derived type D2 derives from B, and implements interface I2 with methods from B.

Assembly A1 has B.
Assembly A2 has D1.
Assembly A3 has I1 and D2.
I2 can be in any assembly.

In the trimmer:
D1 is marked instantiated.
-> B is marked instantiated (as a base type)
-> D1's interfaces are marked, and the implementation methods are marked
-> B.M() is marked
-> I.M() is added as a base method for B.M()

Later, B.M() is passed to IsMethodNeededByInstantiatedTypeDueToPreservedScope()
-> Base methods of B.M() are iterated over
-> I.M() is one of the base methods, and is passed to IsMethodNeedeByTypeDueToPreservedScope()
-> Base methods of I.M() are required, triggering the entire assembly A3 to be mapped.
-> D2 is mapped
-> I2.M() is added as a base method of B.M() -- While base methods of B.M() is being iterated over


There is a psuedo-circular assembly reference with the way we build out TypeMapInfo
A1 (psuedo-)refers to A3 (when A2 is referenced) because B.M() impls I1.M()
A3 refers to A1 because D2 derives from B.

In main the same exact situation doesn't cause issues, and https://github.com/dotnet/linker/pull/3094 fixes this repro for .Net 7, but I don't think a similar situation is guaranteed to never happen. Since base methods can provide interface members, the list of base methods of a type is dependent on which assemblies have been processed by TypeMapInfo at the time GetBaseMethods is called.