### PR TITLE
Make external cecil projects build in isolation

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,6 +7,12 @@
     <CallTarget Targets="VSTest" Condition="'$(IsTestProject)' == 'true'" />
   </Target>
 
+  <!-- Don't flow repo settings (i.e. paths) into referenced submodule repo projects. -->
+  <ItemGroup>
+    <ProjectReference Update="@(ProjectReference->WithMetadataValue('Filename', 'Mono.Cecil'));
+                              @(ProjectReference->WithMetadataValue('Filename', 'Mono.Cecil.Pdb'))"
+                      UndefineProperties="%(UndefineProperties);RepoRoot;VersionsPropsPath" />
+  </ItemGroup>
 
   <!-- Shared logic for reference assemblies. This enables apicompat and
        packaging logic for projects that have corresponding reference assemblies. -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,7 +11,8 @@
   <ItemGroup>
     <ProjectReference Update="@(ProjectReference->WithMetadataValue('Filename', 'Mono.Cecil'));
                               @(ProjectReference->WithMetadataValue('Filename', 'Mono.Cecil.Pdb'))"
-                      UndefineProperties="%(UndefineProperties);RepoRoot;VersionsPropsPath" />
+                      UndefineProperties="%(UndefineProperties);RepoRoot;VersionsPropsPath"
+                      PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Shared logic for reference assemblies. This enables apicompat and


### PR DESCRIPTION
Updates ProjectReferences that point to the two referenced Mono.Cecil projects in order not flow the globally set RepoRoot and VersionsPropsPath properties. That guarantees that these projects are always built deterministically (VS vs dotnet build vs build.cmd).

For more context, see the offline mail conversation between @vitek-karas, @sbomer and me.