### PR TITLE
Remove explicit xcopy-msbuild version from global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,8 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "7.0.100",
-    "xcopy-msbuild": "17.2.1"
+    "dotnet": "7.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22575.1",


### PR DESCRIPTION
This essentially reverts https://github.com/dotnet/linker/pull/2945, the default msbuild version is now recent enough and specifying an old version actually causes issues now.