### PR TITLE
[no-merge] Revert workarounds for possible SDK issue

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -22,8 +22,6 @@
     <Nullable>disable</Nullable>
     <!-- Targets don't match the package id. This is intentional. -->
     <NoWarn>$(NoWarn);NU5129</NoWarn>
-    <!-- Workaround for possible SDK issue - see https://github.com/dotnet/linker/issues/3190 -->
-    <IncludeProjectsNotInAssetsFileInDepsFile>true</IncludeProjectsNotInAssetsFileInDepsFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -17,8 +17,6 @@
     <!-- There are currently no translations, so the satellite assemblies are a waste of space. -->
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <NoWarn Condition="'$(DotNetBuildFromSource)' == 'true'">$(NoWarn);CS8524</NoWarn>
-    <!-- Workaround for possible SDK issue - see https://github.com/dotnet/linker/issues/3190 -->
-    <IncludeProjectsNotInAssetsFileInDepsFile>true</IncludeProjectsNotInAssetsFileInDepsFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using this to try to get the tests to fail again - locally it magically works even without the workarounds.