### PR TITLE
Match SDK versions of MSBuild framework

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,10 +14,12 @@
     <MicrosoftNETSdkILPackageVersion>7.0.0-rtm.22507.1</MicrosoftNETSdkILPackageVersion>
     <!-- see https://github.com/dotnet/runtime/issues/1338 -->
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETSdkILPackageVersion)</MicrosoftNETCoreILAsmVersion>
-    <!-- SRM version should match the SDK version at https://github.com/dotnet/sdk/blob/master/eng/Versions.props -->
+
+    <!-- These should match the SDK versions at https://github.com/dotnet/sdk/blob/master/eng/Versions.props -->
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
-    <MicrosoftBuildFrameworkVersion>17.0.0-preview-21267-01</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>17.0.0-preview-21267-01</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>
+
     <MicrosoftDotNetApiCompatVersion>8.0.0-beta.22630.1</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21271.1</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,8 +17,8 @@
 
     <!-- These should match the SDK versions at https://github.com/dotnet/sdk/blob/master/eng/Versions.props -->
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
-    <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildFrameworkVersion>17.3.2</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.3.2</MicrosoftBuildUtilitiesCoreVersion>
 
     <MicrosoftDotNetApiCompatVersion>8.0.0-beta.22630.1</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21271.1</MicrosoftDotNetCodeAnalysisVersion>


### PR DESCRIPTION
The version of `Microsoft.Build.Framework` that we depend on has a transitive dependency on `System.Drawing.Common` that is being flagged due to a security vulnerablility in https://github.com/dotnet/sdk/issues/29927. The dependency is probably unused, but we would like to fix it to prevent further false positive reports.

This is being referenced as a transitive dependency of `Microsoft.Build.Framework`: Microsoft.Build.Framework/17.0.0-preview-21267-01 -> System.Security.Permissions/4.7.0 -> System.Windows.Extensions/4.7.0 -> System.Drawing.Common/4.7.0. 

`dotnet/sdk` uses a lower version (15.4.8) of `Microsoft.Build.Framework`, which doesn't have a dependency on System.Drawing.Common. `dotnet/linker` used to reference the same version but we bumped it in https://github.com/dotnet/linker/pull/1840 and https://github.com/dotnet/linker/pull/2047. @marek-safar do you know why we made the upgrade? My inclination is to change back to 15.4.8, since I don't think we can actually be depending on any API surface newer than what ships with the SDK. If there's a requirement to reference a higher version, please let me know.
