### PR TITLE
Add tests for ldtoken analysis and fixes a small bug for a field

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1793,6 +1793,7 @@ namespace Mono.Linker.Steps
 			case DependencyKind.DynamicDependency:
 			case DependencyKind.DynamicallyAccessedMember:
 			case DependencyKind.InteropMethodDependency:
+			case DependencyKind.Ldtoken:
 				if (isReflectionAccessCoveredByDAM = Annotations.FlowAnnotations.ShouldWarnWhenAccessedForReflection (field))
 					Context.LogWarning (origin, DiagnosticId.DynamicallyAccessedMembersFieldAccessedViaReflection, field.GetDisplayName ());
 


### PR DESCRIPTION
LdToken acts basically as a reflection access and so it needs to warn about the returned member if that has annotations on it.

This adds tests for https://github.com/dotnet/linker/issues/3172 which is not fixed by this change.