### PR TITLE
Use new submodule URL for dotnet/cecil

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cecil"]
 	path = external/cecil
-	url = https://github.com/mono/cecil.git
+	url = https://github.com/dotnet/cecil.git


### PR DESCRIPTION
GitHub does a redirect but it's better to be consistent.