### PR TITLE
[release/7.0] Remove explicit xcopy-msbuild version from global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,8 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "7.0.100",
-    "xcopy-msbuild": "17.2.1"
+    "dotnet": "7.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22561.2",


### PR DESCRIPTION
Backport of https://github.com/dotnet/linker/pull/3136