### PR TITLE
Improves GetDisplayName for types

### DIFF
--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -66,6 +66,7 @@ namespace Mono.Linker
 					break;
 				}
 
+				type = type.GetElementType ();
 				if (type.DeclaringType is not TypeReference declaringType)
 					break;
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -57,6 +57,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			linkedMembers.Remove ("System.Int32 System.Runtime.CompilerServices.RefSafetyRulesAttribute::Version");
 			linkedMembers.Remove ("System.Void System.Runtime.CompilerServices.RefSafetyRulesAttribute::.ctor(System.Int32)");
 
+			// Workaround for compiler injected attribute to describe the language version
+			verifiedGeneratedTypes.Add ("Microsoft.CodeAnalysis.EmbeddedAttribute");
+			verifiedGeneratedTypes.Add ("System.Runtime.CompilerServices.RefSafetyRulesAttribute");
+
 			var membersToAssert = originalAssembly.MainModule.Types;
 			foreach (var originalMember in membersToAssert) {
 				if (originalMember is TypeDefinition td) {
@@ -99,10 +103,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		protected virtual void VerifyTypeDefinition (TypeDefinition original, TypeDefinition linked)
 		{
-			// Workaround for compiler injected attribute to describe the language version
-			verifiedGeneratedTypes.Add ("Microsoft.CodeAnalysis.EmbeddedAttribute");
-			verifiedGeneratedTypes.Add ("System.Runtime.CompilerServices.RefSafetyRulesAttribute");
-
 			if (linked != null && verifiedGeneratedTypes.Contains (linked.FullName))
 				return;
 


### PR DESCRIPTION
If there's a TypeReference which is not a definition (for example it's a by-ref, or a pointer, ...) and it's also a nested type, the current code would not include the owning type in the type name. For type defs we always include the owning type name.

This change fixes that.

Also a small tweak in the test infra to avoid adding the same values into a hashset every time we visit a type.