### PR TITLE
Fix race condition in build

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -52,10 +52,7 @@
   <ItemGroup>
     <ProjectReference Include="../linker/Mono.Linker.csproj" PrivateAssets="All" Condition=" '$(TargetFramework)' == '$(NetCoreAppToolCurrent)' " />
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" PrivateAssets="All" Publish="True" />
-    <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="../../external/cecil/Mono.Cecil.csproj" PrivateAssets="All">
-      <!-- https://github.com/dotnet/sdk/issues/2280#issuecomment-392815466 -->
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
-    </ProjectReference>
+    <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="../../external/cecil/Mono.Cecil.csproj" PrivateAssets="All" />
     <ProjectReference Condition="('$(UseCecilPackage)' != 'true') And ('$(TargetFramework)' != 'net472')" Include="../../external/cecil/symbols/pdb/Mono.Cecil.Pdb.csproj" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
This is an attempt to fix a race condition in our build, where Mono.Cecil was being built twice into the same output path. See https://github.com/dotnet/installer/pull/15228#issuecomment-1381987801 for context.

Before this change, I saw this line twice in the output:
```
Mono.Cecil -> C:\Users\svbomer\src\linker\artifacts\bin\Mono.Cecil\Debug\netstandard2.0\Mono.Cecil.dll
```

After this change, I only see it once. I don't understand why `SetTargetFramework` was needed in the first place in https://github.com/dotnet/linker/pull/1891#discussion_r593494437, but it no longer seems necessary. Probably the recent changes to the cecil build (arcade onboarding) caused this to become a problem.

I have been able to build locally >100 times in a row with this change, without hitting the race, so I think this fixes it. Previously I was seeing it fail about one in ten builds locally.