### PR TITLE
Unpin Microsoft.CodeAnalysis.NetAnalyzers version

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -2,7 +2,6 @@
   <ItemGroup Condition="'$(RunAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" PrivateAssets="all" />
     <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="all" /> -->
   </ItemGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,6 @@
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftCodeAnalysisVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.*</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.22513.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftILVerificationVersion>7.0.0-preview.7.22375.6</MicrosoftILVerificationVersion>
     <!-- This controls the version of the cecil package, or the version of cecil in the project graph
          when we build the cecil submodule. The reference assembly package will depend on this version of cecil.


### PR DESCRIPTION
This removes the version number added in https://github.com/dotnet/linker/pull/3077, which is no longer necessary to build with the released .NET 7 bits and was causing problems in https://github.com/dotnet/installer/pull/15228#issuecomment-1379601205 (it was hitting the check added in https://github.com/dotnet/roslyn-analyzers/commit/187b69eb2ad2097cb065a0565b90b556a206c2b6).