### PR TITLE
Call CheckProcessed before enqueuing to MarkStep._methods

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2940,7 +2940,7 @@ namespace Mono.Linker.Steps
 				Debug.Assert (Annotations.IsMarked (method));
 				break;
 			default:
-				Annotations.Mark (method, reason, ScopeStack.CurrentScope.Origin);
+				Annotations.Mark (method, reason, origin);
 				break;
 			}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2929,11 +2929,36 @@ namespace Mono.Linker.Steps
 			if (Annotations.GetAction (method) == MethodAction.Nothing)
 				Annotations.SetAction (method, MethodAction.Parse);
 
-			EnqueueMethod (method, reason, origin);
 
 			// Use the original reason as it's important to correctly generate warnings
 			// the updated reason is only useful for better tracking of dependencies.
 			ProcessAnalysisAnnotationsForMethod (method, originalReasonKind, origin);
+			// Record the reason for marking a method on each call. The logic under CheckProcessed happens
+			// only once per method.
+			switch (reason.Kind) {
+			case DependencyKind.AlreadyMarked:
+				Debug.Assert (Annotations.IsMarked (method));
+				break;
+			default:
+				Annotations.Mark (method, reason, ScopeStack.CurrentScope.Origin);
+				break;
+			}
+
+			bool markedForCall =
+				reason.Kind == DependencyKind.DirectCall ||
+				reason.Kind == DependencyKind.VirtualCall ||
+				reason.Kind == DependencyKind.Newobj;
+			if (markedForCall) {
+				// Record declaring type of a called method up-front as a special case so that we may
+				// track at least some method calls that trigger a cctor.
+				// Temporarily switch to the original source for marking this method
+				// this is for the same reason as for tracking, but this time so that we report potential
+				// warnings from a better place.
+				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringTypeOfCalledMethod, method), new MessageOrigin (reason.Source as IMemberDefinition ?? method));
+			}
+
+			if (!CheckProcessed (method))
+				EnqueueMethod (method, reason, origin);
 
 			return method;
 		}
@@ -3113,32 +3138,10 @@ namespace Mono.Linker.Steps
 			using var parentScope = ScopeStack.PushScope (new MarkScopeStack.Scope (origin));
 			using var methodScope = ScopeStack.PushScope (new MessageOrigin (method));
 
-			// Record the reason for marking a method on each call. The logic under CheckProcessed happens
-			// only once per method.
-			switch (reason.Kind) {
-			case DependencyKind.AlreadyMarked:
-				Debug.Assert (Annotations.IsMarked (method));
-				break;
-			default:
-				Annotations.Mark (method, reason, ScopeStack.CurrentScope.Origin);
-				break;
-			}
-
 			bool markedForCall =
 				reason.Kind == DependencyKind.DirectCall ||
 				reason.Kind == DependencyKind.VirtualCall ||
 				reason.Kind == DependencyKind.Newobj;
-			if (markedForCall) {
-				// Record declaring type of a called method up-front as a special case so that we may
-				// track at least some method calls that trigger a cctor.
-				// Temporarily switch to the original source for marking this method
-				// this is for the same reason as for tracking, but this time so that we report potential
-				// warnings from a better place.
-				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringTypeOfCalledMethod, method), new MessageOrigin (reason.Source as IMemberDefinition ?? method));
-			}
-
-			if (CheckProcessed (method))
-				return;
 
 			foreach (Action<MethodDefinition> handleMarkMethod in MarkContext.MarkMethodActions)
 				handleMarkMethod (method);

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2933,8 +2933,8 @@ namespace Mono.Linker.Steps
 			// Use the original reason as it's important to correctly generate warnings
 			// the updated reason is only useful for better tracking of dependencies.
 			ProcessAnalysisAnnotationsForMethod (method, originalReasonKind, origin);
-			// Record the reason for marking a method on each call. The logic under CheckProcessed happens
-			// only once per method.
+
+			// Record the reason for marking a method on each call.
 			switch (reason.Kind) {
 			case DependencyKind.AlreadyMarked:
 				Debug.Assert (Annotations.IsMarked (method));
@@ -2957,6 +2957,7 @@ namespace Mono.Linker.Steps
 				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringTypeOfCalledMethod, method), new MessageOrigin (reason.Source as IMemberDefinition ?? method));
 			}
 
+			// We will only enqueue a method to be processed if it hasn't been processed yet.
 			if (!CheckProcessed (method))
 				EnqueueMethod (method, reason, origin);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/linker/issues/3137

We unconditionally add a method to the MarkStep._methods queue and perform a filtering check in ProcessMethod later. This causes _methods to grow to be as large as 110 mb in some cases (see https://github.com/dotnet/linker/issues/3126#issuecomment-1329508820). If we instead perform the filtering check before enqueuing the method, MarkStep_methods reach a max size of ~14mb (in the same repro).