### PR TITLE
Add tests for type deconstruction and construction

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -101,6 +101,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task ConstructedTypesDataFlow ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task DynamicDependencyDataflow ()
 		{
 			return RunTest (nameof (DynamicDependencyDataflow));

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[ExpectedNoWarnings]
+	[SkipKeptItemsValidation]
+	class ConstructedTypesDataFlow
+	{
+		public static void Main()
+		{
+			DeconstructedVariable.Test ();
+		}
+
+		class DeconstructedVariable
+		{
+			[ExpectedWarning("IL2077")]
+			static void DeconstructVariableNoAnnotation ((Type type, object instance) input)
+			{
+				var (type, instance) = input;
+				type.RequiresPublicMethods ();
+			}
+
+			public static void Test ()
+			{
+				DeconstructVariableNoAnnotation ((typeof (string), null));
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -22,16 +23,69 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class DeconstructedVariable
 		{
-			[ExpectedWarning("IL2077")]
+			// https://github.com/dotnet/linker/issues/3158
+			[ExpectedWarning ("IL2077", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
 			static void DeconstructVariableNoAnnotation ((Type type, object instance) input)
 			{
 				var (type, instance) = input;
 				type.RequiresPublicMethods ();
 			}
 
+			record TypeAndInstance ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type, object instance);
+
+			// This is a tricky one - in a way this is a compiler bug
+			// Even though the record's property is declared with the annotation, the generated Deconstruct doesn't
+			// propagate the annotation into the out parameters.
+			// So analyzer would see the annotation (since it doesn't see the Deconstruct call - I think)
+			// But IL tooling will see a problem since it sees the Deconstruct call.
+			[ExpectedWarning ("IL2067", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			static void DeconstructRecordWithAnnotation (TypeAndInstance value)
+			{
+				var (type, instance) = value;
+				type.RequiresPublicMethods ();
+			}
+
+			class TypeAndInstanceManual
+			{
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				public Type type;
+				public object instance;
+
+				public TypeAndInstanceManual ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type, object instance)
+					=> (this.type, this.instance) = (type, instance);
+
+				public void Deconstruct ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] out Type type, out object instance)
+					=> (type, instance) = (this.type, this.instance);
+			}
+		
+			// This case actually works because the annotation is correctly propagated through the Deconstruct
+			static void DeconstructClassWithAnnotation (TypeAndInstanceManual value)
+			{
+				var (type, instance) = value;
+				type.RequiresPublicMethods ();
+			}
+
+			record TypeAndInstanceRecordManual ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type, object instance)
+			{
+				// The generated property getter doesn't have the same attributes???
+				// The attributes are only propagated to the generated .ctor - so suppressing the warning the this.type doesn't have the matching annotations
+				[UnconditionalSuppressMessage ("", "IL2072")]
+				public void Deconstruct ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] out Type type, out object instance)
+					=> (type, instance) = (this.type, this.instance);
+			}
+
+			static void DeconstructRecordManualWithAnnotation (TypeAndInstanceRecordManual value)
+			{
+				var (type, instance) = value;
+				type.RequiresPublicMethods ();
+			}
+
 			public static void Test ()
 			{
 				DeconstructVariableNoAnnotation ((typeof (string), null));
+				DeconstructRecordWithAnnotation (new (typeof (string), null));
+				DeconstructClassWithAnnotation (new (typeof (string), null));
+				DeconstructRecordManualWithAnnotation (new (typeof (string), null));
 			}
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -16,7 +16,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	[SkipKeptItemsValidation]
 	class ConstructedTypesDataFlow
 	{
-		public static void Main()
+		public static void Main ()
 		{
 			DeconstructedVariable.Test ();
 			ConstructedVariable.Test ();
@@ -63,7 +63,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				public void Deconstruct ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] out Type type, out object instance)
 					=> (type, instance) = (this.type, this.instance);
 			}
-		
+
 			// This case actually works because the annotation is correctly propagated through the Deconstruct
 			static void DeconstructClassWithAnnotation (TypeAndInstanceManual value)
 			{
@@ -111,7 +111,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class ConstructedVariable
 		{
 			[ExpectedWarning ("IL2077")]
-			static void ConstructedType()
+			static void ConstructedType ()
 			{
 				var ct = (typeof (string), 1);
 				ct.Item1.RequiresPublicMethods ();
@@ -132,7 +132,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[ExpectedWarning ("IL2072")]
-			static void AnonymousTypeWithoutAnnotations()
+			static void AnonymousTypeWithoutAnnotations ()
 			{
 				var ct = new {
 					Type = typeof (string),
@@ -177,7 +177,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				_ = new TypeAndValue (typeUnknown, 3);
 			}
 
-			public static void Test()
+			public static void Test ()
 			{
 				ConstructedType ();
 				ConstructedTypeNamed ();


### PR DESCRIPTION
This was prompted by https://github.com/dotnet/linker/issues/3158
So I just added several tests for various shapes of type deconstructions. To make it symmetric I also added tests for what I call type construction (tuples, anonymous types, records).

The naming is probably pretty bad and thus the test is undiscoverable. If somebody knows the right terminology or has a better idea for naming, please :-)